### PR TITLE
Refactor pin module & backup module

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/BaseActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/BaseActivity.kt
@@ -25,7 +25,6 @@ import io.horizontalsystems.bankwallet.core.App
 import io.horizontalsystems.bankwallet.core.security.EncryptionManager
 import io.horizontalsystems.bankwallet.lib.AlertDialogFragment
 import io.horizontalsystems.bankwallet.modules.pin.PinActivity
-import io.horizontalsystems.bankwallet.modules.pin.PinModule
 import java.util.*
 
 abstract class BaseActivity : AppCompatActivity() {
@@ -46,7 +45,7 @@ abstract class BaseActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         if (this !is PinActivity && App.lockManager.isLocked){
-            PinModule.startForUnlock(this, false)
+//            PinModule.startForUnlock(this, false)
         }
     }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/BaseActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/BaseActivity.kt
@@ -23,8 +23,10 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout
 import io.horizontalsystems.bankwallet.core.App
 import io.horizontalsystems.bankwallet.core.security.EncryptionManager
+import io.horizontalsystems.bankwallet.core.utils.ModuleCode
 import io.horizontalsystems.bankwallet.lib.AlertDialogFragment
 import io.horizontalsystems.bankwallet.modules.pin.PinActivity
+import io.horizontalsystems.bankwallet.modules.pin.PinModule
 import java.util.*
 
 abstract class BaseActivity : AppCompatActivity() {
@@ -44,8 +46,8 @@ abstract class BaseActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-        if (this !is PinActivity && App.lockManager.isLocked){
-//            PinModule.startForUnlock(this, false)
+        if (this !is PinActivity && App.lockManager.isLocked) {
+            PinModule.startForUnlock(this, ModuleCode.UNLOCK_PIN)
         }
     }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/Interfaces.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/Interfaces.kt
@@ -53,6 +53,7 @@ interface ISecuredStorage {
     fun noAuthData(): Boolean
     val savedPin: String?
     fun savePin(pin: String)
+    fun removePin()
     fun pinIsEmpty(): Boolean
 }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/PinManager.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/PinManager.kt
@@ -36,5 +36,6 @@ class PinManager(private val securedStorage: ISecuredStorage) : IPinManager {
 
     override fun clear() {
         pin = null
+        securedStorage.removePin()
     }
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/SecuredStorageManager.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/SecuredStorageManager.kt
@@ -43,6 +43,10 @@ class SecuredStorageManager(private val encryptionManager: IEncryptionManager) :
         App.preferences.edit().putString(LOCK_PIN, encryptionManager.encrypt(pin)).apply()
     }
 
+    override fun removePin() {
+        App.preferences.edit().remove(LOCK_PIN).apply()
+    }
+
     override fun pinIsEmpty(): Boolean {
         val string = App.preferences.getString(LOCK_PIN, null)
         return string.isNullOrEmpty()

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/utils/RequestCode.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/utils/RequestCode.kt
@@ -5,5 +5,6 @@ object ModuleCode {
     const val RESTORE_WORDS = 2
     const val RESTORE_EOS = 3
     const val BACKUP_WORDS = 4
+    const val UNLOCK_PIN = 5
 }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/backup/BackupActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/backup/BackupActivity.kt
@@ -7,10 +7,10 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import io.horizontalsystems.bankwallet.BaseActivity
 import io.horizontalsystems.bankwallet.R
-import io.horizontalsystems.bankwallet.entities.Account
-import io.horizontalsystems.bankwallet.entities.AccountType
 import io.horizontalsystems.bankwallet.core.setOnSingleClickListener
 import io.horizontalsystems.bankwallet.core.utils.ModuleCode
+import io.horizontalsystems.bankwallet.entities.Account
+import io.horizontalsystems.bankwallet.entities.AccountType
 import io.horizontalsystems.bankwallet.modules.backup.words.BackupWordsActivity
 import io.horizontalsystems.bankwallet.modules.backup.words.BackupWordsModule
 import io.horizontalsystems.bankwallet.modules.pin.PinModule
@@ -31,7 +31,7 @@ class BackupActivity : BaseActivity() {
         buttonNext.setOnSingleClickListener { viewModel.delegate.onClickBackup() }
 
         viewModel.startPinModuleEvent.observe(this, Observer {
-            PinModule.startForUnlock(this)
+            PinModule.startForUnlock(this, ModuleCode.UNLOCK_PIN, true)
         })
 
         viewModel.startBackupEvent.observe(this, Observer { account ->
@@ -52,13 +52,16 @@ class BackupActivity : BaseActivity() {
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
 
-        if (data == null || resultCode != RESULT_OK) return
 
         when (requestCode) {
             ModuleCode.BACKUP_WORDS -> {
+                if (data == null || resultCode != RESULT_OK) return
                 val accountId = data.getStringExtra(BackupWordsActivity.ACCOUNT_ID_KEY)
                 viewModel.delegate.onBackedUp(accountId)
                 finish()
+            }
+            ModuleCode.UNLOCK_PIN -> {
+
             }
         }
     }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/backup/BackupActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/backup/BackupActivity.kt
@@ -1,5 +1,6 @@
 package io.horizontalsystems.bankwallet.modules.backup
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -57,11 +58,14 @@ class BackupActivity : BaseActivity() {
             ModuleCode.BACKUP_WORDS -> {
                 if (data == null || resultCode != RESULT_OK) return
                 val accountId = data.getStringExtra(BackupWordsActivity.ACCOUNT_ID_KEY)
-                viewModel.delegate.onBackedUp(accountId)
+                viewModel.delegate.didBackUp(accountId)
                 finish()
             }
             ModuleCode.UNLOCK_PIN -> {
-
+                when (resultCode ) {
+                    Activity.RESULT_OK -> viewModel.delegate.didUnlock()
+                    Activity.RESULT_CANCELED -> viewModel.delegate.didCancelUnlock()
+                }
             }
         }
     }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/backup/BackupInteractor.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/backup/BackupInteractor.kt
@@ -1,37 +1,16 @@
 package io.horizontalsystems.bankwallet.modules.backup
 
 import io.horizontalsystems.bankwallet.core.IBackupManager
-import io.horizontalsystems.bankwallet.core.ILockManager
 import io.horizontalsystems.bankwallet.core.IPinManager
-import io.reactivex.disposables.Disposable
 
 class BackupInteractor(
-        private val router: BackupModule.Router,
-        private val lockManager: ILockManager,
         private val backupManager: IBackupManager,
-        private val pinManager: IPinManager)
-    : BackupModule.Interactor {
+        private val pinManager: IPinManager) : BackupModule.Interactor {
 
     var delegate: BackupModule.InteractorDelegate? = null
 
-    private var lockStateUpdateDisposable: Disposable? = null
-
-    override fun backup() {
-        if (!pinManager.isPinSet) {
-            delegate?.onPinUnlock()
-            return
-        }
-
-        router.startPinModule()
-
-        lockStateUpdateDisposable?.dispose()
-        lockStateUpdateDisposable = lockManager.lockStateUpdatedSignal.subscribe {
-            if (!lockManager.isLocked) {
-                delegate?.onPinUnlock()
-                lockStateUpdateDisposable?.dispose()
-            }
-        }
-    }
+    override val isPinSet: Boolean
+        get() = pinManager.isPinSet
 
     override fun setBackedUp(accountId: String) {
         backupManager.setIsBackedUp(accountId)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/backup/BackupModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/backup/BackupModule.kt
@@ -1,8 +1,8 @@
 package io.horizontalsystems.bankwallet.modules.backup
 
 import android.content.Context
-import io.horizontalsystems.bankwallet.entities.Account
 import io.horizontalsystems.bankwallet.core.App
+import io.horizontalsystems.bankwallet.entities.Account
 
 object BackupModule {
 
@@ -11,20 +11,21 @@ object BackupModule {
     interface ViewDelegate {
         fun onClickCancel()
         fun onClickBackup()
-        fun onBackedUp(accountId: String)
+        fun didBackUp(accountId: String)
+        fun didUnlock()
+        fun didCancelUnlock()
     }
 
     interface Interactor {
-        fun backup()
+        val isPinSet: Boolean
+
         fun setBackedUp(accountId: String)
     }
 
-    interface InteractorDelegate {
-        fun onPinUnlock()
-    }
+    interface InteractorDelegate
 
     interface Router {
-        fun startPinModule()
+        fun startUnlockPinModule()
         fun startBackupModule(account: Account)
         fun close()
     }
@@ -36,7 +37,7 @@ object BackupModule {
     }
 
     fun init(view: BackupViewModel, router: Router, account: Account) {
-        val interactor = BackupInteractor(router, App.lockManager, App.backupManager, App.pinManager)
+        val interactor = BackupInteractor(App.backupManager, App.pinManager)
         val presenter = BackupPresenter(interactor, router, account)
 
         view.delegate = presenter

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/backup/BackupPresenter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/backup/BackupPresenter.kt
@@ -12,12 +12,6 @@ class BackupPresenter(
 
     var view: BackupModule.View? = null
 
-    //  Interactor delegate
-
-    override fun onPinUnlock() {
-        router.startBackupModule(account)
-    }
-
     //  View delegates
 
     override fun onClickCancel() {
@@ -25,10 +19,22 @@ class BackupPresenter(
     }
 
     override fun onClickBackup() {
-        interactor.backup()
+        if (interactor.isPinSet) {
+            router.startUnlockPinModule()
+        } else {
+            router.startBackupModule(account)
+        }
     }
 
-    override fun onBackedUp(accountId: String) {
+    override fun didUnlock() {
+        router.startBackupModule(account)
+    }
+
+    override fun didCancelUnlock() {
+
+    }
+
+    override fun didBackUp(accountId: String) {
         interactor.setBackedUp(accountId)
     }
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/backup/BackupViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/backup/BackupViewModel.kt
@@ -18,7 +18,7 @@ class BackupViewModel : ViewModel(), BackupModule.View, BackupModule.Router {
 
     // router
 
-    override fun startPinModule() {
+    override fun startUnlockPinModule() {
         startPinModuleEvent.call()
     }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/backup/words/BackupWordsActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/backup/words/BackupWordsActivity.kt
@@ -57,10 +57,6 @@ class BackupWordsActivity : BaseActivity() {
             }
         })
 
-        viewModel.startPinModuleEvent.observe(this, Observer {
-//            PinModule.startForUnlock(this)
-        })
-
         viewModel.notifyBackedUpEvent.observe(this, Observer { accountId ->
             accountId?.let {
                 val intent = Intent().apply {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/backup/words/BackupWordsActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/backup/words/BackupWordsActivity.kt
@@ -9,7 +9,6 @@ import io.horizontalsystems.bankwallet.BaseActivity
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.setOnSingleClickListener
 import io.horizontalsystems.bankwallet.core.utils.ModuleCode
-import io.horizontalsystems.bankwallet.modules.pin.PinModule
 import kotlinx.android.synthetic.main.activity_backup_words.*
 
 class BackupWordsActivity : BaseActivity() {
@@ -59,7 +58,7 @@ class BackupWordsActivity : BaseActivity() {
         })
 
         viewModel.startPinModuleEvent.observe(this, Observer {
-            PinModule.startForUnlock(this)
+//            PinModule.startForUnlock(this)
         })
 
         viewModel.notifyBackedUpEvent.observe(this, Observer { accountId ->

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/backup/words/BackupWordsModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/backup/words/BackupWordsModule.kt
@@ -37,7 +37,6 @@ object BackupWordsModule {
     }
 
     interface IRouter {
-        fun startPinModule()
         fun notifyBackedUp(accountId: String)
         fun close()
     }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/backup/words/BackupWordsViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/backup/words/BackupWordsViewModel.kt
@@ -15,7 +15,6 @@ class BackupWordsViewModel : ViewModel(), BackupWordsModule.IView, BackupWordsMo
     val wordIndexesToConfirmLiveData = MutableLiveData<List<Int>>()
     val validateWordsLiveEvent = SingleLiveEvent<Void>()
     val notifyBackedUpEvent = SingleLiveEvent<String>()
-    val startPinModuleEvent = SingleLiveEvent<Void>()
     val closeLiveEvent = SingleLiveEvent<Void>()
 
     fun init(accountId: String, words: List<String>) {
@@ -45,10 +44,6 @@ class BackupWordsViewModel : ViewModel(), BackupWordsModule.IView, BackupWordsMo
     }
 
     // router
-
-    override fun startPinModule() {
-        startPinModuleEvent.call()
-    }
 
     override fun notifyBackedUp(accountId: String) {
         notifyBackedUpEvent.value = accountId

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/launcher/LaunchModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/launcher/LaunchModule.kt
@@ -10,6 +10,8 @@ object LaunchModule {
 
     interface IViewDelegate {
         fun viewDidLoad()
+        fun didUnlock()
+        fun didCancelUnlock()
     }
 
     interface IInteractor {
@@ -24,6 +26,7 @@ object LaunchModule {
         fun openWelcomeModule()
         fun openMainModule()
         fun openUnlockModule()
+        fun closeApplication()
     }
 
     fun init(view: LaunchViewModel, router: IRouter) {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/launcher/LaunchPresenter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/launcher/LaunchPresenter.kt
@@ -15,4 +15,13 @@ class LaunchPresenter(private val interactor: LaunchModule.IInteractor,
             else -> router.openUnlockModule()
         }
     }
+
+    override fun didUnlock() {
+        router.openMainModule()
+    }
+
+    override fun didCancelUnlock() {
+        router.closeApplication()
+    }
+
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/launcher/LaunchViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/launcher/LaunchViewModel.kt
@@ -11,6 +11,7 @@ class LaunchViewModel : ViewModel(), LaunchModule.IView, LaunchModule.IRouter {
     val openWelcomeModule = SingleLiveEvent<Void>()
     val openMainModule = SingleLiveEvent<Void>()
     val openUnlockModule = SingleLiveEvent<Void>()
+    val closeApplication = SingleLiveEvent<Void>()
 
     fun init() {
         LaunchModule.init(this, this)
@@ -37,4 +38,7 @@ class LaunchViewModel : ViewModel(), LaunchModule.IView, LaunchModule.IRouter {
         openUnlockModule.call()
     }
 
+    override fun closeApplication() {
+        closeApplication.call()
+    }
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/launcher/LauncherActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/launcher/LauncherActivity.kt
@@ -1,5 +1,7 @@
 package io.horizontalsystems.bankwallet.modules.launcher
 
+import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
@@ -41,8 +43,26 @@ class LauncherActivity : AppCompatActivity() {
         })
 
         viewModel.openUnlockModule.observe(this, Observer {
-            PinModule.startForUnlock(this)
+            PinModule.startForUnlock(this, REQUEST_CODE_UNLOCK_PIN)
+        })
+
+        viewModel.closeApplication.observe(this, Observer {
+            finishAffinity()
         })
     }
 
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == REQUEST_CODE_UNLOCK_PIN) {
+            when (resultCode) {
+                Activity.RESULT_OK -> viewModel.delegate.didUnlock()
+                Activity.RESULT_CANCELED -> viewModel.delegate.didCancelUnlock()
+            }
+        }
+    }
+
+    companion object {
+        const val REQUEST_CODE_UNLOCK_PIN = 1
+    }
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/pin/PinActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/pin/PinActivity.kt
@@ -1,5 +1,6 @@
 package io.horizontalsystems.bankwallet.modules.pin
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -10,6 +11,7 @@ import android.view.ViewGroup
 import android.view.animation.AnimationUtils
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.hardware.fingerprint.FingerprintManagerCompat
 import androidx.lifecycle.Observer
@@ -23,6 +25,7 @@ import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.App
 import io.horizontalsystems.bankwallet.core.security.FingerprintAuthenticationDialogFragment
 import io.horizontalsystems.bankwallet.modules.main.MainModule
+import io.horizontalsystems.bankwallet.modules.restore.eos.RestoreEosActivity
 import io.horizontalsystems.bankwallet.ui.extensions.*
 import io.horizontalsystems.bankwallet.viewHelpers.DateHelper
 import io.horizontalsystems.bankwallet.viewHelpers.HudHelper
@@ -73,9 +76,9 @@ class PinActivity : BaseActivity(), NumPadItemsAdapter.Listener, FingerprintAuth
         })
 
         viewModel.titleLiveDate.observe(this, Observer { title ->
-                        title?.let {
-                            shadowlessToolbar.bindTitle(getString(it))
-                        }
+            title?.let {
+                shadowlessToolbar.bindTitle(getString(it))
+            }
         })
 
         viewModel.addPagesEvent.observe(this, Observer { pinPages ->
@@ -124,7 +127,13 @@ class PinActivity : BaseActivity(), NumPadItemsAdapter.Listener, FingerprintAuth
             }
         })
 
-        viewModel.dismissLiveEvent.observe(this, Observer {
+        viewModel.dismissWithCancelLiveEvent.observe(this, Observer {
+            setResult(Activity.RESULT_CANCELED)
+            finish()
+        })
+
+        viewModel.dismissWithSuccessLiveEvent.observe(this, Observer {
+            setResult(Activity.RESULT_OK)
             finish()
         })
 
@@ -206,11 +215,12 @@ class PinActivity : BaseActivity(), NumPadItemsAdapter.Listener, FingerprintAuth
             context.startActivity(intent)
         }
 
-        fun startForUnlock(context: Context, showCancel: Boolean) {
+        fun startForResult(context: AppCompatActivity, requestCode: Int, interactionType: PinInteractionType, showCancel: Boolean = true) {
             val intent = Intent(context, PinActivity::class.java)
+            intent.putExtra(keyInteractionType, interactionType)
             intent.putExtra(keyShowCancel, showCancel)
-            intent.putExtra(keyInteractionType, PinInteractionType.UNLOCK)
-            context.startActivity(intent)
+
+            context.startActivityForResult(intent, requestCode)
         }
     }
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/pin/PinModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/pin/PinModule.kt
@@ -1,6 +1,7 @@
 package io.horizontalsystems.bankwallet.modules.pin
 
 import android.content.Context
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.hardware.fingerprint.FingerprintManagerCompat
 import java.util.*
 
@@ -47,16 +48,16 @@ object PinModule {
         fun didStartedAdapters()
     }
 
-    fun startForSetPin(context: Context) {
-        PinActivity.start(context, PinInteractionType.SET_PIN)
+    fun startForSetPin(context: AppCompatActivity, requestCode: Int) {
+        PinActivity.startForResult(context, requestCode, PinInteractionType.SET_PIN)
     }
 
     fun startForEditPin(context: Context) {
         PinActivity.start(context, PinInteractionType.EDIT_PIN)
     }
 
-    fun startForUnlock(context: Context, showCancel: Boolean = false) {
-        PinActivity.startForUnlock(context, showCancel)
+    fun startForUnlock(context: AppCompatActivity, requestCode: Int, showCancel: Boolean = false) {
+        PinActivity.startForResult(context, requestCode, PinInteractionType.UNLOCK, showCancel)
     }
 
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/pin/PinViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/pin/PinViewModel.kt
@@ -21,7 +21,8 @@ class PinViewModel: ViewModel(), PinModule.IPinView, SetPinModule.ISetPinRouter,
     val fillPinCircles = MutableLiveData<Pair<Int, Int>>()
     val navigateToMainLiveEvent = SingleLiveEvent<Unit>()
     val hideToolbar = SingleLiveEvent<Unit>()
-    val dismissLiveEvent = SingleLiveEvent<Unit>()
+    val dismissWithCancelLiveEvent = SingleLiveEvent<Unit>()
+    val dismissWithSuccessLiveEvent = SingleLiveEvent<Unit>()
     val showBackButton = SingleLiveEvent<Unit>()
     val showFingerprintInputLiveEvent = SingleLiveEvent<FingerprintManagerCompat.CryptoObject>()
     val resetCirclesWithShakeAndDelayForPage = SingleLiveEvent<Int>()
@@ -92,8 +93,12 @@ class PinViewModel: ViewModel(), PinModule.IPinView, SetPinModule.ISetPinRouter,
         closeApplicationLiveEvent.call()
     }
 
-    override fun dismiss() {
-        dismissLiveEvent.call()
+    override fun dismissModuleWithCancel() {
+        dismissWithCancelLiveEvent.call()
+    }
+
+    override fun dismissModuleWithSuccess() {
+        dismissWithSuccessLiveEvent.call()
     }
 
     override fun showLockView(until: Date) {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/pin/edit/EditPinModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/pin/edit/EditPinModule.kt
@@ -8,7 +8,8 @@ import io.horizontalsystems.bankwallet.modules.pin.PinViewModel
 object EditPinModule {
 
     interface IEditPinRouter {
-        fun dismiss()
+        fun dismissModuleWithSuccess()
+        fun dismissModuleWithCancel()
     }
 
     fun init(view: PinViewModel, router: IEditPinRouter, keystoreSafeExecute: IKeyStoreSafeExecute) {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/pin/edit/EditPinPresenter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/pin/edit/EditPinPresenter.kt
@@ -13,7 +13,7 @@ class EditPinPresenter(interactor: PinModule.IPinInteractor, private val router:
         val pinPages = mutableListOf<PinPage>()
 
         pages.forEach { page ->
-            when(page) {
+            when (page) {
                 Page.UNLOCK -> pinPages.add(PinPage(R.string.EditPin_UnlockInfo))
                 Page.ENTER -> pinPages.add(PinPage(R.string.EditPin_NewPinInfo))
                 Page.CONFIRM -> pinPages.add(PinPage(R.string.SetPin_ConfirmInfo))
@@ -24,10 +24,10 @@ class EditPinPresenter(interactor: PinModule.IPinInteractor, private val router:
     }
 
     override fun didSavePin() {
-        router.dismiss()
+        router.dismissModuleWithSuccess()
     }
 
     override fun onBackPressed() {
-        router.dismiss()
+        router.dismissModuleWithCancel()
     }
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/pin/set/SetPinModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/pin/set/SetPinModule.kt
@@ -9,6 +9,8 @@ object SetPinModule {
 
     interface ISetPinRouter {
         fun navigateToMain()
+        fun dismissModuleWithSuccess()
+        fun dismissModuleWithCancel()
     }
 
     fun init(view: PinViewModel, router: ISetPinRouter, keystoreSafeExecute: IKeyStoreSafeExecute) {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/pin/set/SetPinPresenter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/pin/set/SetPinPresenter.kt
@@ -7,19 +7,23 @@ import io.horizontalsystems.bankwallet.modules.pin.PinPage
 
 class SetPinPresenter(
         private val interactor: PinModule.IPinInteractor,
-        private val router: SetPinModule.ISetPinRouter): ManagePinPresenter(interactor, pages = listOf(Page.ENTER, Page.CONFIRM)) {
+        private val router: SetPinModule.ISetPinRouter) : ManagePinPresenter(interactor, pages = listOf(Page.ENTER, Page.CONFIRM)) {
 
     override fun viewDidLoad() {
         view?.setTitle(R.string.SetPin_Title)
 
         val pinPages = mutableListOf<PinPage>()
         pages.forEach { page ->
-            when(page) {
+            when (page) {
                 Page.ENTER -> pinPages.add(PinPage(R.string.SetPin_Info))
                 Page.CONFIRM -> pinPages.add(PinPage(R.string.SetPin_ConfirmInfo))
             }
         }
         view?.addPages(pinPages)
+    }
+
+    override fun onBackPressed() {
+        router.dismissModuleWithCancel()
     }
 
     override fun didSavePin() {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/pin/unlock/UnlockPinModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/pin/unlock/UnlockPinModule.kt
@@ -13,7 +13,8 @@ import io.horizontalsystems.bankwallet.modules.pin.PinViewModel
 
 object UnlockPinModule {
     interface IUnlockPinRouter {
-        fun dismiss()
+        fun dismissModuleWithSuccess()
+        fun dismissModuleWithCancel()
         fun closeApplication()
     }
 
@@ -26,7 +27,6 @@ object UnlockPinModule {
     }
 
     interface IUnlockPinInteractorDelegate {
-        fun didBiometricUnlock()
         fun unlock()
         fun wrongPinSubmitted()
         fun setCryptoObject(cryptoObject: FingerprintManagerCompat.CryptoObject)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/pin/unlock/UnlockPinPresenter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/pin/unlock/UnlockPinPresenter.kt
@@ -36,7 +36,7 @@ class UnlockPinPresenter(
 
             if (enteredPin.length == PinModule.PIN_COUNT) {
                 if (interactor.unlock(enteredPin)) {
-                    router.dismiss()
+                    router.dismissModuleWithSuccess()
                 } else {
                     wrongPinSubmitted()
                 }
@@ -56,12 +56,8 @@ class UnlockPinPresenter(
         }
     }
 
-    override fun didBiometricUnlock() {
-        router.dismiss()
-    }
-
     override fun unlock() {
-        router.dismiss()
+        router.dismissModuleWithSuccess()
     }
 
     override fun setCryptoObject(cryptoObject: FingerprintManagerCompat.CryptoObject) {
@@ -92,7 +88,7 @@ class UnlockPinPresenter(
 
     override fun onBackPressed() {
         if(showCancelButton) {
-            router.dismiss()
+            router.dismissModuleWithCancel()
         } else {
             router.closeApplication()
         }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsActivity.kt
@@ -50,7 +50,7 @@ class SecuritySettingsActivity : BaseActivity() {
             PinModule.startForEditPin(this)
         })
 
-        viewModel.openSetPinLiveEvent.observe(this, Observer { requestCode ->
+        viewModel.openSetPinLiveEvent.observe(this, Observer {
             PinModule.startForSetPin(this, REQUEST_CODE_SET_PIN)
         })
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsInteractor.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsInteractor.kt
@@ -2,6 +2,7 @@ package io.horizontalsystems.bankwallet.modules.settings.security
 
 import io.horizontalsystems.bankwallet.core.IBackupManager
 import io.horizontalsystems.bankwallet.core.ILocalStorage
+import io.horizontalsystems.bankwallet.core.IPinManager
 import io.horizontalsystems.bankwallet.core.ISystemInfoManager
 import io.horizontalsystems.bankwallet.entities.BiometryType
 import io.reactivex.disposables.CompositeDisposable
@@ -9,7 +10,8 @@ import io.reactivex.disposables.CompositeDisposable
 class SecuritySettingsInteractor(
         private val backupManager: IBackupManager,
         private val localStorage: ILocalStorage,
-        private val systemInfoManager: ISystemInfoManager)
+        private val systemInfoManager: ISystemInfoManager,
+        private val pinManager: IPinManager)
     : SecuritySettingsModule.ISecuritySettingsInteractor {
 
     var delegate: SecuritySettingsModule.ISecuritySettingsInteractorDelegate? = null
@@ -31,8 +33,15 @@ class SecuritySettingsInteractor(
         return localStorage.isBiometricOn
     }
 
+    override val isPinSet: Boolean
+        get() = pinManager.isPinSet
+
     override fun setBiometricUnlockOn(biometricUnlockOn: Boolean) {
         localStorage.isBiometricOn = biometricUnlockOn
+    }
+
+    override fun disablePin() {
+        pinManager.clear()
     }
 
     override fun clear() {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsModule.kt
@@ -11,6 +11,7 @@ object SecuritySettingsModule {
         fun setBiometricUnlockOn(biometricUnlockOn: Boolean)
         fun setBiometryType(biometryType: BiometryType)
         fun setBackedUp(backedUp: Boolean)
+        fun setPinEnabled(enabled: Boolean)
     }
 
     interface ISecuritySettingsViewDelegate {
@@ -18,16 +19,21 @@ object SecuritySettingsModule {
         fun didSwitchBiometricUnlock(biometricUnlockOn: Boolean)
         fun didTapManageKeys()
         fun didTapEditPin()
+        fun didTapEnablePin(enable: Boolean)
         fun onClear()
+        fun didSetPin()
+        fun didCancelSetPin()
     }
 
     interface ISecuritySettingsInteractor {
         val nonBackedUpCount: Int
         val biometryType: BiometryType
+        val isPinSet: Boolean
 
         fun getBiometricUnlockOn(): Boolean
         fun setBiometricUnlockOn(biometricUnlockOn: Boolean)
         fun clear()
+        fun disablePin()
     }
 
     interface ISecuritySettingsInteractorDelegate {
@@ -37,6 +43,7 @@ object SecuritySettingsModule {
     interface ISecuritySettingsRouter {
         fun showManageKeys()
         fun showEditPin()
+        fun showSetPin()
     }
 
     fun start(context: Context) {
@@ -44,7 +51,7 @@ object SecuritySettingsModule {
     }
 
     fun init(view: SecuritySettingsViewModel, router: ISecuritySettingsRouter) {
-        val interactor = SecuritySettingsInteractor(App.backupManager, App.localStorage, App.systemInfoManager)
+        val interactor = SecuritySettingsInteractor(App.backupManager, App.localStorage, App.systemInfoManager, App.pinManager)
         val presenter = SecuritySettingsPresenter(router, interactor)
 
         view.delegate = presenter

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsPresenter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsPresenter.kt
@@ -9,6 +9,7 @@ class SecuritySettingsPresenter(private val router: SecuritySettingsModule.ISecu
         view?.setBiometricUnlockOn(interactor.getBiometricUnlockOn())
         view?.setBiometryType(interactor.biometryType)
         view?.setBackedUp(interactor.nonBackedUpCount == 0)
+        view?.setPinEnabled(interactor.isPinSet)
     }
 
     override fun didSwitchBiometricUnlock(biometricUnlockOn: Boolean) {
@@ -21,6 +22,23 @@ class SecuritySettingsPresenter(private val router: SecuritySettingsModule.ISecu
 
     override fun didTapEditPin() {
         router.showEditPin()
+    }
+
+    override fun didTapEnablePin(enable: Boolean) {
+        if (enable) {
+            router.showSetPin()
+        } else {
+            interactor.disablePin()
+            view?.setPinEnabled(false)
+        }
+    }
+
+    override fun didSetPin() {
+        view?.setPinEnabled(true)
+    }
+
+    override fun didCancelSetPin() {
+        view?.setPinEnabled(false)
     }
 
     override fun onClear() {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsViewModel.kt
@@ -14,6 +14,8 @@ class SecuritySettingsViewModel : ViewModel(), SecuritySettingsModule.ISecurityS
     val biometricUnlockOnLiveData = MutableLiveData<Boolean>()
     val openManageKeysLiveEvent = SingleLiveEvent<Unit>()
     val openEditPinLiveEvent = SingleLiveEvent<Unit>()
+    val openSetPinLiveEvent = SingleLiveEvent<Unit>()
+    val pinEnabledLiveEvent = MutableLiveData<Boolean>()
 
     fun init() {
         SecuritySettingsModule.init(this, this)
@@ -40,6 +42,10 @@ class SecuritySettingsViewModel : ViewModel(), SecuritySettingsModule.ISecurityS
         backedUpLiveData.postValue(backedUp)
     }
 
+    override fun setPinEnabled(enabled: Boolean) {
+        pinEnabledLiveEvent.postValue(enabled)
+    }
+
     //  ISecuritySettingsRouter
 
     override fun showManageKeys() {
@@ -48,5 +54,9 @@ class SecuritySettingsViewModel : ViewModel(), SecuritySettingsModule.ISecurityS
 
     override fun showEditPin() {
         openEditPinLiveEvent.call()
+    }
+
+    override fun showSetPin() {
+        openSetPinLiveEvent.call()
     }
 }

--- a/app/src/main/res/layout/activity_settings_security.xml
+++ b/app/src/main/res/layout/activity_settings_security.xml
@@ -48,13 +48,13 @@
                 app:layout_constraintTop_toBottomOf="@+id/manageKeys" />
 
             <io.horizontalsystems.bankwallet.modules.settings.SettingsItemView
-                android:id="@+id/fingerprint"
+                android:id="@+id/enablePin"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="32dp"
                 app:layout_constraintTop_toBottomOf="@+id/manageKeys"
-                app:setting_icon="@drawable/ic_fingerprint"
-                app:setting_title="@string/SettingsSecurity_Fingerprint" />
+                app:setting_icon="@drawable/ic_passcode"
+                app:setting_title="@string/SettingsSecurity_EnablePin" />
 
             <io.horizontalsystems.bankwallet.modules.settings.SettingsItemView
                 android:id="@+id/changePin"
@@ -62,9 +62,17 @@
                 android:layout_height="wrap_content"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/fingerprint"
-                app:setting_icon="@drawable/ic_passcode"
+                app:layout_constraintTop_toBottomOf="@+id/enablePin"
                 app:setting_title="@string/SettingsSecurity_EditPin" />
+
+            <io.horizontalsystems.bankwallet.modules.settings.SettingsItemView
+                android:id="@+id/fingerprint"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="32dp"
+                app:layout_constraintTop_toBottomOf="@+id/changePin"
+                app:setting_icon="@drawable/ic_fingerprint"
+                app:setting_title="@string/SettingsSecurity_Fingerprint" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -197,6 +197,7 @@
     <!--Setting_Security-->
 
     <string name="SettingsSecurity_Fingerprint">Fingerprint</string>
+    <string name="SettingsSecurity_EnablePin">Passcode</string>
     <string name="SettingsSecurity_EditPin">Edit Passcode</string>
     <string name="SettingsSecurity_ManageKeys">Manage Keys</string>
     <string name="SettingsSecurity_BackupWallet">Backup Wallet</string>


### PR DESCRIPTION
Refactor "pin module":
- make pin optional
- use activity result code to return pin module action results
- add settings item for enabling pin

Refactor "backup module":
- remove router from interactor
- use pin module's returned result instead of subscribing to pin manager's lockStateUpdate event