### PR TITLE
Update binance-chain-kit dependency version.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -133,7 +133,7 @@ dependencies {
     implementation 'com.github.horizontalsystems:ethereum-kit-android:6d9a47d928'
     implementation 'com.github.horizontalsystems:blockchain-fee-rate-kit-android:6c9917a'
     implementation 'com.github.horizontalsystems:hd-wallet-kit-android:a3666d8'
-    implementation 'com.github.horizontalsystems:binance-chain-kit-android:60911d0c39'
+    implementation 'com.github.horizontalsystems:binance-chain-kit-android:8b24d51'
     implementation ('com.github.horizontalsystems:eos-kit-android:dcba60f') {
         exclude group: 'org.bitcoinj', module:'bitcoinj-core'
     }


### PR DESCRIPTION
- Update binance-chain-kit dependency version to (8b24d51 commit)