### PR TITLE
Hide link that opens transaction info in external source for EOS

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/FullTransactionInfoModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/FullTransactionInfoModule.kt
@@ -32,6 +32,7 @@ object FullTransactionInfoModule {
         fun viewDidLoad()
         fun onRetryLoad()
 
+        val canShowTransactionInProviderSite: Boolean
         val providerName: String?
         val sectionCount: Int
         fun getSection(row: Int): FullTransactionSection?

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/FullTransactionInfoPresenter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/FullTransactionInfoPresenter.kt
@@ -12,6 +12,9 @@ class FullTransactionInfoPresenter(val interactor: FullTransactionInfoInteractor
     //
     // State
     //
+    override val canShowTransactionInProviderSite: Boolean
+        get() = interactor.url(state.transactionHash) != null
+
     override val providerName: String?
         get() = state.transactionRecord?.providerName
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/views/FullTransactionInfoActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/views/FullTransactionInfoActivity.kt
@@ -203,12 +203,16 @@ class SectionViewAdapter(val context: Context) : RecyclerView.Adapter<RecyclerVi
             }
             is SectionLinkViewHolder -> {
                 providerName?.let {
-                    val changeProviderStyle = SpannableString(providerName)
-                    changeProviderStyle.setSpan(UnderlineSpan(), 0, changeProviderStyle.length, 0)
+                    if (!viewModel.delegate.canShowTransactionInProviderSite) {
+                        holder.transactionLink.visibility = View.GONE
+                    } else {
+                        val changeProviderStyle = SpannableString(providerName)
+                        changeProviderStyle.setSpan(UnderlineSpan(), 0, changeProviderStyle.length, 0)
 
-                    holder.transactionLink.text = changeProviderStyle
-                    holder.transactionLink.setOnClickListener {
-                        viewModel.delegate.onTapResource()
+                        holder.transactionLink.text = changeProviderStyle
+                        holder.transactionLink.setOnClickListener {
+                            viewModel.delegate.onTapResource()
+                        }
                     }
                 }
             }

--- a/app/src/main/res/layout/view_holder_full_transaction_link.xml
+++ b/app/src/main/res/layout/view_holder_full_transaction_link.xml
@@ -1,17 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical">
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:orientation="vertical"
+              android:paddingTop="16dp"
+              android:paddingBottom="16dp"
+    >
 
     <TextView
         android:id="@+id/transactionLink"
         style="@style/Body1"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="27dp"
+        android:paddingBottom="11dp"
+        android:textAlignment="center"
         android:textColor="?TextColorBarsToDark"
-        android:paddingTop="16dp"
-        android:textAlignment="center" />
+        />
 
 </LinearLayout>


### PR DESCRIPTION
In FullTransactionInfo hide link that opens transaction info for providers that don't support this 
Close #1083