### PR TITLE
Backup alert improvements and bug fixes

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/BaseActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/BaseActivity.kt
@@ -18,7 +18,7 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout
 import io.horizontalsystems.bankwallet.core.App
-import io.horizontalsystems.bankwallet.lib.AlertDialogFragment
+import io.horizontalsystems.bankwallet.ui.dialogs.AlertDialogFragment
 import java.util.*
 
 abstract class BaseActivity : AppCompatActivity() {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/Interfaces.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/Interfaces.kt
@@ -331,6 +331,7 @@ interface IAccountsStorage {
 
     fun allAccounts(): List<Account>
     fun save(account: Account)
+    fun update(account: Account)
     fun delete(id: String)
     fun getNonBackedUpCount(): Flowable<Int>
     fun clear()
@@ -368,7 +369,7 @@ interface IWalletManager {
     val walletsUpdatedSignal: Observable<Unit>
     fun wallet(coin: Coin): Wallet?
 
-    fun preloadWallets()
+    fun loadWallets()
     fun enable(wallets: List<Wallet>)
     fun clear()
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/AccountManager.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/AccountManager.kt
@@ -44,7 +44,7 @@ class AccountManager(private val storage: IAccountsStorage, private val accountC
     }
 
     override fun update(account: Account) {
-        storage.save(account)
+        storage.update(account)
 
         cache.update(account)
         accountsSubject.onNext(accounts)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/storage/AccountsDao.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/storage/AccountsDao.kt
@@ -9,7 +9,7 @@ interface AccountsDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insert(accountRow: AccountRecord)
 
-    @Update(onConflict = OnConflictStrategy.REPLACE)
+    @Update
     fun update(accountRow: AccountRecord)
 
     @Query("UPDATE AccountRecord SET deleted = 1 WHERE id = :id")

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/storage/AccountsDao.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/storage/AccountsDao.kt
@@ -1,9 +1,6 @@
 package io.horizontalsystems.bankwallet.core.storage
 
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
-import androidx.room.Query
+import androidx.room.*
 import io.reactivex.Flowable
 
 @Dao
@@ -11,6 +8,9 @@ interface AccountsDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insert(accountRow: AccountRecord)
+
+    @Update(onConflict = OnConflictStrategy.REPLACE)
+    fun update(accountRow: AccountRecord)
 
     @Query("UPDATE AccountRecord SET deleted = 1 WHERE id = :id")
     fun delete(id: String)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceFragment.kt
@@ -16,8 +16,8 @@ import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.AdapterState
 import io.horizontalsystems.bankwallet.core.App
 import io.horizontalsystems.bankwallet.core.setOnSingleClickListener
-import io.horizontalsystems.bankwallet.lib.AlertDialogFragment
-import io.horizontalsystems.bankwallet.lib.BalanceSortDialogFragment
+import io.horizontalsystems.bankwallet.ui.dialogs.AlertDialogFragment
+import io.horizontalsystems.bankwallet.ui.dialogs.BalanceSortDialogFragment
 import io.horizontalsystems.bankwallet.modules.main.MainActivity
 import io.horizontalsystems.bankwallet.modules.managecoins.ManageWalletsModule
 import io.horizontalsystems.bankwallet.modules.settings.managekeys.ManageKeysModule

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceFragment.kt
@@ -16,10 +16,10 @@ import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.AdapterState
 import io.horizontalsystems.bankwallet.core.App
 import io.horizontalsystems.bankwallet.core.setOnSingleClickListener
+import io.horizontalsystems.bankwallet.modules.backup.BackupModule
 import io.horizontalsystems.bankwallet.ui.dialogs.BalanceSortDialogFragment
 import io.horizontalsystems.bankwallet.modules.main.MainActivity
 import io.horizontalsystems.bankwallet.modules.managecoins.ManageWalletsModule
-import io.horizontalsystems.bankwallet.modules.settings.managekeys.ManageKeysModule
 import io.horizontalsystems.bankwallet.ui.dialogs.BackupAlertDialog
 import io.horizontalsystems.bankwallet.ui.extensions.NpaLinearLayoutManager
 import io.horizontalsystems.bankwallet.viewHelpers.AnimationHelper
@@ -105,14 +105,16 @@ class BalanceFragment : Fragment(), CoinsAdapter.Listener, BalanceSortDialogFrag
             activity?.let { ctxActivity ->
                 BackupAlertDialog.show(activity = ctxActivity, listener = object : BackupAlertDialog.Listener{
                     override fun onBackupButtonClick() {
-                        viewModel.delegate.openManageKeys()
+                        viewModel.delegate.openBackup()
                     }
                 })
             }
         })
 
-        viewModel.openManageKeys.observe(viewLifecycleOwner, Observer {
-            context?.let { ctx -> ManageKeysModule.start(ctx) }
+        viewModel.openBackup.observe(viewLifecycleOwner, Observer { (account, coinCodesStringRes) ->
+            context?.let { ctx ->
+                BackupModule.start(ctx, account, getString(coinCodesStringRes))
+            }
         })
 
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceFragment.kt
@@ -16,11 +16,11 @@ import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.AdapterState
 import io.horizontalsystems.bankwallet.core.App
 import io.horizontalsystems.bankwallet.core.setOnSingleClickListener
-import io.horizontalsystems.bankwallet.ui.dialogs.AlertDialogFragment
 import io.horizontalsystems.bankwallet.ui.dialogs.BalanceSortDialogFragment
 import io.horizontalsystems.bankwallet.modules.main.MainActivity
 import io.horizontalsystems.bankwallet.modules.managecoins.ManageWalletsModule
 import io.horizontalsystems.bankwallet.modules.settings.managekeys.ManageKeysModule
+import io.horizontalsystems.bankwallet.ui.dialogs.BackupAlertDialog
 import io.horizontalsystems.bankwallet.ui.extensions.NpaLinearLayoutManager
 import io.horizontalsystems.bankwallet.viewHelpers.AnimationHelper
 import io.horizontalsystems.bankwallet.viewHelpers.DateHelper
@@ -102,15 +102,13 @@ class BalanceFragment : Fragment(), CoinsAdapter.Listener, BalanceSortDialogFrag
         })
 
         viewModel.showBackupAlert.observe(viewLifecycleOwner, Observer {
-            AlertDialogFragment.newInstance(
-                    description = R.string.Receive_Alert_NotBackedUp_Description,
-                    buttonText = R.string.Receive_Alert_NotBackedUp_Button,
-                    cancelable = true,
-                    listener = object : AlertDialogFragment.Listener {
-                        override fun onButtonClick() {
-                            viewModel.delegate.openManageKeys()
-                        }
-                    }).show(childFragmentManager, "coin_backup_alert")
+            activity?.let { ctxActivity ->
+                BackupAlertDialog.show(activity = ctxActivity, listener = object : BackupAlertDialog.Listener{
+                    override fun onBackupButtonClick() {
+                        viewModel.delegate.openManageKeys()
+                    }
+                })
+            }
         })
 
         viewModel.openManageKeys.observe(viewLifecycleOwner, Observer {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceModule.kt
@@ -3,6 +3,7 @@ package io.horizontalsystems.bankwallet.modules.balance
 import io.horizontalsystems.bankwallet.core.AdapterState
 import io.horizontalsystems.bankwallet.core.App
 import io.horizontalsystems.bankwallet.core.IBalanceAdapter
+import io.horizontalsystems.bankwallet.entities.Account
 import io.horizontalsystems.bankwallet.entities.Currency
 import io.horizontalsystems.bankwallet.entities.Rate
 import io.horizontalsystems.bankwallet.entities.Wallet
@@ -33,7 +34,7 @@ object BalanceModule {
         fun onClear()
         fun onSortClick()
         fun onSortTypeChanged(sortType: BalanceSortType)
-        fun openManageKeys()
+        fun openBackup()
     }
 
     interface IInteractor {
@@ -60,7 +61,7 @@ object BalanceModule {
         fun openSendDialog(wallet: Wallet)
         fun openManageCoins()
         fun openSortTypeDialog(sortingType: BalanceSortType)
-        fun openManageKeys()
+        fun openBackup(account: Account, coinCodesStringRes: Int)
     }
 
     class BalanceItemDataSource {
@@ -158,7 +159,7 @@ object BalanceModule {
 
     fun init(view: BalanceViewModel, router: IRouter) {
         val interactor = BalanceInteractor(App.walletManager, App.adapterManager, App.rateStorage, App.currencyManager, App.localStorage)
-        val presenter = BalancePresenter(interactor, router, BalanceItemDataSource(), BalanceViewItemFactory())
+        val presenter = BalancePresenter(interactor, router, BalanceItemDataSource(), App.predefinedAccountTypeManager, BalanceViewItemFactory())
 
         presenter.view = view
         interactor.delegate = presenter

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceModule.kt
@@ -150,8 +150,7 @@ object BalanceModule {
             val wallet: Wallet,
             var balance: BigDecimal = BigDecimal.ZERO,
             var state: AdapterState = AdapterState.NotSynced,
-            var rate: Rate? = null,
-            var isBackedUp: Boolean = false
+            var rate: Rate? = null
     ) {
         val fiatValue: BigDecimal?
             get() = rate?.let { balance.times(it.value) }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalancePresenter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalancePresenter.kt
@@ -62,7 +62,7 @@ class BalancePresenter(
     }
 
     override fun onReceive(position: Int) {
-        if (dataSource.getItem(position).isBackedUp) {
+        if (dataSource.getItem(position).wallet.account.isBackedUp) {
             router.openReceiveDialog(dataSource.getItem(position).wallet)
         } else {
             view?.showBackupAlert()
@@ -99,7 +99,7 @@ class BalancePresenter(
         val items = wallets.map {
             val adapter = interactor.getBalanceAdapterForWallet(it)
 
-            BalanceModule.BalanceItem(it, adapter?.balance ?: BigDecimal.ZERO, adapter?.state ?: AdapterState.NotReady,  isBackedUp = it.account.isBackedUp)
+            BalanceModule.BalanceItem(it, adapter?.balance ?: BigDecimal.ZERO, adapter?.state ?: AdapterState.NotReady)
         }
         dataSource.set(items)
         dataSource.currency?.let {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceViewModel.kt
@@ -2,6 +2,7 @@ package io.horizontalsystems.bankwallet.modules.balance
 
 import androidx.lifecycle.ViewModel
 import io.horizontalsystems.bankwallet.SingleLiveEvent
+import io.horizontalsystems.bankwallet.entities.Account
 import io.horizontalsystems.bankwallet.entities.Wallet
 
 class BalanceViewModel : ViewModel(), BalanceModule.IView, BalanceModule.IRouter {
@@ -19,7 +20,7 @@ class BalanceViewModel : ViewModel(), BalanceModule.IView, BalanceModule.IRouter
     val reloadItemLiveEvent = SingleLiveEvent<Int>()
     val setSortingOnLiveEvent = SingleLiveEvent<Boolean>()
     val showBackupAlert = SingleLiveEvent<Unit>()
-    val openManageKeys = SingleLiveEvent<Unit>()
+    val openBackup = SingleLiveEvent<Pair<Account, Int>>()
 
     fun init() {
         BalanceModule.init(this, this)
@@ -79,7 +80,7 @@ class BalanceViewModel : ViewModel(), BalanceModule.IView, BalanceModule.IRouter
         showBackupAlert.call()
     }
 
-    override fun openManageKeys() {
-        openManageKeys.call()
+    override fun openBackup(account: Account, coinCodesStringRes: Int) {
+        openBackup.value = Pair(account, coinCodesStringRes)
     }
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/keystore/KeyStoreActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/keystore/KeyStoreActivity.kt
@@ -10,7 +10,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import io.horizontalsystems.bankwallet.R
-import io.horizontalsystems.bankwallet.lib.AlertDialogFragment
+import io.horizontalsystems.bankwallet.ui.dialogs.AlertDialogFragment
 import io.horizontalsystems.bankwallet.modules.launcher.LaunchModule
 import kotlinx.android.synthetic.main.activity_keystore.*
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/main/MainInteractor.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/main/MainInteractor.kt
@@ -11,7 +11,7 @@ class MainInteractor(private val accountManager: IAccountManager, private val wa
 
     override fun onStart() {
         accountManager.preloadAccounts()
-        walletManager.preloadWallets()
+        walletManager.loadWallets()
         adapterManager.preloadAdapters()
 
         accountManager.clearAccounts()

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/managecoins/views/ManageWalletsActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/managecoins/views/ManageWalletsActivity.kt
@@ -9,7 +9,7 @@ import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.EosUnsupportedException
 import io.horizontalsystems.bankwallet.core.utils.ModuleCode
 import io.horizontalsystems.bankwallet.entities.AccountType
-import io.horizontalsystems.bankwallet.lib.AlertDialogFragment
+import io.horizontalsystems.bankwallet.ui.dialogs.AlertDialogFragment
 import io.horizontalsystems.bankwallet.modules.managecoins.ManageWalletsViewModel
 import io.horizontalsystems.bankwallet.modules.restore.eos.RestoreEosModule
 import io.horizontalsystems.bankwallet.modules.restore.words.RestoreWordsModule

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/managekeys/views/ManageKeysActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/managekeys/views/ManageKeysActivity.kt
@@ -9,7 +9,7 @@ import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.EosUnsupportedException
 import io.horizontalsystems.bankwallet.core.utils.ModuleCode
 import io.horizontalsystems.bankwallet.entities.AccountType
-import io.horizontalsystems.bankwallet.lib.AlertDialogFragment
+import io.horizontalsystems.bankwallet.ui.dialogs.AlertDialogFragment
 import io.horizontalsystems.bankwallet.modules.backup.BackupModule
 import io.horizontalsystems.bankwallet.modules.restore.eos.RestoreEosModule
 import io.horizontalsystems.bankwallet.modules.restore.words.RestoreWordsModule

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsActivity.kt
@@ -8,7 +8,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import io.horizontalsystems.bankwallet.BaseActivity
 import io.horizontalsystems.bankwallet.R
-import io.horizontalsystems.bankwallet.lib.AlertDialogFragment
+import io.horizontalsystems.bankwallet.ui.dialogs.AlertDialogFragment
 import io.horizontalsystems.bankwallet.modules.pin.PinModule
 import io.horizontalsystems.bankwallet.modules.settings.managekeys.ManageKeysModule
 import io.horizontalsystems.bankwallet.ui.extensions.TopMenuItem

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/dialogs/AlertDialogFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/dialogs/AlertDialogFragment.kt
@@ -1,4 +1,4 @@
-package io.horizontalsystems.bankwallet.lib
+package io.horizontalsystems.bankwallet.ui.dialogs
 
 import android.app.Dialog
 import android.os.Bundle

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/dialogs/BackupAlertDialog.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/dialogs/BackupAlertDialog.kt
@@ -1,0 +1,41 @@
+package io.horizontalsystems.bankwallet.ui.dialogs
+
+import android.app.Dialog
+import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.FragmentActivity
+import io.horizontalsystems.bankwallet.R
+import io.horizontalsystems.bankwallet.viewHelpers.bottomDialog
+
+class BackupAlertDialog(private val listener: Listener) : DialogFragment() {
+
+    interface Listener {
+        fun onBackupButtonClick() {}
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val rootView = View.inflate(context, R.layout.fragment_bottom_backup_alert, null) as ViewGroup
+
+        rootView.findViewById<Button>(R.id.backupButton)?.apply {
+            setOnClickListener {
+                listener.onBackupButtonClick()
+                dismiss()
+            }
+        }
+
+        return bottomDialog(activity, rootView)
+    }
+
+    companion object {
+        fun show(activity: FragmentActivity, listener: Listener) {
+            val fragment = BackupAlertDialog(listener)
+            val transaction = activity.supportFragmentManager.beginTransaction()
+
+            transaction.add(fragment, "bottom_backup_alert")
+            transaction.commitAllowingStateLoss()
+        }
+    }
+}

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/dialogs/BalanceSortDialogFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/dialogs/BalanceSortDialogFragment.kt
@@ -1,4 +1,4 @@
-package io.horizontalsystems.bankwallet.lib
+package io.horizontalsystems.bankwallet.ui.dialogs
 
 import android.os.Bundle
 import android.view.*

--- a/app/src/main/res/layout/fragment_bottom_backup_alert.xml
+++ b/app/src/main/res/layout/fragment_bottom_backup_alert.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="8dp"
+        android:background="@drawable/bottom_sheet_floating_background"
+        android:backgroundTint="?attr/BottomSheetBackground"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/dialogIcon"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginStart="12dp"
+            android:layout_marginTop="10dp"
+            android:src="@drawable/ic_attention"
+            android:tint="@color/red_warning"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/dialogTitle"
+            style="@style/BaseSb"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginEnd="14dp"
+            android:ellipsize="end"
+            android:singleLine="true"
+            android:text="@string/Receive_Alert_NotBackedUp_Title"
+            android:textColor="?BottomDialogTextColor"
+            app:layout_constraintBottom_toBottomOf="@+id/dialogIcon"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/dialogIcon"
+            app:layout_constraintTop_toTopOf="@+id/dialogIcon" />
+
+        <View
+            android:id="@+id/border"
+            android:layout_width="0dp"
+            android:layout_height="0.5dp"
+            android:layout_marginTop="10dp"
+            android:background="@color/steel_15"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/dialogIcon" />
+
+        <TextView
+            android:id="@+id/dialogText"
+            style="@style/Body1Grey"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            android:paddingBottom="8dp"
+            android:text="@string/Receive_Alert_NotBackedUp_Description"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/border" />
+
+        <Button
+            android:id="@+id/backupButton"
+            style="@style/ButtonYellow"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
+            android:text="@string/Receive_Alert_NotBackedUp_Button"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/dialogText" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_bottom_backup_alert.xml
+++ b/app/src/main/res/layout/fragment_bottom_backup_alert.xml
@@ -2,86 +2,85 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:paddingStart="8dp"
+    android:paddingEnd="8dp"
+    android:paddingBottom="8dp">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginBottom="8dp"
+    <View
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         android:background="@drawable/bottom_sheet_floating_background"
         android:backgroundTint="?attr/BottomSheetBackground"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <ImageView
-            android:id="@+id/dialogIcon"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_marginStart="12dp"
-            android:layout_marginTop="10dp"
-            android:src="@drawable/ic_attention"
-            android:tint="@color/red_warning"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+    <ImageView
+        android:id="@+id/dialogIcon"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_marginStart="12dp"
+        android:layout_marginTop="10dp"
+        android:src="@drawable/ic_attention"
+        android:tint="@color/red_warning"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
-            android:id="@+id/dialogTitle"
-            style="@style/BaseSb"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="12dp"
-            android:layout_marginEnd="14dp"
-            android:ellipsize="end"
-            android:singleLine="true"
-            android:text="@string/Receive_Alert_NotBackedUp_Title"
-            android:textColor="?BottomDialogTextColor"
-            app:layout_constraintBottom_toBottomOf="@+id/dialogIcon"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/dialogIcon"
-            app:layout_constraintTop_toTopOf="@+id/dialogIcon" />
+    <TextView
+        android:id="@+id/dialogTitle"
+        style="@style/BaseSb"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_marginEnd="14dp"
+        android:ellipsize="end"
+        android:singleLine="true"
+        android:text="@string/Receive_Alert_NotBackedUp_Title"
+        android:textColor="?BottomDialogTextColor"
+        app:layout_constraintBottom_toBottomOf="@+id/dialogIcon"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/dialogIcon"
+        app:layout_constraintTop_toTopOf="@+id/dialogIcon" />
 
-        <View
-            android:id="@+id/border"
-            android:layout_width="0dp"
-            android:layout_height="0.5dp"
-            android:layout_marginTop="10dp"
-            android:background="@color/steel_15"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/dialogIcon" />
+    <View
+        android:id="@+id/border"
+        android:layout_width="0dp"
+        android:layout_height="0.5dp"
+        android:layout_marginTop="10dp"
+        android:background="@color/steel_15"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/dialogIcon" />
 
-        <TextView
-            android:id="@+id/dialogText"
-            style="@style/Body1Grey"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
-            android:layout_marginEnd="16dp"
-            android:paddingBottom="8dp"
-            android:text="@string/Receive_Alert_NotBackedUp_Description"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/border" />
+    <TextView
+        android:id="@+id/dialogText"
+        style="@style/Body1Grey"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:paddingBottom="8dp"
+        android:text="@string/Receive_Alert_NotBackedUp_Description"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/border" />
 
-        <Button
-            android:id="@+id/backupButton"
-            style="@style/ButtonYellow"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginBottom="16dp"
-            android:text="@string/Receive_Alert_NotBackedUp_Button"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/dialogText" />
+    <Button
+        android:id="@+id/backupButton"
+        style="@style/ButtonYellow"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
+        android:text="@string/Receive_Alert_NotBackedUp_Button"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/dialogText" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,6 +123,7 @@
     <string name="Deposit_Your_Address">Your Address</string>
     <string name="Deposit_Your_Account">Your Account</string>
 
+    <string name="Receive_Alert_NotBackedUp_Title">Backup Alert</string>
     <string name="Receive_Alert_NotBackedUp_Button">Backup</string>
     <string name="Receive_Alert_NotBackedUp_Description">You need to backup the keys for this wallet before you may receive funds on it. </string>
 


### PR DESCRIPTION
- Update account state BackedUp in Balance page
- Fix deletion of enabled wallets when their account becomes Backed Up
- Move AlertDialog and BalanceSortDialog to ui/dialogs package
- Show Backup Alert as bottom dialog
- Open directly Backup activity when user clicks on BackupButton in BackupAlertDialog shown in Balance page
Close #1167, #1023