### PR TITLE
Fix the issue with crashing when enabling coin

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceInteractor.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceInteractor.kt
@@ -71,6 +71,7 @@ class BalanceInteractor(
         delegate?.didUpdateCurrency(currencyManager.baseCurrency)
     }
 
+    @Synchronized
     private fun onUpdateWallets() {
         adapterDisposables.clear()
 
@@ -83,6 +84,7 @@ class BalanceInteractor(
         }
     }
 
+    @Synchronized
     private fun subscribeToAdapterUpdates(wallet: Wallet, initialUpdate: Boolean) {
         adapterManager.getBalanceAdapterForWallet(wallet)?.let { adapter ->
 


### PR DESCRIPTION
The problem was in the concurrent execution of methods. It starts to update wallets list in one thread. Then it updates the balance for newly enabled coin in the second thread before the updating wallet list is finished. Since the wallet list doesn't contain the enabled coin it doesn't find it and crashes.

Close #1187 