### PR TITLE
Add showFromAddress flag to TransactionViewItem

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/BitcoinBaseAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/BitcoinBaseAdapter.kt
@@ -112,7 +112,7 @@ abstract class BitcoinBaseAdapter(open val kit: AbstractKit)
                 amount = transaction.amount.toBigDecimal().divide(satoshisInBitcoin, decimal, RoundingMode.HALF_EVEN),
                 fee = transaction.fee?.toBigDecimal()?.divide(satoshisInBitcoin, decimal, RoundingMode.HALF_EVEN),
                 timestamp = transaction.timestamp,
-                from = emptyList(),
+                from = transaction.from.map { TransactionAddress(it.address, it.mine) },
                 to = transaction.to.map { TransactionAddress(it.address, it.mine) }
         )
     }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/factories/TransactionViewItemFactory.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/factories/TransactionViewItemFactory.kt
@@ -51,6 +51,7 @@ class TransactionViewItemFactory(private val feeCoinProvider: FeeCoinProvider) {
                 fromAddress,
                 toAddress,
                 isSentToSelf(record),
+                showFromAddress(wallet.coin.type),
                 incoming,
                 if (record.timestamp == 0L) null else Date(record.timestamp * 1000),
                 status,
@@ -63,6 +64,10 @@ class TransactionViewItemFactory(private val feeCoinProvider: FeeCoinProvider) {
         val allToAddressesMine = record.to.all { it.mine }
 
         return allFromAddressesMine && allToAddressesMine
+    }
+
+    private fun showFromAddress(coinType: CoinType): Boolean {
+        return !(coinType == CoinType.Bitcoin || coinType == CoinType.BitcoinCash || coinType == CoinType.Dash)
     }
 
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionsModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionsModule.kt
@@ -19,6 +19,7 @@ data class TransactionViewItem(
         val from: String?,
         val to: String?,
         val sentToSelf: Boolean,
+        val showFromAddress: Boolean,
         val incoming: Boolean,
         val date: Date?,
         val status: TransactionStatus,

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/TransactionInfoView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/TransactionInfoView.kt
@@ -103,7 +103,7 @@ class TransactionInfoView : ConstraintLayout {
                 itemTime.bind(context.getString(R.string.TransactionInfo_Time), txRec.date?.let { DateHelper.getFullDateWithShortMonth(it) } ?: "")
                 itemStatus.bindStatus(txStatus)
 
-                if (txRec.from.isNullOrEmpty()) {
+                if (txRec.from.isNullOrEmpty() || !txRec.showFromAddress) {
                     itemFrom.visibility = View.GONE
                 } else {
                     itemFrom.visibility = View.VISIBLE


### PR DESCRIPTION
- for BTC, BCH and DASH don't show from address field
- add from addresses to TransactionRecord in BitcoinBaseAdapter because setting it to empty list breaks correctness of function isSentToSelf() in TransactionViewItemFactory

Close #1234 