### PR TITLE
Sync rate stats on return from background

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/App.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/App.kt
@@ -56,7 +56,8 @@ class App : Application() {
 
         lateinit var rateSyncScheduler: RateSyncScheduler
         lateinit var rateManager: RateManager
-        lateinit var rateStatsManager: RateStatsManager
+        lateinit var rateStatsManager: IRateStatsManager
+        lateinit var rateStatsSyncer: IRateStatsSyncer
         lateinit var connectivityManager: ConnectivityManager
         lateinit var appDatabase: AppDatabase
         lateinit var rateStorage: IRateStorage
@@ -147,6 +148,10 @@ class App : Application() {
 
         rateManager = RateManager(rateStorage, networkManager, walletManager, currencyManager, connectivityManager)
         rateSyncScheduler = RateSyncScheduler(rateManager, walletManager, currencyManager, connectivityManager)
+
+        rateStatsSyncer = RateStatsSyncer(rateStatsManager, walletManager, currencyManager, rateStorage).apply {
+            backgroundManager.registerListener(this)
+        }
 
         transactionDataProviderManager = TransactionDataProviderManager(appConfigProvider, localStorage)
         transactionInfoFactory = FullTransactionInfoFactory(networkManager, transactionDataProviderManager)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/Interfaces.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/Interfaces.kt
@@ -4,6 +4,7 @@ import android.text.SpannableString
 import androidx.biometric.BiometricPrompt
 import com.google.gson.JsonObject
 import io.horizontalsystems.bankwallet.core.managers.ServiceExchangeApi.HostType
+import io.horizontalsystems.bankwallet.core.managers.StatsResponse
 import io.horizontalsystems.bankwallet.entities.*
 import io.horizontalsystems.bankwallet.entities.Currency
 import io.horizontalsystems.bankwallet.lib.chartview.ChartView
@@ -356,6 +357,17 @@ interface IRateStorage {
 
 interface IRateManager {
     fun syncLatestRates()
+}
+
+interface IRateStatsManager {
+    val statsFlowable: Flowable<StatsResponse>
+    fun syncStats(coinCode: String, currencyCode: String)
+}
+
+interface IRateStatsSyncer {
+    var balanceStatsOn: Boolean
+    var lockStatsOn: Boolean
+    var rateChartShown: Boolean
 }
 
 interface IAccountsStorage {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/RateStatsSyncer.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/RateStatsSyncer.kt
@@ -1,0 +1,94 @@
+package io.horizontalsystems.bankwallet.core.managers
+
+import android.app.Activity
+import io.horizontalsystems.bankwallet.core.*
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.schedulers.Schedulers
+
+class RateStatsSyncer(private val rateStatsManager: IRateStatsManager,
+                      private val walletManager: IWalletManager,
+                      private val currencyManager: ICurrencyManager,
+                      private val rateStorage: IRateStorage) : IRateStatsSyncer, BackgroundManager.Listener {
+
+    private var disposables = CompositeDisposable()
+    private var rateDisposables = CompositeDisposable()
+
+    init {
+        walletManager.walletsUpdatedSignal
+                .subscribeOn(Schedulers.io())
+                .observeOn(Schedulers.io())
+                .subscribe {
+                    syncStatsAll()
+                    subscribeToRates(currencyManager.baseCurrency.code)
+                }
+                .let { disposables.add(it) }
+
+        currencyManager.baseCurrencyUpdatedSignal
+                .subscribeOn(Schedulers.io())
+                .observeOn(Schedulers.io())
+                .subscribe {
+                    syncStatsAll()
+                    subscribeToRates(currencyManager.baseCurrency.code)
+                }
+                .let { disposables.add(it) }
+    }
+
+    // IRateStatsSyncer
+
+    override var balanceStatsOn: Boolean = false
+        set(value) {
+            field = value
+            syncStatsAll()
+        }
+    override var lockStatsOn: Boolean = false
+        set(value) {
+            field = value
+            syncStatsAll()
+        }
+
+    override var rateChartShown: Boolean = false
+        set(value) {
+            field = value
+            syncStatsAll()
+        }
+
+    // BackgroundManager.Listener
+
+    override fun willEnterForeground(activity: Activity) {
+        syncStatsAll()
+    }
+
+    override fun didEnterBackground() {
+
+    }
+
+    // private methods
+
+    private fun syncStatsAll() {
+        val baseCurrencyCode = currencyManager.baseCurrency.code
+        walletManager.wallets.forEach { wallet ->
+            syncStats(wallet.coin.code, baseCurrencyCode)
+        }
+    }
+
+    private fun syncStats(coinCode: String, currencyCode: String) {
+        if (balanceStatsOn || lockStatsOn || rateChartShown) {
+            rateStatsManager.syncStats(coinCode, currencyCode)
+        }
+    }
+
+    private fun subscribeToRates(baseCurrencyCode: String) {
+        rateDisposables.clear()
+
+        walletManager.wallets.forEach { wallet ->
+            rateStorage.latestRateObservable(wallet.coin.code, baseCurrencyCode)
+                    .subscribeOn(Schedulers.io())
+                    .observeOn(Schedulers.io())
+                    .subscribe { syncStats(wallet.coin.code, baseCurrencyCode) }
+                    .let {
+                        rateDisposables.add(it)
+                    }
+        }
+    }
+
+}

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceModule.kt
@@ -41,10 +41,11 @@ object BalanceModule {
     }
 
     interface IInteractor {
+        var chartEnabled: Boolean
+
         fun refresh()
         fun initWallets()
         fun fetchRates(currencyCode: String, coinCodes: List<CoinCode>)
-        fun fetchRateStats(currencyCode: String, coinCode: CoinCode)
         fun getSortingType(): BalanceSortType
         fun clear()
         fun saveSortingType(sortType: BalanceSortType)
@@ -57,7 +58,7 @@ object BalanceModule {
         fun didUpdateBalance(wallet: Wallet, balance: BigDecimal)
         fun didUpdateState(wallet: Wallet, state: AdapterState)
         fun didUpdateRate(rate: Rate)
-        fun onReceiveRateStats(coinCode: CoinCode, data: StatsData)
+        fun onReceiveRateStats(data: StatsData)
         fun onFailFetchChartStats(coinCode: String)
         fun didRefresh()
     }
@@ -90,8 +91,6 @@ object BalanceModule {
                 field = value
                 items = sorter.sort(items, sortType)
             }
-
-        var chartEnabled = false
 
         @Synchronized
         fun addUpdatedPosition(position: Int) {
@@ -170,7 +169,7 @@ object BalanceModule {
 
     fun init(view: BalanceViewModel, router: IRouter) {
         val currencyManager = App.currencyManager
-        val interactor = BalanceInteractor(App.walletManager, App.adapterManager, App.rateStorage, App.rateStatsManager, currencyManager, App.localStorage, App.rateManager)
+        val interactor = BalanceInteractor(App.walletManager, App.adapterManager, App.rateStorage, App.rateStatsManager, App.rateStatsSyncer, currencyManager, App.localStorage, App.rateManager)
         val presenter = BalancePresenter(interactor, router, DataSource(currencyManager.baseCurrency, BalanceSorter()), App.predefinedAccountTypeManager, BalanceViewItemFactory())
 
         presenter.view = view

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceViewModel.kt
@@ -37,7 +37,7 @@ class BalanceViewModel : ViewModel(), BalanceModule.IView, BalanceModule.IRouter
     }
 
     override fun updateItem(position: Int) {
-        reloadItemLiveEvent.value = position
+        reloadItemLiveEvent.postValue(position)
     }
 
     override fun updateHeader() {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/ratechart/RateChartFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/ratechart/RateChartFragment.kt
@@ -1,5 +1,6 @@
 package io.horizontalsystems.bankwallet.modules.ratechart
 
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -62,6 +63,12 @@ class RateChartFragment(private val coin: Coin) : BottomSheetDialogFragment(), C
                 }
             }
         }
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+
+        presenter.onChartClosed()
     }
 
     private fun observeData() {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/ratechart/RateChartModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/ratechart/RateChartModule.kt
@@ -9,7 +9,6 @@ import io.horizontalsystems.bankwallet.entities.CurrencyValue
 import io.horizontalsystems.bankwallet.entities.Rate
 import io.horizontalsystems.bankwallet.lib.chartview.ChartView.ChartType
 import io.horizontalsystems.bankwallet.lib.chartview.models.DataPoint
-import io.horizontalsystems.bankwallet.modules.transactions.CoinCode
 
 object RateChartModule {
 
@@ -27,16 +26,21 @@ object RateChartModule {
         fun viewDidLoad()
         fun onSelect(type: ChartType)
         fun onTouchSelect(point: DataPoint)
+        fun onChartClosed()
     }
 
     interface Interactor {
         var defaultChartType: ChartType
-        fun getRateStats(coinCode: CoinCode, currencyCode: String)
+        var chartEnabled: Boolean
+
+        fun subscribeToLatestRate(coinCode: String, currencyCode: String)
+        fun subscribeToChartStats()
         fun clear()
     }
 
     interface InteractorDelegate {
-        fun onReceiveStats(data: Pair<StatsData, Rate>)
+        fun onReceiveStats(data: StatsData)
+        fun onReceiveLatestRate(rate: Rate)
         fun onReceiveError(ex: Throwable)
     }
 
@@ -46,7 +50,7 @@ object RateChartModule {
 
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             val view = RateChartView()
-            val interactor = RateChartInteractor(App.rateStatsManager, App.rateStorage, App.localStorage)
+            val interactor = RateChartInteractor(App.rateStatsManager,App.rateStatsSyncer, App.rateStorage, App.localStorage)
             val presenter = RateChartPresenter(view, interactor, coin.code, App.currencyManager.baseCurrency, RateChartViewFactory())
 
             interactor.delegate = presenter

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/ratechart/RateChartPresenter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/ratechart/RateChartPresenter.kt
@@ -18,11 +18,20 @@ class RateChartPresenter(
         private val interactor: Interactor,
         private val coinCode: CoinCode,
         private val currency: Currency,
-        private val factory: RateChartViewFactory)
-    : ViewModel(), ViewDelegate, InteractorDelegate {
+        private val factory: RateChartViewFactory) : ViewModel(), ViewDelegate, InteractorDelegate {
 
-    private var rate: Rate? = null
+    private var latestRate: Rate? = null
+        set(value) {
+            field = value
+            updateChart()
+        }
+
     private var statsData: StatsData? = null
+        set(value) {
+            field = value
+            updateChart()
+        }
+
     private var chartType = interactor.defaultChartType
 
     //  ViewDelegate
@@ -30,15 +39,21 @@ class RateChartPresenter(
     override fun viewDidLoad() {
         view.showSpinner()
         view.setChartType(interactor.defaultChartType)
-        showOrFetch()
+
+        interactor.subscribeToChartStats()
+        interactor.subscribeToLatestRate(coinCode, currency.code)
+        interactor.chartEnabled = true
     }
 
     override fun onSelect(type: ChartType) {
+        if (chartType == type)
+            return
+
         chartType = type
         interactor.defaultChartType = type
 
         view.showSpinner()
-        showOrFetch()
+        updateChart()
     }
 
     override fun onTouchSelect(point: DataPoint) {
@@ -46,12 +61,27 @@ class RateChartPresenter(
         view.showSelectedPoint(Triple(point.time, currencyValue, chartType))
     }
 
+    override fun onChartClosed() {
+        interactor.chartEnabled = false
+    }
+
     //  InteractorDelegate
 
-    override fun onReceiveStats(data: Pair<StatsData, Rate>) {
-        rate = data.second
-        statsData = data.first
-        val stats = data.first.stats
+    @Synchronized
+    override fun onReceiveStats(data: StatsData) {
+        if (data.coinCode != coinCode)
+            return
+
+        statsData = data
+    }
+
+    @Synchronized
+    override fun onReceiveLatestRate(rate: Rate) {
+        latestRate = rate
+    }
+
+    private fun updateChart() {
+        val stats = statsData?.stats ?: return
 
         for (type in stats.keys) {
             val chartType = ChartType.fromString(type) ?: continue
@@ -69,21 +99,13 @@ class RateChartPresenter(
         view.showError(ex)
     }
 
-    private fun showOrFetch() {
-        if (statsData == null) {
-            interactor.getRateStats(coinCode, currency.code)
-        } else {
-            showChart()
-        }
-    }
-
     private fun showChart() {
         val statsData = statsData ?: return
 
         view.hideSpinner()
 
         try {
-            val viewItem = factory.createViewItem(chartType, statsData, rate, currency)
+            val viewItem = factory.createViewItem(chartType, statsData, latestRate, currency)
             view.showChart(viewItem)
         } catch (e: Exception) {
             view.showError(e)
@@ -95,4 +117,5 @@ class RateChartPresenter(
     override fun onCleared() {
         interactor.clear()
     }
+
 }


### PR DESCRIPTION
- implement RateStatsSyncer
- transfer stats via publish subject from manager instead of one time subscription
- subscribe syncer on currency, wallet, last rate changes
- store sync triggers in stats syncer

Close #1315 