### PR TITLE
Fix transactionInfo bottom sheet bug

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/main/MainActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/main/MainActivity.kt
@@ -181,6 +181,8 @@ class MainActivity : BaseActivity(), TransactionInfoView.Listener {
             override fun onStateChanged(@NonNull bottomSheet: View, newState: Int) {
                 if (newState == BottomSheetBehavior.STATE_EXPANDED) {
                     bottomSheetBehavior.isFitToContents = true
+                    bottomSheetDim.alpha = 1f
+                    bottomSheetDim.visibility = View.VISIBLE
                 }
             }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionsViewModel.kt
@@ -70,7 +70,7 @@ class TransactionsViewModel : ViewModel(), TransactionsModule.IView, Transaction
     }
 
     override fun openTransactionInfo(transactionViewItem: TransactionViewItem) {
-        transactionViewItemLiveEvent.value = transactionViewItem
+        transactionViewItemLiveEvent.postValue(transactionViewItem)
     }
 
     override fun onCleared() {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/TransactionInfoViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/TransactionInfoViewModel.kt
@@ -26,7 +26,7 @@ class TransactionInfoViewModel : ViewModel(), TransactionInfoModule.View, Transa
     }
 
     fun setViewItem(transactionViewItem: TransactionViewItem) {
-        transactionLiveData.value = transactionViewItem
+        transactionLiveData.postValue(transactionViewItem)
     }
 
     fun onClickTransactionId() {


### PR DESCRIPTION
- use postValue for liveData assignments
- when bottom sheet changes state to expanded show background dim

targeting #1490 