### PR TITLE
Failed transactions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -146,7 +146,7 @@ dependencies {
     releaseImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.6.3'
 
     // Wallet kits
-    implementation 'com.github.horizontalsystems:bitcoin-kit-android:3606d4a'
+    implementation 'com.github.horizontalsystems:bitcoin-kit-android:b64f1aa'
     implementation 'com.github.horizontalsystems:ethereum-kit-android:c03f4ba'
     implementation 'com.github.horizontalsystems:blockchain-fee-rate-kit-android:15df939'
     implementation 'com.github.horizontalsystems:hd-wallet-kit-android:68903dc'

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/Interfaces.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/Interfaces.kt
@@ -253,7 +253,7 @@ interface ITransactionsAdapter {
     val lastBlockHeight: Int?
     val lastBlockHeightUpdatedFlowable: Flowable<Unit>
 
-    fun getTransactions(from: Pair<String, Int>? = null, limit: Int): Single<List<TransactionRecord>>
+    fun getTransactions(from: TransactionRecord?, limit: Int): Single<List<TransactionRecord>>
     val transactionRecordsFlowable: Flowable<List<TransactionRecord>>
 }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/BinanceAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/BinanceAdapter.kt
@@ -65,8 +65,8 @@ class BinanceAdapter(
     override val transactionRecordsFlowable: Flowable<List<TransactionRecord>>
         get() = asset.transactionsFlowable.map { it.map { tx -> transactionRecord(tx) } }
 
-    override fun getTransactions(from: Pair<String, Int>?, limit: Int): Single<List<TransactionRecord>> {
-        return binanceKit.transactions(asset, from?.first, limit).map { list ->
+    override fun getTransactions(from: TransactionRecord?, limit: Int): Single<List<TransactionRecord>> {
+        return binanceKit.transactions(asset, from?.transactionHash, limit).map { list ->
             list.map { transactionRecord(it) }
         }
     }
@@ -91,6 +91,7 @@ class BinanceAdapter(
         }
 
         return TransactionRecord(
+                uid = transaction.hash,
                 transactionHash = transaction.hash,
                 transactionIndex = 0,
                 interTransactionIndex = 0,

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/BitcoinAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/BitcoinAdapter.kt
@@ -96,8 +96,8 @@ class BitcoinAdapter(override val kit: BitcoinKit)
         // ignored for now
     }
 
-    override fun getTransactions(from: Pair<String, Int>?, limit: Int): Single<List<TransactionRecord>> {
-        return kit.transactions(from?.first, limit).map { it.map { tx -> transactionRecord(tx) } }
+    override fun getTransactions(from: TransactionRecord?, limit: Int): Single<List<TransactionRecord>> {
+        return kit.transactions(from?.uid, limit).map { it.map { tx -> transactionRecord(tx) } }
     }
 
     companion object {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/BitcoinBaseAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/BitcoinBaseAdapter.kt
@@ -131,6 +131,7 @@ abstract class BitcoinBaseAdapter(open val kit: AbstractKit)
         }
 
         return TransactionRecord(
+                uid = transaction.uid,
                 transactionHash = transaction.transactionHash,
                 transactionIndex = transaction.transactionIndex,
                 interTransactionIndex = 0,

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/BitcoinBaseAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/BitcoinBaseAdapter.kt
@@ -7,6 +7,7 @@ import io.horizontalsystems.bankwallet.modules.transactions.TransactionLockInfo
 import io.horizontalsystems.bitcoincore.AbstractKit
 import io.horizontalsystems.bitcoincore.core.IPluginData
 import io.horizontalsystems.bitcoincore.models.TransactionInfo
+import io.horizontalsystems.bitcoincore.models.TransactionStatus
 import io.horizontalsystems.hodler.HodlerOutputData
 import io.horizontalsystems.hodler.HodlerPlugin
 import io.reactivex.BackpressureStrategy
@@ -121,7 +122,7 @@ abstract class BitcoinBaseAdapter(open val kit: AbstractKit)
     }
 
     fun transactionRecord(transaction: TransactionInfo): TransactionRecord {
-        val hodlerOutputData = transaction.to.first { it.pluginId == HodlerPlugin.id }.pluginData as? HodlerOutputData
+        val hodlerOutputData = transaction.to.firstOrNull { it.pluginId == HodlerPlugin.id }?.pluginData as? HodlerOutputData
         var transactionLockInfo: TransactionLockInfo? = null
 
         hodlerOutputData?.approxUnlockTime?.let { approxUnlockTime ->
@@ -139,6 +140,7 @@ abstract class BitcoinBaseAdapter(open val kit: AbstractKit)
                 timestamp = transaction.timestamp,
                 from = transaction.from.map { TransactionAddress(it.address, it.mine) },
                 to = transaction.to.map { TransactionAddress(it.address, it.mine) },
+                failed = transaction.status == TransactionStatus.INVALID,
                 lockInfo = transactionLockInfo
         )
     }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/BitcoinCashAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/BitcoinCashAdapter.kt
@@ -95,8 +95,8 @@ class BitcoinCashAdapter(override val kit: BitcoinCashKit)
         // ignored for now
     }
 
-    override fun getTransactions(from: Pair<String, Int>?, limit: Int): Single<List<TransactionRecord>> {
-        return kit.transactions(from?.first, limit).map { it.map { tx -> transactionRecord(tx) } }
+    override fun getTransactions(from: TransactionRecord?, limit: Int): Single<List<TransactionRecord>> {
+        return kit.transactions(from?.uid, limit).map { it.map { tx -> transactionRecord(tx) } }
     }
 
     companion object {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/DashAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/DashAdapter.kt
@@ -95,8 +95,8 @@ class DashAdapter(override val kit: DashKit) :
         // ignored for now
     }
 
-    override fun getTransactions(from: Pair<String, Int>?, limit: Int): Single<List<TransactionRecord>> {
-        return kit.transactions(from?.first, limit).map { it.map { tx -> transactionRecord(tx) } }
+    override fun getTransactions(from: TransactionRecord?, limit: Int): Single<List<TransactionRecord>> {
+        return kit.transactions(from?.uid, limit).map { it.map { tx -> transactionRecord(tx) } }
     }
 
     // ISendDashAdapter

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/EosAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/EosAdapter.kt
@@ -47,8 +47,8 @@ class EosAdapter(eos: CoinType.Eos, private val eosKit: EosKit, private val deci
     override val transactionRecordsFlowable: Flowable<List<TransactionRecord>>
         get() = token.transactionsFlowable.map { it.map { tx -> transactionRecord(tx) } }
 
-    override fun getTransactions(from: Pair<String, Int>?, limit: Int): Single<List<TransactionRecord>> {
-        return eosKit.transactions(token, from?.second, limit).map { list ->
+    override fun getTransactions(from: TransactionRecord?, limit: Int): Single<List<TransactionRecord>> {
+        return eosKit.transactions(token, from?.interTransactionIndex, limit).map { list ->
             list.map { transactionRecord(it) }
         }
     }
@@ -71,6 +71,7 @@ class EosAdapter(eos: CoinType.Eos, private val eosKit: EosKit, private val deci
         }
 
         return TransactionRecord(
+                uid = transaction.id,
                 transactionHash = transaction.id,
                 transactionIndex = 0,
                 interTransactionIndex = transaction.actionSequence,

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/Erc20Adapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/Erc20Adapter.kt
@@ -48,8 +48,8 @@ class Erc20Adapter(
 
     // ITransactionsAdapter
 
-    override fun getTransactions(from: Pair<String, Int>?, limit: Int): Single<List<TransactionRecord>> {
-        return erc20Kit.transactions(from?.let { TransactionKey(it.first.hexStringToByteArray(), it.second) }, limit).map {
+    override fun getTransactions(from: TransactionRecord?, limit: Int): Single<List<TransactionRecord>> {
+        return erc20Kit.transactions(from?.let { TransactionKey(it.transactionHash.hexStringToByteArray(), it.interTransactionIndex) }, limit).map {
             it.map { tx -> transactionRecord(tx) }
         }
     }
@@ -90,6 +90,7 @@ class Erc20Adapter(
         }
 
         return TransactionRecord(
+                uid = "${transaction.transactionHash}${transaction.interTransactionIndex}",
                 transactionHash = transaction.transactionHash,
                 transactionIndex = transaction.transactionIndex ?: 0,
                 interTransactionIndex = transaction.interTransactionIndex,

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/EthereumAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/EthereumAdapter.kt
@@ -43,8 +43,8 @@ class EthereumAdapter(kit: EthereumKit)
 
     // ITransactionsAdapter
 
-    override fun getTransactions(from: Pair<String, Int>?, limit: Int): Single<List<TransactionRecord>> {
-        return ethereumKit.transactions(from?.first, limit).map {
+    override fun getTransactions(from: TransactionRecord?, limit: Int): Single<List<TransactionRecord>> {
+        return ethereumKit.transactions(from?.transactionHash, limit).map {
             it.map { tx -> transactionRecord(tx) }
         }
     }
@@ -74,6 +74,7 @@ class EthereumAdapter(kit: EthereumKit)
         val fee = transaction.gasUsed?.toBigDecimal()?.multiply(transaction.gasPrice.toBigDecimal())?.movePointLeft(decimal)
 
         return TransactionRecord(
+                uid = transaction.hash,
                 transactionHash = transaction.hash,
                 transactionIndex = transaction.transactionIndex ?: 0,
                 interTransactionIndex = 0,

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/factories/TransactionViewItemFactory.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/factories/TransactionViewItemFactory.kt
@@ -37,12 +37,12 @@ class TransactionViewItemFactory(private val feeCoinProvider: FeeCoinProvider) {
         }
 
         var amount = record.amount
-        val currencyValue = rate?.let {
-            val amountLocked = lockInfo?.amount
-            if (sentToSelf && amountLocked != null) {
-                amount = amountLocked
-            }
 
+        if (sentToSelf && lockInfo?.amount != null) {
+            amount = lockInfo.amount
+        }
+
+        val currencyValue = rate?.let {
             CurrencyValue(it.currency, amount * it.value)
         }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/factories/TransactionViewItemFactory.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/factories/TransactionViewItemFactory.kt
@@ -13,7 +13,9 @@ class TransactionViewItemFactory(private val feeCoinProvider: FeeCoinProvider) {
 
         var status: TransactionStatus = TransactionStatus.Pending
 
-        if (record.blockHeight != null && lastBlockHeight != null) {
+        if (record.failed) {
+            status = TransactionStatus.Failed
+        } else if (record.blockHeight != null && lastBlockHeight != null) {
 
             val confirmations = lastBlockHeight - record.blockHeight.toInt() + 1
             if (confirmations >= 0) {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/entities/TransactionRecord.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/entities/TransactionRecord.kt
@@ -1,7 +1,6 @@
 package io.horizontalsystems.bankwallet.entities
 
 import io.horizontalsystems.bankwallet.modules.transactions.TransactionLockInfo
-import io.horizontalsystems.bitcoincore.core.IPluginOutputData
 import java.math.BigDecimal
 import java.util.*
 
@@ -57,5 +56,4 @@ data class TransactionItem(val wallet: Wallet, val record: TransactionRecord) : 
 
 class TransactionAddress(
         val address: String,
-        val mine: Boolean,
-        val pluginData: Map<Byte, IPluginOutputData>? = null)
+        val mine: Boolean)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/entities/TransactionRecord.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/entities/TransactionRecord.kt
@@ -14,7 +14,8 @@ data class TransactionRecord(
         val timestamp: Long,
         val from: List<TransactionAddress>,
         val to: List<TransactionAddress>,
-        val lockInfo: TransactionLockInfo? = null)
+        val lockInfo: TransactionLockInfo? = null,
+        val failed: Boolean = false)
     : Comparable<TransactionRecord> {
 
     override fun compareTo(other: TransactionRecord): Int {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/entities/TransactionRecord.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/entities/TransactionRecord.kt
@@ -2,9 +2,9 @@ package io.horizontalsystems.bankwallet.entities
 
 import io.horizontalsystems.bankwallet.modules.transactions.TransactionLockInfo
 import java.math.BigDecimal
-import java.util.*
 
 data class TransactionRecord(
+        val uid: String,
         val transactionHash: String,
         val transactionIndex: Int,
         val interTransactionIndex: Int,
@@ -28,13 +28,13 @@ data class TransactionRecord(
 
     override fun equals(other: Any?): Boolean {
         if (other is TransactionRecord) {
-            return transactionHash == other.transactionHash && interTransactionIndex == other.interTransactionIndex
+            return uid == other.uid
         }
         return super.equals(other)
     }
 
     override fun hashCode(): Int {
-        return Objects.hash(transactionHash, interTransactionIndex)
+        return uid.hashCode()
     }
 }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/Pool.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/Pool.kt
@@ -68,10 +68,10 @@ class Pool(val state: State) {
         val unusedRecordsSize = state.unusedRecords.size
         if (unusedRecordsSize > limit) return null
 
-        val hashFrom = state.records.lastOrNull()?.let { Pair(it.transactionHash, it.interTransactionIndex) }
+        val recordFrom = state.records.lastOrNull()
         val fetchLimit = limit + 1 - unusedRecordsSize
 
-        return TransactionsModule.FetchData(state.wallet, hashFrom, fetchLimit)
+        return TransactionsModule.FetchData(state.wallet, recordFrom, fetchLimit)
     }
 
     fun add(transactionRecords: List<TransactionRecord>) {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionStatusWithTimeView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionStatusWithTimeView.kt
@@ -30,8 +30,12 @@ class TransactionStatusWithTimeView : ConstraintLayout {
         txTime.visibility = View.GONE
         completedIcon.visibility = View.GONE
         transactionProgressView.visibility = View.GONE
+        failedText.visibility = View.GONE
 
         when (transactionStatus) {
+            is TransactionStatus.Failed -> {
+                failedText.visibility = View.VISIBLE
+            }
             is TransactionStatus.Completed -> {
                 txTime.text = time
                 txTime.visibility = View.VISIBLE

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionsModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionsModule.kt
@@ -38,7 +38,7 @@ sealed class TransactionStatus {
 
 object TransactionsModule {
 
-    data class FetchData(val wallet: Wallet, val from: Pair<String, Int>?, val limit: Int)
+    data class FetchData(val wallet: Wallet, val from: TransactionRecord?, val limit: Int)
 
     interface IView {
         fun showFilters(filters: List<Wallet?>)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionsModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionsModule.kt
@@ -33,6 +33,7 @@ sealed class TransactionStatus {
     object Pending : TransactionStatus()
     class Processing(val progress: Double) : TransactionStatus() //progress in 0.0 .. 1.0
     object Completed : TransactionStatus()
+    object Failed : TransactionStatus()
 }
 
 object TransactionsModule {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionsModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionsModule.kt
@@ -5,9 +5,6 @@ import io.horizontalsystems.bankwallet.core.App
 import io.horizontalsystems.bankwallet.core.factories.TransactionViewItemFactory
 import io.horizontalsystems.bankwallet.entities.*
 import io.horizontalsystems.bankwallet.entities.Currency
-import io.horizontalsystems.bitcoincore.core.IPluginOutputData
-import io.horizontalsystems.hodler.HodlerOutputData
-import io.horizontalsystems.hodler.HodlerPlugin
 import java.math.BigDecimal
 import java.util.*
 
@@ -30,19 +27,7 @@ data class TransactionViewItem(
         val lockInfo: TransactionLockInfo?)
 
 
-data class TransactionLockInfo(val lockedUntil: Date, val originalAddress: String, val amount: BigDecimal?) {
-
-    companion object {
-        fun from(pluginData: Map<Byte, IPluginOutputData>?, valueToAmount: (Long?) -> BigDecimal?): TransactionLockInfo? {
-            val hodlerPluginData = pluginData?.get(HodlerPlugin.id) ?: return null
-            val hodlerOutputData = hodlerPluginData as? HodlerOutputData ?: return null
-            val lockedUntil = hodlerOutputData.approxUnlockTime ?: return null
-            val lockedValue = valueToAmount(hodlerOutputData.value)
-
-            return TransactionLockInfo(Date(lockedUntil * 1000), hodlerOutputData.addressString, lockedValue)
-        }
-    }
-}
+data class TransactionLockInfo(val lockedUntil: Date, val originalAddress: String, val amount: BigDecimal?)
 
 sealed class TransactionStatus {
     object Pending : TransactionStatus()

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/TransactionInfoStatusView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/TransactionInfoStatusView.kt
@@ -29,13 +29,12 @@ open class TransactionInfoStatusView : ConstraintLayout {
 
     fun bind(transactionStatus: TransactionStatus, incoming: Boolean) {
         progressBarWrapper.visibility = View.GONE
-        statusIcon.visibility = View.GONE
         confirmedText.visibility = View.GONE
         progressText.visibility = View.GONE
+        failedText.visibility = View.GONE
 
         when (transactionStatus) {
             is TransactionStatus.Completed -> {
-                statusIcon.visibility = View.VISIBLE
                 confirmedText.visibility = View.VISIBLE
             }
             is TransactionStatus.Processing -> {
@@ -49,9 +48,9 @@ open class TransactionInfoStatusView : ConstraintLayout {
     }
 
     private fun fillProgress(progress: Double = 0.0, incoming: Boolean) {
-        progressBar1.setImageResource(if(progress >= 0.33) getColoredBar(incoming) else R.drawable.status_progress_bar_grey)
-        progressBar2.setImageResource(if(progress >= 0.66) getColoredBar(incoming) else R.drawable.status_progress_bar_grey)
-        progressBar3.setImageResource(if(progress > 1.0) getColoredBar(incoming) else R.drawable.status_progress_bar_grey)
+        progressBar1.setImageResource(if (progress >= 0.33) getColoredBar(incoming) else R.drawable.status_progress_bar_grey)
+        progressBar2.setImageResource(if (progress >= 0.66) getColoredBar(incoming) else R.drawable.status_progress_bar_grey)
+        progressBar3.setImageResource(if (progress > 1.0) getColoredBar(incoming) else R.drawable.status_progress_bar_grey)
         progressBarWrapper.visibility = View.VISIBLE
 
         progressText.setText(if (incoming) R.string.Transactions_Receiving else R.string.Transactions_Sending)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/TransactionInfoStatusView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/TransactionInfoStatusView.kt
@@ -34,6 +34,9 @@ open class TransactionInfoStatusView : ConstraintLayout {
         failedText.visibility = View.GONE
 
         when (transactionStatus) {
+            is TransactionStatus.Failed -> {
+                failedText.visibility = View.VISIBLE
+            }
             is TransactionStatus.Completed -> {
                 confirmedText.visibility = View.VISIBLE
             }

--- a/app/src/main/res/drawable/ic_attention_12.xml
+++ b/app/src/main/res/drawable/ic_attention_12.xml
@@ -1,0 +1,8 @@
+<vector android:autoMirrored="true" android:height="12dp"
+    android:viewportHeight="12" android:viewportWidth="12"
+    android:width="12dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#00000000"
+        android:pathData="M6,6m-5.5,0a5.5,5.5 0,1 1,11 0a5.5,5.5 0,1 1,-11 0"
+        android:strokeColor="#808085" android:strokeWidth="1"/>
+    <path android:fillColor="#808085" android:pathData="M6,9.18C5.5361,9.18 5.16,8.8039 5.16,8.34C5.16,7.8761 5.5361,7.5 6,7.5C6.4639,7.5 6.84,7.8761 6.84,8.34C6.84,8.8039 6.4639,9.18 6,9.18ZM5.1736,3.6333C5.0932,3.0111 5.3687,2.7 6,2.7C6.6313,2.7 6.9068,3.0111 6.8264,3.6333L6.4651,6.4901C6.4354,6.7243 6.2361,6.9 6,6.9C5.7639,6.9 5.5646,6.7243 5.535,6.4901L5.1736,3.6333Z"/>
+</vector>

--- a/app/src/main/res/layout/view_transaction_info_status.xml
+++ b/app/src/main/res/layout/view_transaction_info_status.xml
@@ -1,35 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    xmlns:tools="http://schemas.android.com/tools">
-
-    <ImageView
-        android:id="@+id/statusIcon"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/ic_checkmark_green"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:visibility="visible"/>
+    android:layout_height="wrap_content">
 
     <TextView
         android:id="@+id/confirmedText"
         style="@style/Subhead2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="4dp"
-        android:layout_marginEnd="8dp"
+        android:drawableEnd="@drawable/ic_checkmark_green"
+        android:drawablePadding="8dp"
         android:text="@string/TransactionInfo_Status_Confirmed"
         android:textColor="?TextColorBarsToDark"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="@+id/statusIcon"
-        app:layout_constraintEnd_toStartOf="@+id/statusIcon"
-        app:layout_constraintTop_toTopOf="@+id/statusIcon"
-        tools:visibility="visible"/>
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/failedText"
+        style="@style/Subhead2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:drawableEnd="@drawable/ic_attention_red"
+        android:drawablePadding="8dp"
+        android:text="@string/Transactions_Failed"
+        android:textColor="?TextColorBarsToDark"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
         android:id="@+id/progressText"
@@ -41,7 +39,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/progressBarWrapper"
         app:layout_constraintTop_toTopOf="parent"
-        tools:visibility="visible"
         tools:text="@string/Transactions_Sending" />
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/view_transaction_status.xml
+++ b/app/src/main/res/layout/view_transaction_status.xml
@@ -6,6 +6,21 @@
     android:layout_height="19dp">
 
     <TextView
+        android:id="@+id/failedText"
+        style="@style/Subhead2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:drawableStart="@drawable/ic_attention_12"
+        android:drawablePadding="12dp"
+        android:drawableTint="?ColorLucian"
+        android:includeFontPadding="false"
+        android:text="@string/Transactions_Failed"
+        android:textColor="?ColorLucian"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
         android:id="@+id/txTime"
         style="@style/Subhead2"
         android:layout_width="wrap_content"
@@ -32,7 +47,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        />
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -171,6 +171,7 @@
     <string name="Transactions_EmptyList">You don\’t have any transactions yet</string>
     <string name="Transactions_Receiving">Receiving</string>
     <string name="Transactions_Sending">Sending</string>
+    <string name="Transactions_Failed">Failed</string>
 
     <!--Transaction Info-->
 


### PR DESCRIPTION
ref #1017 

- add field "failed"  to TransactionRecord
- add Failed item to TransactionStatus
- handle showing failed transactions in transactions tab and transaction info view
- add field "uid" which uniquely identifies TransactionRecord, change TransactionRecord equals and hashCode methods accordingly
- request transactions by passing from TransactionRecord instead of  pair<hash, interTransactionIndex>

