### PR TITLE
Minor fixes

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceFragment.kt
@@ -152,7 +152,7 @@ class BalanceFragment : Fragment(), BalanceCoinAdapter.Listener, BalanceSortDial
             activity?.let { activity ->
                 val title = getString(R.string.ManageKeys_Delete_Alert_Title)
                 val subtitle = getString(predefinedAccount.title)
-                val description = getString(R.string.ManageKeys_Delete_Alert)
+                val description = getString(R.string.ManageKeys_Delete_Alert, getString(predefinedAccount.title), coin.title)
                 ManageKeysDialog.show(title, subtitle, description, activity, object : ManageKeysDialog.Listener {
                     override fun onClickBackupKey() {
                         viewModel.delegate.onBackupClick()

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/main/MainSettingsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/main/MainSettingsFragment.kt
@@ -10,7 +10,7 @@ import android.view.ViewGroup
 import android.widget.CompoundButton
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
+import androidx.lifecycle.ViewModelProvider
 import io.horizontalsystems.bankwallet.BuildConfig
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.modules.main.MainActivity
@@ -34,7 +34,7 @@ class MainSettingsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val presenter = ViewModelProviders.of(this, MainSettingsModule.Factory()).get(MainSettingsPresenter::class.java)
+        val presenter = ViewModelProvider(this, MainSettingsModule.Factory()).get(MainSettingsPresenter::class.java)
         val presenterView = presenter.view as MainSettingsView
         val router = presenter.router as MainSettingsRouter
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionsPresenter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionsPresenter.kt
@@ -73,7 +73,7 @@ class TransactionsPresenter(
 
         val filters = when {
             wallets.size < 2 -> listOf()
-            else -> listOf(null).plus(wallets)
+            else -> listOf(null).plus(getOrderedList(wallets))
         }
 
         view?.showFilters(filters)
@@ -148,6 +148,12 @@ class TransactionsPresenter(
 
     override fun fetchRecords(fetchDataList: List<TransactionsModule.FetchData>) {
         interactor.fetchRecords(fetchDataList)
+    }
+
+    private fun getOrderedList(wallets: List<Wallet>): MutableList<Wallet> {
+        val walletList = wallets.toMutableList()
+        walletList.sortBy { it.coin.code }
+        return walletList
     }
 
 }

--- a/app/src/main/res/layout/view_cell.xml
+++ b/app/src/main/res/layout/view_cell.xml
@@ -117,6 +117,7 @@
         android:layout_height="match_parent"
         android:src="@drawable/ic_attention"
         android:tint="?ColorLucian"
+        android:layout_marginEnd="16dp"
         android:visibility="gone"
         app:layout_constraintEnd_toStartOf="@+id/arrowIcon" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -431,7 +431,7 @@
     <string name="ManageKeys_Delete_ConfirmationLose">If you didn\'t backup the private key for this wallet, you will lose access to your funds.</string>
     <string name="ManageKeys_Delete_FromPhone">Delete from Phone</string>
     <string name="ManageKeys_Delete_Alert_Title">Backup Required</string>
-    <string name="ManageKeys_Delete_Alert">You need to backup the private key before it can be deleted from this phone.</string>
+    <string name="ManageKeys_Delete_Alert">You need to backup the %s Wallet before you may receive %s.</string>
 
     <!-- Manage Keys Alert -->
 
@@ -482,7 +482,7 @@
     <string name="Charts_Rate_High">%s High</string>
     <string name="Charts_Rate_Low">%s Low</string>
     <string name="Charts_MarketCap">Mkt. Cap</string>
-    <string name="Charts_Volume24">Volume (24 hours)</string>
+    <string name="Charts_Volume24">Volume (24h)</string>
     <string name="Charts_inCirculation">in Circulation</string>
     <string name="Charts_TotalSupply">Total Supply</string>
     <string name="Charts_CryptoCompare" translatable="false">\@CryptoCompare.com</string>


### PR DESCRIPTION
- Fix text for Receive alert when coin not backed up yet
- Show filters in Transactions in Alphabetical order
- Fix alert icon right padding in Settings
- Rename Volume to Volume (24h) in Rate Chart Info
ref #1772, #1774, #1775 , #1766 