### PR TITLE
Round locked-date info for Locked transactions in tx-info tab

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -126,6 +126,9 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-common-java8:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
 
+    // Apache Commons lib
+    implementation "org.apache.commons:commons-lang3:3.9"
+
     // Room
     def room_version = '2.2.2'
     implementation "androidx.room:room-runtime:$room_version"

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/TransactionInfoView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/TransactionInfoView.kt
@@ -103,9 +103,12 @@ class TransactionInfoView : ConstraintLayoutWithHeader {
                 txInfoCoinName.text = txRec.wallet.coin.title
 
                 if (txRec.lockInfo != null) {
+                    val roundedDate = DateHelper.roundDateHour(txRec.lockInfo.lockedUntil, true)
+
                     itemLockTime.visibility = View.VISIBLE
-                    itemLockTime.bindInfo("${context.getString(R.string.TransactionInfo_LockedUntil)} ${DateHelper.getFullDate(txRec.lockInfo.lockedUntil)}", R.drawable.ic_lock)
+                    itemLockTime.bindInfo("${context.getString(R.string.TransactionInfo_LockedUntil)} ${DateHelper.getFullDate(roundedDate)}", R.drawable.ic_lock)
                     itemLockTime.setOnClickListener { viewModel.onClickLockInfo() }
+
                 } else {
                     itemLockTime.visibility = View.GONE
                 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/viewHelpers/DateHelper.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/viewHelpers/DateHelper.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.text.format.DateFormat
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.App
+import org.apache.commons.lang3.time.DateUtils
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -18,6 +19,17 @@ object DateHelper {
     fun getFullDate(date: Date): String = formatDate(date, "MMM d, yyyy, $timeFormat")
     fun getDateWithYear(date: Date): String = formatDate(date, "MMM d, yyyy")
     fun getFullDate(timestamp: Long): String = formatDate(Date(timestamp), "MMM d, yyyy, $timeFormat")
+
+    fun roundDateHour(date: Date, ceiling: Boolean): Date {
+        return roundDate(date, Calendar.HOUR, ceiling)
+    }
+
+    fun roundDate(date: Date, roundField: Int, ceiling: Boolean): Date {
+        if(ceiling)
+            return DateUtils.ceiling(date, roundField)
+        else
+            return DateUtils.round(date, roundField)
+    }
 
     fun getTxDurationString(context: Context, durationInSec: Long): String {
         return when {

--- a/app/src/test/java/io/horizontalsystems/bankwallet/modules/receive/ReceivePresenterTest.kt
+++ b/app/src/test/java/io/horizontalsystems/bankwallet/modules/receive/ReceivePresenterTest.kt
@@ -16,7 +16,7 @@ class ReceivePresenterTest {
 
     private var coin = Mockito.mock(Coin::class.java)
     private val coinAddress = "[coin_address]"
-    private val addressItem = AddressItem(address = coinAddress, coin = coin)
+    private val addressItem = AddressItem(address = coinAddress, addressType = null, coin = coin)
 
     private lateinit var presenter: ReceivePresenter
 

--- a/app/src/test/java/io/horizontalsystems/bankwallet/viewHelpers/DateHelperTest.kt
+++ b/app/src/test/java/io/horizontalsystems/bankwallet/viewHelpers/DateHelperTest.kt
@@ -1,0 +1,27 @@
+package io.horizontalsystems.bankwallet.viewHelpers
+
+import org.junit.Test
+
+import org.junit.Assert.*
+import java.text.SimpleDateFormat
+import java.util.*
+
+class DateHelperTest {
+
+    @Test
+    fun testRoundDate() {
+
+        val dateStr1 = "31/12/2020 23:01"
+        val dateStr2 = "01/01/2021 00:00"
+        val dateStr3 = "31/12/2020 23:00"
+
+        val formatter = SimpleDateFormat("dd/MM/yyyy HH:mm")
+
+        var dateRoundHour = formatter.parse(dateStr1)
+        val dateRoundedCeiling = formatter.parse(dateStr2)
+        val dateRounded = formatter.parse(dateStr3)
+
+        assertEquals(DateHelper.roundDate(dateRoundHour,Calendar.HOUR, true), dateRoundedCeiling)
+        assertEquals(DateHelper.roundDate(dateRoundHour,Calendar.HOUR, false), dateRounded)
+    }
+}


### PR DESCRIPTION
Ref #1799

- Round the hour part of locked-date info for Locked transactions in tx-info tab.