### PR TITLE
Minor fixes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -174,7 +174,7 @@ dependencies {
     hockeyAppImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.6.3'
 
     // Wallet kits
-    implementation 'com.github.horizontalsystems:bitcoin-kit-android:6dc70a3'
+    implementation 'com.github.horizontalsystems:bitcoin-kit-android:f940727'
     implementation 'com.github.horizontalsystems:ethereum-kit-android:c12eab7'
     implementation 'com.github.horizontalsystems:blockchain-fee-rate-kit-android:169917d'
     implementation 'com.github.horizontalsystems:hd-wallet-kit-android:68903dc'

--- a/app/src/main/res/layout/view_transaction_status.xml
+++ b/app/src/main/res/layout/view_transaction_status.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
-    android:layout_height="19dp">
+    android:layout_height="wrap_content">
 
     <TextView
         android:id="@+id/failedText"


### PR DESCRIPTION
- Set layout height for tx status to 'wrap_content'. When setting fixed 19dp height, text don't fit for some devices with low resolution
- Update bitcoin-kit

ref #1806 