### PR TITLE
Bug fixes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -178,7 +178,7 @@ dependencies {
     implementation 'com.github.horizontalsystems:hd-wallet-kit-android:68903dc'
     implementation 'com.github.horizontalsystems:binance-chain-kit-android:809e1a5'
     implementation 'com.github.horizontalsystems:xrates-kit-android:7d651b8'
-    implementation('com.github.horizontalsystems:eos-kit-android:5d2d6d2') {
+    implementation('com.github.horizontalsystems:eos-kit-android:70897ea') {
         exclude group: 'com.google.protobuf'
     }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceViewModel.kt
@@ -1,5 +1,7 @@
 package io.horizontalsystems.bankwallet.modules.balance
 
+import android.os.Handler
+import android.os.Looper
 import androidx.lifecycle.ViewModel
 import io.horizontalsystems.bankwallet.SingleLiveEvent
 import io.horizontalsystems.bankwallet.entities.Account
@@ -20,9 +22,11 @@ class BalanceViewModel : ViewModel(), BalanceModule.IView, BalanceModule.IRouter
 
     val isSortOn = SingleLiveEvent<Boolean>()
     val setHeaderViewItem = SingleLiveEvent<BalanceHeaderViewItem>()
-    val setViewItems = SingleLiveEvent<List<BalanceViewItem>>() // MuLiveData
+    val setViewItems = SingleLiveEvent<List<BalanceViewItem>>()
     val showBackupAlert = SingleLiveEvent<Pair<Coin, PredefinedAccountType>>()
     val didRefreshLiveEvent = SingleLiveEvent<Void>()
+
+    private val mainThreadHandler = Handler(Looper.getMainLooper())
 
     fun init() {
         BalanceModule.init(this, this)
@@ -67,7 +71,14 @@ class BalanceViewModel : ViewModel(), BalanceModule.IView, BalanceModule.IRouter
     }
 
     override fun set(viewItems: List<BalanceViewItem>) {
-        setViewItems.postValue(viewItems)
+        /**
+         * viewItems are updated very often and partially, using updateType payload for recyclerView adapter.
+         * Since LiveData doesn't handle backpressure and propagates only last item, sometimes view does not receive updates.
+         * As a temporary solution LiveData.setValue() is used instead of postValue(), also it is called in main thread using Handler.
+         */
+        mainThreadHandler.post {
+            setViewItems.value = viewItems
+        }
     }
 
     override fun showBackupRequired(coin: Coin, predefinedAccountType: PredefinedAccountType) {


### PR DESCRIPTION
- In balance module BalanceViewItems are updated very often and partially, using updateType payload for recyclerView adapter. Since LiveData doesn't handle backpressure and propagates only last item, sometimes view does not receive updates. As a temporary solution LiveData.setValue() is used instead of postValue(), also it is called in main thread using Handler.

- Update eos-kit, get bug fixes

ref #1818 