### PR TITLE
In coin manager don't highlight whole coin cell when clicking on switch

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/createwallet/view/CoinItemsAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/createwallet/view/CoinItemsAdapter.kt
@@ -85,6 +85,10 @@ class CoinItemWithSwitchViewHolder(
             toggleSwitch.isChecked = !toggleSwitch.isChecked
             onSwitch.invoke(toggleSwitch.isChecked, adapterPosition)
         }
+
+        toggleSwitch.setOnClickListener {
+            onSwitch.invoke(toggleSwitch.isChecked, adapterPosition)
+        }
     }
 
     fun bind(item: CoinManageViewItem) {

--- a/app/src/main/res/layout/view_holder_coin_manage_item.xml
+++ b/app/src/main/res/layout/view_holder_coin_manage_item.xml
@@ -76,7 +76,7 @@
         android:layout_marginEnd="8dp"
         android:theme="@style/SwitchTheme"
         android:visibility="gone"
-        android:clickable="false"
+        android:clickable="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
- make switch clickable and set click listener

ref #1837 