### PR TITLE
Upgrade btc-kit dependencies with BCH restore API url fixed.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -171,7 +171,7 @@ dependencies {
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.2'
 
     // Wallet kits
-    implementation 'com.github.horizontalsystems:bitcoin-kit-android:b25a602'
+    implementation 'com.github.horizontalsystems:bitcoin-kit-android:df9c318'
     implementation 'com.github.horizontalsystems:ethereum-kit-android:c12eab7'
     implementation 'com.github.horizontalsystems:blockchain-fee-rate-kit-android:344f900'
     implementation 'com.github.horizontalsystems:hd-wallet-kit-android:68903dc'

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -413,7 +413,7 @@
     <string name="CoinOption_Title">Restore Options</string>
     <string name="CoinOption_Fast" translatable="false">API</string>
     <string name="CoinOption_Fast_Subtitle">0–2 hours (Recommended)</string>
-    <string name="CoinOption_RestoreSourceDescription">API sources links: \nbtc.horizontalsystems.xyz/apg \ndash.horizontalsystems.xyz/apg \nbch.horizontalsystems.xyz/apg</string>
+    <string name="CoinOption_RestoreSourceDescription">API sources links: \nbtc.horizontalsystems.xyz/apg \ndash.horizontalsystems.xyz/apg \ncashexplorer.bitcoin.com/api/</string>
     <string name="CoinOption_Slow" translatable="false">Blockchain</string>
     <string name="CoinOption_Slow_Subtitle">1–24 hours</string>
     <string name="CoinOption_AddressFormatTitle">Bitcoin address format</string>


### PR DESCRIPTION
Ref #1899 
- Upgrade btc-kit dependencies with BCH restore API url fixed.