### PR TITLE
Upgrade btc-kit dependencies with dep. conflicts fix. (okHttp3).

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -171,7 +171,7 @@ dependencies {
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.2'
 
     // Wallet kits
-    implementation 'com.github.horizontalsystems:bitcoin-kit-android:df9c318'
+    implementation 'com.github.horizontalsystems:bitcoin-kit-android:c9e55cf'
     implementation 'com.github.horizontalsystems:ethereum-kit-android:c12eab7'
     implementation 'com.github.horizontalsystems:blockchain-fee-rate-kit-android:344f900'
     implementation 'com.github.horizontalsystems:hd-wallet-kit-android:68903dc'


### PR DESCRIPTION
- Upgrade btc-kit dependencies with dep. conflicts fix. (okHttp3 to 4.0.1).