### PR TITLE
Replace BitcoinCash Coin.space-API with Cashexplorer.bitcoin.com  in Full TxInfo

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/Interfaces.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/Interfaces.kt
@@ -121,7 +121,7 @@ interface IRandomProvider {
 }
 
 interface INetworkManager {
-    fun getTransaction(host: String, path: String): Flowable<JsonObject>
+    fun getTransaction(host: String, path: String, isSafeCall: Boolean): Flowable<JsonObject>
     fun getTransactionWithPost(host: String, path: String, body: Map<String, Any>): Flowable<JsonObject>
     fun ping(host: String, url: String): Flowable<Any>
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/NetworkManager.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/NetworkManager.kt
@@ -1,5 +1,6 @@
 package io.horizontalsystems.bankwallet.core.managers
 
+import android.annotation.SuppressLint
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonObject
 import io.horizontalsystems.bankwallet.core.INetworkManager
@@ -10,12 +11,19 @@ import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.*
+import java.security.SecureRandom
+import java.security.cert.CertificateException
+import java.security.cert.X509Certificate
 import java.util.concurrent.TimeUnit
+import javax.net.ssl.HostnameVerifier
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManager
+import javax.net.ssl.X509TrustManager
 
 class NetworkManager : INetworkManager {
 
-    override fun getTransaction(host: String, path: String): Flowable<JsonObject> {
-        return ServiceFullTransaction.service(host).getFullTransaction(path)
+    override fun getTransaction(host: String, path: String, isSafeCall: Boolean): Flowable<JsonObject> {
+        return ServiceFullTransaction.service(host, isSafeCall).getFullTransaction(path)
     }
 
     override fun getTransactionWithPost(host: String, path: String, body: Map<String, Any>): Flowable<JsonObject> {
@@ -30,8 +38,8 @@ class NetworkManager : INetworkManager {
 }
 
 object ServiceFullTransaction {
-    fun service(apiURL: String): FullTransactionAPI {
-        return APIClient.retrofit(apiURL)
+    fun service(apiURL: String, isSafeCall: Boolean = true): FullTransactionAPI {
+        return APIClient.retrofit(apiURL, 60, isSafeCall)
                 .create(FullTransactionAPI::class.java)
     }
 
@@ -59,7 +67,7 @@ object ServicePing {
 }
 
 object APIClient {
-    fun retrofit(apiURL: String, timeout: Long = 60): Retrofit {
+    fun retrofit(apiURL: String, timeout: Long = 60, isSafeCall: Boolean = true): Retrofit {
 
         val logger = HttpLoggingInterceptor().apply {
             level = HttpLoggingInterceptor.Level.BASIC
@@ -70,6 +78,10 @@ object APIClient {
         httpClient.connectTimeout(timeout, TimeUnit.SECONDS)
         httpClient.readTimeout(timeout, TimeUnit.SECONDS)
 
+        //TODO Replace this implementation with Manifest file settings when support for SDK 26 removed
+        if (!isSafeCall) // if host name cannot be verified, has no or self signed certificate, do unsafe request
+            setUnsafeSocketFactory(httpClient)
+
         val gsonBuilder = GsonBuilder().setLenient()
 
         return Retrofit.Builder()
@@ -78,5 +90,38 @@ object APIClient {
                 .addConverterFactory(GsonConverterFactory.create(gsonBuilder.create()))
                 .client(httpClient.build())
                 .build()
+    }
+
+    @SuppressLint("TrustAllX509TrustManager", "BadHostnameVerifier")
+    private fun setUnsafeSocketFactory(builder: OkHttpClient.Builder) {
+        try {
+            val trustAllCerts = arrayOf<TrustManager>(
+                    object : X509TrustManager {
+                        @Throws(CertificateException::class)
+                        override fun checkClientTrusted(chain: Array<X509Certificate>,
+                                                        authType: String) {
+                        }
+
+                        @Throws(CertificateException::class)
+                        override fun checkServerTrusted(chain: Array<X509Certificate>,
+                                                        authType: String) {
+                        }
+
+                        override fun getAcceptedIssuers(): Array<X509Certificate> {
+                            return arrayOf()
+                        }
+                    }
+            )
+            val sslContext = SSLContext.getInstance("SSL")
+            sslContext.init(null, trustAllCerts, SecureRandom())
+            val sslSocketFactory = sslContext.socketFactory
+            builder.sslSocketFactory(sslSocketFactory, (trustAllCerts[0] as X509TrustManager))
+            builder.hostnameVerifier(HostnameVerifier { hostname, session -> true })
+            builder.connectTimeout(5000, TimeUnit.MILLISECONDS)
+            builder.readTimeout(60000, TimeUnit.MILLISECONDS)
+
+        } catch (e: Exception) {
+            throw RuntimeException(e)
+        }
     }
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/TransactionDataProviderManager.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/TransactionDataProviderManager.kt
@@ -24,9 +24,9 @@ class TransactionDataProviderManager(appConfig: IAppConfigTestMode, private val 
     }
 
     private val bitcoinCashProviders = when {
-        appConfig.testMode -> listOf(CoinSpaceBitcoinCashProvider())
+        appConfig.testMode -> listOf(CashexplorerBitcoinCashProvider())
         else -> listOf(
-                CoinSpaceBitcoinCashProvider(),
+                CashexplorerBitcoinCashProvider(),
                 BlockChairBitcoinCashProvider(),
                 BtcComBitcoinCashProvider())
     }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/FullTransactionInfoModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/FullTransactionInfoModule.kt
@@ -71,9 +71,9 @@ object FullTransactionInfoModule {
         fun apiRequest(hash: String): Request
     }
 
-    sealed class Request(val url: String) {
-        class GetRequest(url: String) : Request(url)
-        class PostRequest(url: String, val body: Map<String, Any>) : Request(url)
+    sealed class Request(val url: String,val isSafeCall: Boolean) {
+        class GetRequest(url: String, isSafeCall: Boolean = true) : Request(url, isSafeCall)
+        class PostRequest(url: String, val body: Map<String, Any>) : Request(url, true)
     }
 
     interface FullProvider {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/FullTransactionInfoProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/FullTransactionInfoProvider.kt
@@ -24,7 +24,7 @@ class FullTransactionInfoProvider(private val networkManager: INetworkManager,
 
         val requestFlowable = when (request) {
             is FullTransactionInfoModule.Request.GetRequest -> {
-                networkManager.getTransaction(host, uri)
+                networkManager.getTransaction(host, uri, request.isSafeCall)
             }
             is FullTransactionInfoModule.Request.PostRequest -> {
                 networkManager.getTransactionWithPost(host, uri, request.body)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/providers/CashexplorerBitcoinCashProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/providers/CashexplorerBitcoinCashProvider.kt
@@ -5,18 +5,18 @@ import com.google.gson.JsonObject
 import io.horizontalsystems.bankwallet.modules.fulltransactioninfo.FullTransactionInfoModule
 import io.horizontalsystems.bankwallet.modules.fulltransactioninfo.FullTransactionInfoModule.Request.GetRequest
 
-class CoinSpaceBitcoinCashProvider : FullTransactionInfoModule.BitcoinForksProvider {
-    override val name = "Coin.space"
-    override val pingUrl = "https://bch.coin.space/api/sync"
+class CashexplorerBitcoinCashProvider : FullTransactionInfoModule.BitcoinForksProvider {
+    override val name = "Cashexplorer.bitcoin.com"
+    override val pingUrl = "https://cashexplorer.bitcoin.com/api/sync"
 
-    private val baseUrl = "https://bch.coin.space"
+    private val baseUrl = "https://cashexplorer.bitcoin.com"
 
     override fun url(hash: String): String {
         return "$baseUrl/tx/$hash"
     }
 
     override fun apiRequest(hash: String): FullTransactionInfoModule.Request {
-        return GetRequest("$baseUrl/api/tx/$hash")
+        return GetRequest("$baseUrl/api/tx/$hash", false)
     }
 
     override fun convert(json: JsonObject): BitcoinResponse {


### PR DESCRIPTION
Ref #1956 

- Replace BitcoinCash Coin.space-API with Cashexplorer.bitcoin.com in Full TxInfo
- Implement custom SSL-certificate trust utility to connect to hosts with Self signed and not verified certs.