### PR TITLE
Fix BitcoinCash api provider status. 

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/Interfaces.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/Interfaces.kt
@@ -123,7 +123,7 @@ interface IRandomProvider {
 interface INetworkManager {
     fun getTransaction(host: String, path: String, isSafeCall: Boolean): Flowable<JsonObject>
     fun getTransactionWithPost(host: String, path: String, body: Map<String, Any>): Flowable<JsonObject>
-    fun ping(host: String, url: String): Flowable<Any>
+    fun ping(host: String, url: String, isSafeCall: Boolean): Flowable<Any>
 }
 
 interface IClipboardManager {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/NetworkManager.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/NetworkManager.kt
@@ -31,8 +31,8 @@ class NetworkManager : INetworkManager {
                 .getFullTransactionWithPost(path, body.mapValues { it.value.toString() })
     }
 
-    override fun ping(host: String, url: String): Flowable<Any> {
-        return ServicePing.service(host).ping(url)
+    override fun ping(host: String, url: String, isSafeCall: Boolean): Flowable<Any> {
+        return ServicePing.service(host, isSafeCall).ping(url)
     }
 
 }
@@ -56,8 +56,8 @@ object ServiceFullTransaction {
 }
 
 object ServicePing {
-    fun service(apiURL: String): FullTransactionAPI {
-        return APIClient.retrofit(apiURL, timeout = 8).create(FullTransactionAPI::class.java)
+    fun service(apiURL: String, isSafeCall: Boolean = true): FullTransactionAPI {
+        return APIClient.retrofit(apiURL, timeout = 8, isSafeCall = isSafeCall).create(FullTransactionAPI::class.java)
     }
 
     interface FullTransactionAPI {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/FullTransactionInfoModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/FullTransactionInfoModule.kt
@@ -66,6 +66,7 @@ object FullTransactionInfoModule {
     interface Provider {
         val name: String
         val pingUrl: String
+        val isTrusted: Boolean
 
         fun url(hash: String): String?
         fun apiRequest(hash: String): Request

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/dataprovider/DataProviderSettingsInteractor.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/dataprovider/DataProviderSettingsInteractor.kt
@@ -15,11 +15,11 @@ class DataProviderSettingsInteractor(private val dataProviderManager: ITransacti
     val disposables = CompositeDisposable()
     var delegate: DataProviderSettingsModule.InteractorDelegate? = null
 
-    override fun pingProvider(name: String, url: String) {
+    override fun pingProvider(name: String, url: String, isTrusted: Boolean) {
         val uri = URL(url)
         val host = "${uri.protocol}://${uri.host}"
 
-        disposables.add(networkManager.ping(host, url)
+        disposables.add(networkManager.ping(host, url, isSafeCall = isTrusted)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/dataprovider/DataProviderSettingsModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/dataprovider/DataProviderSettingsModule.kt
@@ -21,7 +21,7 @@ object DataProviderSettingsModule {
     }
 
     interface Interactor {
-        fun pingProvider(name: String, url: String)
+        fun pingProvider(name: String, url: String, isTrusted: Boolean)
         fun providers(coin: Coin): List<FullTransactionInfoModule.Provider>
         fun baseProvider(coin: Coin): FullTransactionInfoModule.Provider
         fun setBaseProvider(name: String, coin: Coin)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/dataprovider/DataProviderSettingsPresenter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/dataprovider/DataProviderSettingsPresenter.kt
@@ -13,7 +13,7 @@ class DataProviderSettingsPresenter(val coin: Coin, val transactionHash: String,
         val allProviders = interactor.providers(coin)
 
         allProviders.forEach { provider ->
-            interactor.pingProvider(provider.name, provider.pingUrl)
+            interactor.pingProvider(provider.name, provider.pingUrl, provider.isTrusted)
         }
 
         items = allProviders.map {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/providers/BinanceChainProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/providers/BinanceChainProvider.kt
@@ -11,6 +11,7 @@ class BinanceChainProvider(val testMode: Boolean) : FullTransactionInfoModule.Bi
 
     override val name = "Binance.org"
     override val pingUrl = "$baseApiUrl/node-info"
+    override val isTrusted: Boolean = true
 
     override fun url(hash: String): String {
         return "https://${if (testMode) "testnet-explorer" else "explorer"}.binance.org/tx/$hash"

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/providers/BlockchairProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/providers/BlockchairProvider.kt
@@ -12,6 +12,7 @@ import java.util.*
 
 class BlockChairBitcoinProvider : FullTransactionInfoModule.BitcoinForksProvider {
     private val baseApiUrl = "https://api.blockchair.com/bitcoin"
+    override val isTrusted: Boolean = true
 
     override val name = "BlockChair.com"
     override val pingUrl = "$baseApiUrl/stats"
@@ -38,6 +39,7 @@ class BlockChairBitcoinCashProvider : FullTransactionInfoModule.BitcoinForksProv
 
     override val name = "BlockChair.com"
     override val pingUrl = "$baseApiUrl/stats"
+    override val isTrusted: Boolean = true
 
     override fun url(hash: String): String {
         return "https://blockchair.com/bitcoin-cash/transaction/$hash"
@@ -61,6 +63,7 @@ class BlockChairDashProvider : FullTransactionInfoModule.BitcoinForksProvider {
 
     override val name = "BlockChair.com"
     override val pingUrl = "$baseApiUrl/stats"
+    override val isTrusted: Boolean = true
 
     override fun url(hash: String): String {
         return "https://blockchair.com/dash/transaction/$hash"
@@ -84,6 +87,7 @@ class BlockChairEthereumProvider : FullTransactionInfoModule.EthereumForksProvid
 
     override val name = "BlockChair.com"
     override val pingUrl = "$baseApiUrl/stats"
+    override val isTrusted: Boolean = true
 
     override fun url(hash: String): String {
         return "https://blockchair.com/ethereum/transaction/$hash"

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/providers/BtcComProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/providers/BtcComProvider.kt
@@ -12,6 +12,7 @@ class BtcComBitcoinProvider : FullTransactionInfoModule.BitcoinForksProvider {
 
     override val name = "Btc.com"
     override val pingUrl = "$baseApiUrl/block/0"
+    override val isTrusted: Boolean = true
 
     override fun url(hash: String): String {
         return "https://btc.com/$hash"
@@ -31,6 +32,7 @@ class BtcComBitcoinCashProvider : FullTransactionInfoModule.BitcoinForksProvider
 
     override val name = "Btc.com"
     override val pingUrl = "$baseApiUrl/block/0"
+    override val isTrusted: Boolean = true
 
     override fun url(hash: String): String {
         return "https://bch.btc.com/$hash"

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/providers/CashexplorerBitcoinCashProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/providers/CashexplorerBitcoinCashProvider.kt
@@ -8,6 +8,7 @@ import io.horizontalsystems.bankwallet.modules.fulltransactioninfo.FullTransacti
 class CashexplorerBitcoinCashProvider : FullTransactionInfoModule.BitcoinForksProvider {
     override val name = "Cashexplorer.bitcoin.com"
     override val pingUrl = "https://cashexplorer.bitcoin.com/api/sync"
+    override val isTrusted: Boolean = false
 
     private val baseUrl = "https://cashexplorer.bitcoin.com"
 
@@ -16,7 +17,7 @@ class CashexplorerBitcoinCashProvider : FullTransactionInfoModule.BitcoinForksPr
     }
 
     override fun apiRequest(hash: String): FullTransactionInfoModule.Request {
-        return GetRequest("$baseUrl/api/tx/$hash", false)
+        return GetRequest("$baseUrl/api/tx/$hash", isTrusted)
     }
 
     override fun convert(json: JsonObject): BitcoinResponse {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/providers/EosGreymassProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/providers/EosGreymassProvider.kt
@@ -7,6 +7,7 @@ class EosGreymassProvider : FullTransactionInfoModule.EosProvider {
 
     override val name = "Greymass.com"
     override val pingUrl = "https://eos.greymass.com/"
+    override val isTrusted: Boolean = true
 
     override fun url(hash: String): String? {
         return null

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/providers/EtherscanProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/providers/EtherscanProvider.kt
@@ -16,6 +16,7 @@ class EtherscanEthereumProvider(val testMode: Boolean) : FullTransactionInfoModu
 
     override val name = "Etherscan.io"
     override val pingUrl = if (testMode) "https://api-ropsten.etherscan.io/api?module=stats&action=ethprice" else "https://api.etherscan.io/api?module=stats&action=ethprice"
+    override val isTrusted: Boolean = true
 
     override fun url(hash: String): String = "$url$hash"
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/providers/HorsysProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/providers/HorsysProvider.kt
@@ -12,6 +12,7 @@ class HorsysBitcoinProvider(val testMode: Boolean) : FullTransactionInfoModule.B
 
     override val name = "HorizontalSystems.xyz"
     override val pingUrl = "$baseUrl/apg/block/0"
+    override val isTrusted: Boolean = true
 
     override fun url(hash: String): String? {
         return null
@@ -32,6 +33,7 @@ class HorsysDashProvider(val testMode: Boolean) : FullTransactionInfoModule.Bitc
 
     override val name: String = "HorizontalSystems.xyz"
     override val pingUrl = "$baseUrl/apg/block/0"
+    override val isTrusted: Boolean = true
 
     override fun url(hash: String): String {
         return "$baseUrl/insight/tx/$hash"

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/providers/InsightDashProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/fulltransactioninfo/providers/InsightDashProvider.kt
@@ -10,6 +10,7 @@ class InsightDashProvider : FullTransactionInfoModule.BitcoinForksProvider {
 
     override val name = "Insight.dash.org"
     override val pingUrl = "$baseApiUrl/block/0"
+    override val isTrusted: Boolean = true
 
     override fun url(hash: String): String {
         return "https://insight.dash.org/insight/tx/$hash"


### PR DESCRIPTION
Ref #1956 
- Fix BitcoinCash api provider status. 
- Apply SSL trust utility for cashexplorer.bitcoin.com provider.