### PR TITLE
Add Non-SSL btc-testnet.horizontalsystems.xyz url to cleartext-permit list

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -2,5 +2,6 @@
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">134.209.138.9</domain>
+        <domain includeSubdomains="true">btc-testnet.horizontalsystems.xyz</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
Ref #1961 

- Add Non-SSL btc-testnet.horizontalsystems.xyz url to cleartext-permit list. (Allow non-https url traffic)