### PR TITLE
Upgrade xrates-kit dependencies with rates value parsing fix.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -177,7 +177,7 @@ dependencies {
     implementation 'com.github.horizontalsystems:blockchain-fee-rate-kit-android:4159cc1'
     implementation 'com.github.horizontalsystems:hd-wallet-kit-android:68903dc'
     implementation 'com.github.horizontalsystems:binance-chain-kit-android:3327874'
-    implementation 'com.github.horizontalsystems:xrates-kit-android:531eb6b'
+    implementation 'com.github.horizontalsystems:xrates-kit-android:37f988f'
     implementation('com.github.horizontalsystems:eos-kit-android:70897ea') {
         exclude group: 'com.google.protobuf'
     }


### PR DESCRIPTION
- Upgrade xrates-kit dependencies (Return last CLOSE value  instead of average)
