### PR TITLE
Use shuffled ordering for bitcoin-kit transaction inputs and outputs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -172,7 +172,7 @@ dependencies {
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.2'
 
     // Wallet kits
-    implementation 'com.github.horizontalsystems:bitcoin-kit-android:a15532f'
+    implementation 'com.github.horizontalsystems:bitcoin-kit-android:05e7e3a'
     implementation 'com.github.horizontalsystems:ethereum-kit-android:d5fb068'
     implementation 'com.github.horizontalsystems:blockchain-fee-rate-kit-android:4159cc1'
     implementation 'com.github.horizontalsystems:hd-wallet-kit-android:68903dc'

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/BitcoinBaseAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/BitcoinBaseAdapter.kt
@@ -7,6 +7,7 @@ import io.horizontalsystems.bitcoincore.AbstractKit
 import io.horizontalsystems.bitcoincore.BitcoinCore
 import io.horizontalsystems.bitcoincore.core.Bip
 import io.horizontalsystems.bitcoincore.core.IPluginData
+import io.horizontalsystems.bitcoincore.models.TransactionDataSortType
 import io.horizontalsystems.bitcoincore.models.TransactionInfo
 import io.horizontalsystems.bitcoincore.models.TransactionStatus
 import io.horizontalsystems.hodler.HodlerOutputData
@@ -84,8 +85,7 @@ abstract class BitcoinBaseAdapter(open val kit: AbstractKit, open val settings: 
     fun send(amount: BigDecimal, address: String, feeRate: Long, pluginData: Map<Byte, IPluginData>?): Single<Unit> {
         return Single.create { emitter ->
             try {
-                kit.send(address, (amount * satoshisInBitcoin).toLong(), feeRate = feeRate.toInt(), pluginData = pluginData
-                        ?: mapOf())
+                kit.send(address, (amount * satoshisInBitcoin).toLong(),  true, feeRate.toInt(), TransactionDataSortType.Shuffle, pluginData ?: mapOf())
                 emitter.onSuccess(Unit)
             } catch (ex: Exception) {
                 emitter.onError(ex)


### PR DESCRIPTION
ref #1967 