### PR TITLE
Refactor method for refreshing adapters after blockchain settings change

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/Interfaces.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/Interfaces.kt
@@ -39,6 +39,7 @@ interface IAdapterManager {
     fun getTransactionsAdapterForWallet(wallet: Wallet): ITransactionsAdapter?
     fun getBalanceAdapterForWallet(wallet: Wallet): IBalanceAdapter?
     fun getReceiveAdapterForWallet(wallet: Wallet): IReceiveAdapter?
+    fun refreshAdapters(wallets: List<Wallet>)
 }
 
 interface ILocalStorage {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/addressformat/AddressFormatSettingsInteractor.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/addressformat/AddressFormatSettingsInteractor.kt
@@ -1,5 +1,6 @@
 package io.horizontalsystems.bankwallet.modules.addressformat
 
+import io.horizontalsystems.bankwallet.core.IAdapterManager
 import io.horizontalsystems.bankwallet.core.IAppConfigProvider
 import io.horizontalsystems.bankwallet.core.IDerivationSettingsManager
 import io.horizontalsystems.bankwallet.core.IWalletManager
@@ -12,7 +13,8 @@ import io.horizontalsystems.bankwallet.entities.Wallet
 class AddressFormatSettingsInteractor(
         private val derivationSettingsManager: IDerivationSettingsManager,
         private val appConfigProvider: IAppConfigProvider,
-        private val walletManager: IWalletManager
+        private val walletManager: IWalletManager,
+        private val adapterManager: IAdapterManager
 ) : AddressFormatSettingsModule.IInteractor {
 
     override fun derivation(coinType: CoinType): Derivation {
@@ -34,9 +36,6 @@ class AddressFormatSettingsInteractor(
     }
 
     override fun reSyncWallet(wallet: Wallet) {
-        walletManager.delete(listOf(wallet))
-
-        //start wallet with updated settings
-        walletManager.save(listOf(wallet))
+        adapterManager.refreshAdapters(listOf(wallet))
     }
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/addressformat/AddressFormatSettingsModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/addressformat/AddressFormatSettingsModule.kt
@@ -7,8 +7,11 @@ import androidx.lifecycle.ViewModelProvider
 import io.horizontalsystems.bankwallet.core.App
 import io.horizontalsystems.bankwallet.core.utils.ModuleCode
 import io.horizontalsystems.bankwallet.core.utils.ModuleField
-import io.horizontalsystems.bankwallet.entities.*
 import io.horizontalsystems.bankwallet.entities.AccountType.Derivation
+import io.horizontalsystems.bankwallet.entities.Coin
+import io.horizontalsystems.bankwallet.entities.CoinType
+import io.horizontalsystems.bankwallet.entities.DerivationSetting
+import io.horizontalsystems.bankwallet.entities.Wallet
 
 object AddressFormatSettingsModule {
 
@@ -54,7 +57,7 @@ object AddressFormatSettingsModule {
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             val view = AddressFormatSettingsView()
             val router = AddressFormatSettingsRouter()
-            val interactor = AddressFormatSettingsInteractor(App.derivationSettingsManager, App.appConfigProvider, App.walletManager)
+            val interactor = AddressFormatSettingsInteractor(App.derivationSettingsManager, App.appConfigProvider, App.walletManager, App.adapterManager)
             val presenter = AddressFormatSettingsPresenter(view, router, interactor, coinTypes, showDoneButton)
 
             return presenter as T

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/privacy/PrivacySettingsModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/privacy/PrivacySettingsModule.kt
@@ -57,8 +57,8 @@ object PrivacySettingsModule {
         fun litecoin(): Coin
         fun bitcoinCash(): Coin
         fun dash(): Coin
-        fun getWalletForUpdate(coinType: CoinType): Wallet?
-        fun reSyncWallet(wallet: Wallet)
+        fun getWalletsForUpdate(coinType: CoinType): List<Wallet>
+        fun reSyncWallets(wallets: List<Wallet>)
 
         fun clear()
     }
@@ -73,7 +73,7 @@ object PrivacySettingsModule {
     }
 
     fun init(view: PrivacySettingsViewModel, router: IPrivacySettingsRouter) {
-        val interactor = PrivacySettingsInteractor(App.pinComponent, App.netKitManager, App.blockchainSettingsManager, App.appConfigProvider, App.walletManager, App.localStorage)
+        val interactor = PrivacySettingsInteractor(App.pinComponent, App.netKitManager, App.blockchainSettingsManager, App.appConfigProvider, App.walletManager, App.localStorage, App.adapterManager)
         val presenter = PrivacySettingsPresenter(interactor, router)
         interactor.delegate = presenter
         view.delegate = presenter

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/privacy/PrivacySettingsPresenter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/privacy/PrivacySettingsPresenter.kt
@@ -128,7 +128,7 @@ class PrivacySettingsPresenter(
     }
 
     private fun onSelectCommunicationMode(coin: Coin, selectedValue: CommunicationMode, currentValue: CommunicationMode) {
-        if (currentValue != selectedValue && interactor.getWalletForUpdate(coin.type) != null) {
+        if (currentValue != selectedValue && interactor.getWalletsForUpdate(coin.type).count() > 0) {
             view?.showCommunicationModeChangeAlert(coin, selectedValue)
         } else {
             updateCommunicationMode(coin, selectedValue)
@@ -136,7 +136,7 @@ class PrivacySettingsPresenter(
     }
 
     private fun onSelectSyncMode(coin: Coin, selectedValue: SyncMode, currentValue: SyncMode) {
-        if (currentValue != selectedValue && interactor.getWalletForUpdate(coin.type) != null) {
+        if (currentValue != selectedValue && interactor.getWalletsForUpdate(coin.type).count() > 0) {
             view?.showRestoreModeChangeAlert(coin, selectedValue)
         } else {
             updateSyncMode(coin, selectedValue)
@@ -155,8 +155,8 @@ class PrivacySettingsPresenter(
     override fun proceedWithSyncModeChange(coin: Coin, syncMode: SyncMode) {
         updateSyncMode(coin, syncMode)
 
-        interactor.getWalletForUpdate(coin.type)?.let {
-            interactor.reSyncWallet(it)
+        interactor.getWalletsForUpdate(coin.type).let {
+            interactor.reSyncWallets(it)
         }
     }
 
@@ -172,8 +172,8 @@ class PrivacySettingsPresenter(
     override fun proceedWithCommunicationModeChange(coin: Coin, communicationMode: CommunicationMode) {
         updateCommunicationMode(coin, communicationMode)
 
-        interactor.getWalletForUpdate(coin.type)?.let {
-            interactor.reSyncWallet(it)
+        interactor.getWalletsForUpdate(coin.type).let {
+            interactor.reSyncWallets(it)
         }
     }
 


### PR DESCRIPTION
- add method refreshAdapters to AdapterManager, for partially refreshing adapters
- in PrivacySettingsInteractor include Erc20 wallets when updating settings for CoinType.Ethereum

ref #2058 