### PR TITLE
Optimize Keystore error validation

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/App.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/App.kt
@@ -43,7 +43,7 @@ class App : CoreApp() {
 
         lateinit var wordsManager: WordsManager
         lateinit var networkManager: INetworkManager
-        lateinit var keyStoreChangeListener: KeyStoreChangeListener
+        lateinit var backgroundStateChangeListener: BackgroundStateChangeListener
         lateinit var appConfigProvider: IAppConfigProvider
         lateinit var adapterManager: IAdapterManager
         lateinit var walletManager: IWalletManager
@@ -153,9 +153,7 @@ class App : CoreApp() {
         encryptionManager = EncryptionManager(keyProvider)
 
         systemInfoManager = SystemInfoManager()
-        keyStoreChangeListener = KeyStoreChangeListener(systemInfoManager, keyStoreManager).apply {
-            backgroundManager.registerListener(this)
-        }
+
         languageManager = LanguageManager()
         currencyManager = CurrencyManager(localStorage, appConfigProvider)
         numberFormatter = NumberFormatter(languageManager)
@@ -195,7 +193,9 @@ class App : CoreApp() {
                         RateChartActivity::class.java.name
                 ),
                 onFire = { activity, requestCode -> LockScreenModule.startForUnlock(activity, requestCode) }
-        ).apply {
+        )
+
+        backgroundStateChangeListener = BackgroundStateChangeListener(systemInfoManager, keyStoreManager, pinComponent).apply {
             backgroundManager.registerListener(this)
         }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/App.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/App.kt
@@ -191,8 +191,7 @@ class App : CoreApp() {
                         LauncherActivity::class.java.name,
                         TorConnectionActivity::class.java.name,
                         RateChartActivity::class.java.name
-                ),
-                onFire = { activity, requestCode -> LockScreenModule.startForUnlock(activity, requestCode) }
+                )
         )
 
         backgroundStateChangeListener = BackgroundStateChangeListener(systemInfoManager, keyStoreManager, pinComponent).apply {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/BackgroundStateChangeListener.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/BackgroundStateChangeListener.kt
@@ -2,6 +2,7 @@ package io.horizontalsystems.bankwallet.core.managers
 
 import android.app.Activity
 import io.horizontalsystems.bankwallet.modules.keystore.KeyStoreActivity
+import io.horizontalsystems.bankwallet.modules.lockscreen.LockScreenModule
 import io.horizontalsystems.core.BackgroundManager
 import io.horizontalsystems.core.IKeyStoreManager
 import io.horizontalsystems.core.IPinComponent
@@ -33,6 +34,10 @@ class BackgroundStateChangeListener(
         }
 
         pinComponent.willEnterForeground(activity)
+
+        if (pinComponent.shouldShowPin(activity)){
+            LockScreenModule.startForUnlock(activity, 1)
+        }
     }
 
     override fun didEnterBackground() {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/KeyStoreChangeListener.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/KeyStoreChangeListener.kt
@@ -5,21 +5,20 @@ import io.horizontalsystems.bankwallet.modules.keystore.KeyStoreActivity
 import io.horizontalsystems.core.BackgroundManager
 import io.horizontalsystems.core.IKeyStoreManager
 import io.horizontalsystems.core.ISystemInfoManager
+import io.horizontalsystems.core.security.KeyStoreValidationResult
 
 class KeyStoreChangeListener(private val systemInfoManager: ISystemInfoManager, private val keyStoreManager: IKeyStoreManager)
     : BackgroundManager.Listener {
 
     override fun willEnterForeground(activity: Activity) {
-        when {
-            systemInfoManager.isSystemLockOff -> {
-                KeyStoreActivity.startForNoSystemLock(activity)
-            }
-            keyStoreManager.isKeyInvalidated -> {
-                KeyStoreActivity.startForInvalidKey(activity)
-            }
-            keyStoreManager.isUserNotAuthenticated -> {
-                KeyStoreActivity.startForUserAuthentication(activity)
-            }
+        if (systemInfoManager.isSystemLockOff){
+            KeyStoreActivity.startForNoSystemLock(activity)
+        }
+
+        when(keyStoreManager.validateKeyStore()) {
+            KeyStoreValidationResult.UserNotAuthenticated -> KeyStoreActivity.startForUserAuthentication(activity)
+            KeyStoreValidationResult.KeyIsInvalid -> KeyStoreActivity.startForInvalidKey(activity)
+            KeyStoreValidationResult.KeyIsValid -> { /* Do nothing */}
         }
     }
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/launcher/LaunchInteractor.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/launcher/LaunchInteractor.kt
@@ -4,6 +4,7 @@ import io.horizontalsystems.bankwallet.core.IAccountManager
 import io.horizontalsystems.core.IKeyStoreManager
 import io.horizontalsystems.core.IPinComponent
 import io.horizontalsystems.core.ISystemInfoManager
+import io.horizontalsystems.core.security.KeyStoreValidationResult
 
 class LaunchInteractor(
         private val accountManager: IAccountManager,
@@ -23,10 +24,7 @@ class LaunchInteractor(
     override val isSystemLockOff: Boolean
         get() = systemInfoManager.isSystemLockOff
 
-    override val isKeyInvalidated: Boolean
-        get() = keyStoreManager.isKeyInvalidated
-
-    override val isUserNotAuthenticated: Boolean
-        get() = keyStoreManager.isUserNotAuthenticated
-
+    override fun validateKeyStore(): KeyStoreValidationResult {
+        return keyStoreManager.validateKeyStore()
+    }
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/launcher/LaunchModule.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/launcher/LaunchModule.kt
@@ -3,6 +3,7 @@ package io.horizontalsystems.bankwallet.modules.launcher
 import android.content.Context
 import android.content.Intent
 import io.horizontalsystems.bankwallet.core.App
+import io.horizontalsystems.core.security.KeyStoreValidationResult
 
 object LaunchModule {
 
@@ -18,8 +19,8 @@ object LaunchModule {
         val isPinNotSet: Boolean
         val isAccountsEmpty: Boolean
         val isSystemLockOff: Boolean
-        val isKeyInvalidated: Boolean
-        val isUserNotAuthenticated: Boolean
+
+        fun validateKeyStore(): KeyStoreValidationResult
     }
 
     interface IInteractorDelegate

--- a/components/keystore/src/main/java/io/horizontalsystems/keystore/BaseKeyStoreActivity.kt
+++ b/components/keystore/src/main/java/io/horizontalsystems/keystore/BaseKeyStoreActivity.kt
@@ -31,7 +31,9 @@ abstract class BaseKeyStoreActivity : AppCompatActivity() {
                             viewModel.delegate.onCloseInvalidKeyWarning()
                         }
 
-                        override fun onCancel() {}
+                        override fun onCancel() {
+                            finishAffinity()
+                        }
                     }).show(supportFragmentManager, "keys_invalidated_alert")
         })
 

--- a/components/keystore/src/main/java/io/horizontalsystems/keystore/KeyStoreInteractor.kt
+++ b/components/keystore/src/main/java/io/horizontalsystems/keystore/KeyStoreInteractor.kt
@@ -8,15 +8,6 @@ class KeyStoreInteractor(private val systemInfoManager: ISystemInfoManager, priv
 
     var delegate: KeyStoreModule.IInteractorDelegate? = null
 
-    override val isSystemLockOff: Boolean
-        get() = systemInfoManager.isSystemLockOff
-
-    override val isKeyInvalidated: Boolean
-        get() = keyStoreManager.isKeyInvalidated
-
-    override val isUserNotAuthenticated: Boolean
-        get() = keyStoreManager.isUserNotAuthenticated
-
     override fun resetApp() {
         keyStoreManager.resetApp()
     }

--- a/components/keystore/src/main/java/io/horizontalsystems/keystore/KeyStoreModule.kt
+++ b/components/keystore/src/main/java/io/horizontalsystems/keystore/KeyStoreModule.kt
@@ -22,10 +22,6 @@ object KeyStoreModule {
     }
 
     interface IInteractor {
-        val isSystemLockOff: Boolean
-        val isKeyInvalidated: Boolean
-        val isUserNotAuthenticated: Boolean
-
         fun resetApp()
         fun removeKey()
     }

--- a/components/pin/src/main/java/io/horizontalsystems/pin/PinComponent.kt
+++ b/components/pin/src/main/java/io/horizontalsystems/pin/PinComponent.kt
@@ -12,8 +12,7 @@ import io.reactivex.Flowable
 class PinComponent(
         private val pinStorage: IPinStorage,
         private val encryptionManager: IEncryptionManager,
-        private val excludedActivityNames: List<String>,
-        private val onFire: (activity: Activity, requestCode: Int) -> Unit
+        private val excludedActivityNames: List<String>
 ) : IPinComponent {
 
     private val pinManager: PinManager by lazy {
@@ -63,13 +62,13 @@ class PinComponent(
 
     override fun willEnterForeground(activity: Activity) {
         appLockManager.willEnterForeground()
-
-        if (isLocked && !excludedActivityNames.contains(activity::class.java.name)) {
-            onFire.invoke(activity, 1)
-        }
     }
 
     override fun didEnterBackground() {
         appLockManager.didEnterBackground()
+    }
+
+    override fun shouldShowPin(activity: Activity): Boolean {
+        return isLocked && !excludedActivityNames.contains(activity::class.java.name)
     }
 }

--- a/components/pin/src/main/java/io/horizontalsystems/pin/PinComponent.kt
+++ b/components/pin/src/main/java/io/horizontalsystems/pin/PinComponent.kt
@@ -1,7 +1,6 @@
 package io.horizontalsystems.pin
 
 import android.app.Activity
-import io.horizontalsystems.core.BackgroundManager
 import io.horizontalsystems.core.IEncryptionManager
 import io.horizontalsystems.core.IPinComponent
 import io.horizontalsystems.core.IPinStorage
@@ -15,7 +14,7 @@ class PinComponent(
         private val encryptionManager: IEncryptionManager,
         private val excludedActivityNames: List<String>,
         private val onFire: (activity: Activity, requestCode: Int) -> Unit
-) : BackgroundManager.Listener, IPinComponent {
+) : IPinComponent {
 
     private val pinManager: PinManager by lazy {
         PinManager(encryptionManager, pinStorage)
@@ -62,7 +61,6 @@ class PinComponent(
         appLockManager.updateLastExitDate()
     }
 
-    //BackgroundManager.Listener
     override fun willEnterForeground(activity: Activity) {
         appLockManager.willEnterForeground()
 

--- a/core/src/main/java/io/horizontalsystems/core/Interfaces.kt
+++ b/core/src/main/java/io/horizontalsystems/core/Interfaces.kt
@@ -3,6 +3,7 @@ package io.horizontalsystems.core
 import android.content.SharedPreferences
 import androidx.biometric.BiometricPrompt
 import io.horizontalsystems.core.entities.Currency
+import io.horizontalsystems.core.security.KeyStoreValidationResult
 import io.reactivex.Flowable
 import io.reactivex.Observable
 import java.util.*
@@ -91,9 +92,7 @@ interface IThemeStorage {
 }
 
 interface IKeyStoreManager {
-    val isKeyInvalidated: Boolean
-    val isUserNotAuthenticated: Boolean
-
+    fun validateKeyStore(): KeyStoreValidationResult
     fun removeKey()
     fun resetApp()
 }

--- a/core/src/main/java/io/horizontalsystems/core/Interfaces.kt
+++ b/core/src/main/java/io/horizontalsystems/core/Interfaces.kt
@@ -1,5 +1,6 @@
 package io.horizontalsystems.core
 
+import android.app.Activity
 import android.content.SharedPreferences
 import androidx.biometric.BiometricPrompt
 import io.horizontalsystems.core.entities.Currency
@@ -55,6 +56,8 @@ interface IPinComponent {
     val isLocked: Boolean
     val pinSetFlowable: Flowable<Unit>
 
+    fun willEnterForeground(activity: Activity)
+    fun didEnterBackground()
     fun updateLastExitDateBeforeRestart()
     fun store(pin: String)
     fun validate(pin: String): Boolean

--- a/core/src/main/java/io/horizontalsystems/core/Interfaces.kt
+++ b/core/src/main/java/io/horizontalsystems/core/Interfaces.kt
@@ -63,6 +63,7 @@ interface IPinComponent {
     fun validate(pin: String): Boolean
     fun clear()
     fun onUnlock()
+    fun shouldShowPin(activity: Activity): Boolean
 }
 
 interface ILanguageManager {


### PR DESCRIPTION
- Close app when user press Back key on Keystore Error Activity
- Make single call to KeyStore validation on app start/resume
- Serialize actions done on EnteringForeground
- Move LockScreen opening code from PinComponent.kt to app
ref #2500