### PR TITLE
Add latest Zcash SDK and simplify initialization

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -184,7 +184,7 @@ dependencies {
     }
 
     //Zcash SDK
-    def zcashVersion = "1.2.0-beta01"
+    def zcashVersion = "1.2.1-beta01"
     def zcashDependencyMainNet = "cash.z.ecc.android:zcash-android-sdk-mainnet:$zcashVersion"
     def zcashDependencyTestNet = "cash.z.ecc.android:zcash-android-sdk-testnet:$zcashVersion"
     releaseImplementation zcashDependencyMainNet

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/zcash/ZcashAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/zcash/ZcashAdapter.kt
@@ -6,7 +6,6 @@ import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.block.CompactBlockProcessor
 import cash.z.ecc.android.sdk.ext.*
 import cash.z.ecc.android.sdk.tool.DerivationTool
-import cash.z.ecc.android.sdk.tool.WalletBirthdayTool
 import cash.z.ecc.android.sdk.validate.AddressType
 import io.horizontalsystems.bankwallet.core.*
 import io.horizontalsystems.bankwallet.entities.*
@@ -28,7 +27,6 @@ class ZcashAdapter(
 
     private val confirmationsThreshold = 10
     private val feeInZatoshi = 10_000L //0.0001 ZEC
-    private val saplingActivationHeight = if (testMode) 280_000 else 419_200
     private val lightWalletDHost = if (testMode) "lightwalletd.testnet.electriccoin.co" else "lightwalletd.electriccoin.co"
     private val lightWalletDPort = 9067
 
@@ -45,23 +43,16 @@ class ZcashAdapter(
 
     init {
         val accountType = (wallet.account.type as? AccountType.Zcash)
-                ?: throw UnsupportedAccountException()
-
+            ?: throw UnsupportedAccountException()
         seed = Mnemonic().toSeed(accountType.words)
-
-        val birthday = when (wallet.account.origin) {
-            AccountOrigin.Created -> null
-            AccountOrigin.Restored -> accountType.birthdayHeight?.toInt() ?: saplingActivationHeight
+        val config = Initializer.Config { config ->
+            config.server(lightWalletDHost, lightWalletDPort)
+            config.birthdayHeight = accountType.birthdayHeight?.toInt()
+            config.alias = getValidAliasFromAccountId(wallet.account.id)
+            config.setSeed(seed)
         }
-        val nearestBirthday = WalletBirthdayTool.loadNearest(context, birthday)
 
-        val initializer = Initializer(context) { builder ->
-            builder.server(lightWalletDHost, lightWalletDPort)
-            builder.setSeed(seed)
-            builder.importedWalletBirthday(nearestBirthday.height)
-            builder.alias = getValidAliasFromAccountId(wallet.account.id)
-        }
-        synchronizer = Synchronizer(initializer)
+        synchronizer = Synchronizer(Initializer(context, config))
         transactionsProvider = ZcashTransactionsProvider(synchronizer)
 
         synchronizer.status.distinctUntilChanged().collectWith(GlobalScope, ::onStatus)


### PR DESCRIPTION
Adding the latest SDK uses a newer checkpoints (mainnet: 1047000, testnet: 1170000).

Technically, no changes are required beyond updating the version number. However, the intention of the SDK changes are to enable developers to use the Initializer with a Config object. This will help in the near future, when switching SDKs can be done programmatically rather than through build flavors.

So this PR suggests a way to simplify the Initializer setup a bit that deletes more code than it adds. 

The underlying changes in the SDK now allow for these improvements:

1. **Ignore Sapling details**
    Developers should not need to worry about the [sapling activation height](https://github.com/horizontalsystems/unstoppable-wallet-android/compare/master...gmale:task/update-sdk#diff-ff2ca67def8ca0191010d4ceb6406e0ec6fc4f42b5df38b3244a2a0a30f7cdfdL54). That can now be an internal implementation detail of the SDK.
2. **Simplified birthday config**
    Developers should not have to worry about [loading birthday objects](https://github.com/horizontalsystems/unstoppable-wallet-android/compare/master...gmale:task/update-sdk#diff-ff2ca67def8ca0191010d4ceb6406e0ec6fc4f42b5df38b3244a2a0a30f7cdfdL56). Instead, just set the birthdayHeight in the config and let the SDK take care of the rest. For new wallets, set the birthdayHeight to null.