### PR TITLE
Fix Zcash restore without birthday height

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -184,7 +184,7 @@ dependencies {
     }
 
     //Zcash SDK
-    def zcashVersion = "1.2.1-beta01"
+    def zcashVersion = "1.2.1-beta02"
     def zcashDependencyMainNet = "cash.z.ecc.android:zcash-android-sdk-mainnet:$zcashVersion"
     def zcashDependencyTestNet = "cash.z.ecc.android:zcash-android-sdk-testnet:$zcashVersion"
     releaseImplementation zcashDependencyMainNet

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/zcash/ZcashAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/zcash/ZcashAdapter.kt
@@ -44,10 +44,11 @@ class ZcashAdapter(
     init {
         val accountType = (wallet.account.type as? AccountType.Zcash)
             ?: throw UnsupportedAccountException()
+        val isRestored = wallet.account.origin == AccountOrigin.Restored
         seed = Mnemonic().toSeed(accountType.words)
         val config = Initializer.Config { config ->
             config.server(lightWalletDHost, lightWalletDPort)
-            config.birthdayHeight = accountType.birthdayHeight?.toInt()
+            config.setBirthdayHeight(accountType.birthdayHeight?.toInt(), isRestored)
             config.alias = getValidAliasFromAccountId(wallet.account.id)
             config.setSeed(seed)
         }


### PR DESCRIPTION
After more testing, I discovered a minor regression while restoring Zcash without specifying a birthday height. The wallet was syncing from the latest checkpoint rather than the oldest. So we iterated on the last round of SDK changes and added a way to restore that was simple yet fixed this problem without requiring the wallets to keep track of sapling details like the activation height.

---- 
#### Steps to reproduce the bug:
1. On a fresh install, restore a Zcash wallet
2. Do not provide a birthday height
3. Observe: the wallet syncs from the latest checkpoint (block 1047000), meaning it will skip most user's transactions
4. Expected: the wallet syncs from sapling activation height whenever no birthday is provided during restore
---- 

After applying this PR, the wallet behaves as expected for restoring with a birthday, restoring without a birthday and creating a new wallet. More details can be found in the [related SDK changes](https://github.com/zcash/zcash-android-wallet-sdk/pull/182).


Note:  when testing add the following line of code to `App.kt` in order to see detailed debug logs:
```kotlin
Twig.plant(TroubleshootingTwig())
``` 