### PR TITLE
Minor bug fixes in swap

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/SwapTradeService.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/SwapTradeService.kt
@@ -93,7 +93,6 @@ class SwapTradeService(
         if (coinTo == coinFrom) {
             coinTo = null
             amountTo = null
-            tradeType = TradeType.ExactIn
         }
         syncState()
     }
@@ -105,7 +104,6 @@ class SwapTradeService(
         if (coinFrom == coinTo) {
             coinFrom = null
             amountFrom = null
-            tradeType = TradeType.ExactOut
         }
         syncState()
     }
@@ -132,10 +130,10 @@ class SwapTradeService(
     }
 
     fun switchCoins() {
-        val swapCoin = coinFrom
-        coinFrom = coinTo
+        val swapCoin = coinTo
+        coinTo = coinFrom
 
-        enterCoinTo(swapCoin)
+        enterCoinFrom(swapCoin)
     }
     //endregion
 
@@ -144,7 +142,7 @@ class SwapTradeService(
         val coinTo = coinTo
         val amount = if (tradeType == TradeType.ExactIn) amountFrom else amountTo
 
-        if (coinFrom == null || coinTo == null || amount == null) {
+        if (coinFrom == null || coinTo == null || amount == null || amount.compareTo(BigDecimal.ZERO) == 0) {
             state = State.NotReady()
         } else {
             state = State.Loading

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/coincard/SwapCoinCardViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/coincard/SwapCoinCardViewModel.kt
@@ -180,7 +180,7 @@ class SwapCoinCardViewModel(
         prefixLiveData.postValue(if (switchService.amountType == AmountType.Currency) fiatService.currency.symbol else null)
 
         if (fullAmountInfo == null) {
-            if (!force) {
+            if (!force && coinCardService.isEstimated) {
                 amountLiveData.postValue(null)
             }
             secondaryInfoLiveData.postValue(secondaryInfoPlaceHolder())

--- a/app/src/main/res/layout/view_card_swap.xml
+++ b/app/src/main/res/layout/view_card_swap.xml
@@ -125,7 +125,7 @@
 
     <TextView
         android:id="@+id/secondaryAmount"
-        style="@style/Subhead1"
+        style="@style/Caption"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="12dp"

--- a/app/src/main/res/navigation/main_graph.xml
+++ b/app/src/main/res/navigation/main_graph.xml
@@ -289,6 +289,10 @@
     <fragment
         android:id="@+id/swapTradeOptionsFragment"
         android:name="io.horizontalsystems.bankwallet.modules.swap.tradeoptions.SwapTradeOptionsFragment"
+        app:enterAnim="@anim/slide_from_bottom"
+        app:exitAnim="@android:anim/fade_out"
+        app:popEnterAnim="@android:anim/fade_in"
+        app:popExitAnim="@anim/slide_to_bottom"
         android:label="SwapTradeOptionsFragment" />
 
     <!--  Dialogs/BottomSheets  -->


### PR DESCRIPTION
- don't reset amount to null after switch for not estimated amount
- set correct style for secondary amount
- set opening animation for advanced settings page

ref #2817 