### PR TITLE
eleminate nested ConstraintLayout in custom views

### DIFF
--- a/app/src/main/res/layout/view_input_address.xml
+++ b/app/src/main/res/layout/view_input_address.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
 
     <TextView
         android:id="@+id/title"
@@ -121,4 +122,4 @@
         app:layout_constraintTop_toBottomOf="@+id/barrierBottom"
         tools:text="After the exchange operation, the amount will be transferred to the specified address" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</merge>

--- a/app/src/main/res/layout/view_input_with_buttons.xml
+++ b/app/src/main/res/layout/view_input_with_buttons.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
 
     <TextView
         android:id="@+id/title"
@@ -122,4 +123,4 @@
         app:layout_constraintTop_toBottomOf="@+id/barrierBottom"
         tools:text="Your Transaction will revert if the price change unfavorably by more than this percentage" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</merge>

--- a/components/chartview/src/main/res/layout/chart_indicator_view.xml
+++ b/components/chartview/src/main/res/layout/chart_indicator_view.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="44dp"
     android:background="@drawable/chart_indicator_background"
     android:foreground="?attr/selectableItemBackground"
-    android:gravity="center_vertical">
+    android:gravity="center_vertical"
+    tools:parentTag="android.widget.LinearLayout">
 
     <ImageView
         android:id="@+id/stateIcon"
@@ -36,4 +37,4 @@
         android:includeFontPadding="false"
         tools:text="Down Trend" />
 
-</LinearLayout>
+</merge>

--- a/components/chartview/src/main/res/layout/view_chart.xml
+++ b/components/chartview/src/main/res/layout/view_chart.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/coinChartView"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:paddingStart="16dp"
-    android:paddingEnd="16dp">
+    android:paddingEnd="16dp"
+    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
 
     <io.horizontalsystems.chartview.ChartView
         android:id="@+id/chartMain"
@@ -62,4 +64,4 @@
         android:gravity="center"
         android:textColor="@color/red_d" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</merge>

--- a/components/views/src/main/res/layout/view_key_input.xml
+++ b/components/views/src/main/res/layout/view_key_input.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     xmlns:tools="http://schemas.android.com/tools"
     android:background="@drawable/input_background_themed"
     android:paddingStart="12dp"
-    android:paddingEnd="8dp">
+    android:paddingEnd="8dp"
+    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
 
     <LinearLayout
         android:id="@+id/addressInputWrapper"
@@ -49,4 +50,4 @@
 
     </LinearLayout>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</merge>

--- a/components/views/src/main/res/layout/view_manage_account_view.xml
+++ b/components/views/src/main/res/layout/view_manage_account_view.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="44dp">
+    android:layout_height="44dp"
+    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
 
     <View
         android:layout_width="match_parent"
@@ -45,4 +46,4 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</merge>

--- a/components/views/src/main/res/layout/view_multiple_input_edit_text.xml
+++ b/components/views/src/main/res/layout/view_multiple_input_edit_text.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -7,7 +7,9 @@
     android:background="@drawable/input_background_themed"
     android:minHeight="44dp"
     android:paddingStart="12dp"
-    android:paddingEnd="8dp">
+    android:paddingEnd="8dp"
+    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
+
 
     <LinearLayout
         android:layout_width="0dp"
@@ -68,4 +70,4 @@
             android:visibility="gone" />
     </LinearLayout>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</merge>

--- a/components/views/src/main/res/layout/view_text_input.xml
+++ b/components/views/src/main/res/layout/view_text_input.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<merge
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -8,7 +8,7 @@
     android:background="@drawable/input_background_themed"
     android:paddingEnd="12dp"
     android:paddingStart="12dp"
-    >
+    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
 
     <TextView
         android:id="@+id/txtPrefix"
@@ -39,4 +39,4 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:text="Address" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</merge>


### PR DESCRIPTION
As far as I know, only ConstraintLayouts should not be nested because they are made to have a flat hierarchy, so I have optimized only the custom views which extend from ConstrantLayout.