### PR TITLE
Create new kit if new account

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/EthereumKitManager.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/EthereumKitManager.kt
@@ -3,6 +3,7 @@ package io.horizontalsystems.bankwallet.core.managers
 import io.horizontalsystems.bankwallet.core.App
 import io.horizontalsystems.bankwallet.core.IEthereumKitManager
 import io.horizontalsystems.bankwallet.core.UnsupportedAccountException
+import io.horizontalsystems.bankwallet.entities.Account
 import io.horizontalsystems.bankwallet.entities.AccountType
 import io.horizontalsystems.bankwallet.entities.CommunicationMode
 import io.horizontalsystems.bankwallet.entities.Wallet
@@ -25,6 +26,8 @@ class EthereumKitManager(
     private var kit: EthereumKit? = null
     private var useCount = 0
 
+    private var currentAccount: Account? = null
+
     override val ethereumKit: EthereumKit?
         get() = kit
 
@@ -45,8 +48,15 @@ class EthereumKitManager(
                 CommunicationMode.Incubed -> SyncSource.Incubed
                 else -> throw Exception("Invalid communication mode for Ethereum: ${communicationMode?.value}")
             }
-            kit = EthereumKit.getInstance(App.instance, accountType.words, syncMode, networkType, rpcApi, etherscanApiKey, account.id)
+
+            if(account != currentAccount) {
+                kit?.stop()
+                kit = EthereumKit.getInstance(App.instance, accountType.words, syncMode, networkType, rpcApi, etherscanApiKey, account.id)
+            }
+
             kit?.start()
+
+            currentAccount = account
 
             return kit!!
         }


### PR DESCRIPTION
@abdrasulov 

May I am missing something and I have some thoughts that I would like to share with you. From my understanding, the EthereumKitManager gets executed only once when the app initially starts. So it makes more sense to store the currentAccount in shared preference because every time the apps start the if(account != currentAccount) statement would be always true because the currentAccount would be null every time the apps starts from the beginning.
If the EthereumKitManager gets executed on other use cases then the logic that I wrote makes sense.

Please check my code and tell me, I will do the same change on the other managers as well if this one is okay.