### PR TITLE
Fix the issue with SingleLiveEvent triggering twice

### DIFF
--- a/core/src/main/java/io/horizontalsystems/core/SingleLiveEvent.kt
+++ b/core/src/main/java/io/horizontalsystems/core/SingleLiveEvent.kt
@@ -22,11 +22,6 @@ class SingleLiveEvent<T> : MutableLiveData<T>() {
         })
     }
 
-    override fun postValue(value: T?) {
-        mPending.set(true)
-        super.postValue(value)
-    }
-
     fun call() {
         value = null
     }


### PR DESCRIPTION
The postValue method calls the setValue at the end. State was reset in both methods. Sometimes it might trigger the observer twice. Left resetting state only in setValue.

#3292 