### PR TITLE
Show the rate diff calculated from the chart points

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/coin/CoinFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/coin/CoinFragment.kt
@@ -206,13 +206,12 @@ class CoinFragment : BaseFragment(), Chart.Listener, TabLayout.OnTabSelectedList
             rootView.post {
                 chart.setData(item.chartData, item.chartType)
             }
+
+            coinRateDiff.setDiff(item.diffValue)
         })
 
         viewModel.latestRateLiveData.observe(viewLifecycleOwner) {
             coinRateLast.text = formatter.formatFiat(it.value, it.currency.symbol, 2, 4)
-        }
-        viewModel.latestRateDiffLiveData.observe(viewLifecycleOwner) {
-            coinRateDiff.setDiff(it)
         }
 
         viewModel.coinDetailsLiveData.observe(viewLifecycleOwner, Observer { item ->

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/coin/CoinService.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/coin/CoinService.kt
@@ -46,7 +46,7 @@ class CoinService(
 
     var coinMarketDetails: CoinMarketDetails? = null
 
-    var lastPoint: LastPoint? = xRateManager.latestRate(coinType, currency.code)?.let { LastPoint(it.rate, it.timestamp) }
+    var lastPoint: LastPoint? = xRateManager.latestRate(coinType, currency.code)?.let { LastPoint(it.rate, it.timestamp, it.rateDiff24h) }
         set(value) {
             field = value
             triggerChartUpdateIfEnoughData()
@@ -90,7 +90,7 @@ class CoinService(
                 }
         xRateManager.latestRateObservable(coinType, currency.code)
                 .subscribeIO({ marketInfo ->
-                    lastPoint = LastPoint(marketInfo.rate, marketInfo.timestamp)
+                    lastPoint = LastPoint(marketInfo.rate, marketInfo.timestamp, marketInfo.rateDiff24h)
                 }, {
                     //ignore
                 }).let {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/coin/CoinViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/coin/CoinViewModel.kt
@@ -45,7 +45,6 @@ class CoinViewModel(
     val extraPages = MutableLiveData<List<CoinExtraPage>>()
     val uncheckIndicators = MutableLiveData<List<ChartIndicator>>()
     val latestRateLiveData = MutableLiveData<CurrencyValue>()
-    val latestRateDiffLiveData = MutableLiveData<BigDecimal>()
 
     var notificationIconVisible = service.notificationsAreEnabled && service.notificationSupported
     var notificationIconActive = false
@@ -114,7 +113,6 @@ class CoinViewModel(
 
     private fun updateLatestRate(latestRate: LatestRate) {
         latestRateLiveData.postValue(CurrencyValue(service.currency, latestRate.rate))
-        latestRateDiffLiveData.postValue(latestRate.rateDiff24h)
     }
 
     fun onSelect(type: ChartType) {


### PR DESCRIPTION
To get equal diffs for the 24h type of chart and latest rate, added the following logic:

 - When the type chart is 24h we add the point to the begging of the chart. The value of this point calculated based on the value and priceDiff24h of the last point. And the timestamp is `last point timestamp - 24h`

#3458 