### PR TITLE
Do not recreate the BalanceFragment when opening it from backstack

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceFragment.kt
@@ -13,7 +13,7 @@ import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
-import androidx.navigation.navGraphViewModels
+import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
@@ -43,7 +43,7 @@ import kotlinx.android.synthetic.main.fragment_balance.*
 
 class BalanceFragment : BaseFragment(), BalanceItemsAdapter.Listener, BackupRequiredDialog.Listener {
 
-    private val viewModel by navGraphViewModels<BalanceViewModel>(R.id.mainFragment) { BalanceModule.Factory() }
+    private val viewModel by viewModels<BalanceViewModel> { BalanceModule.Factory() }
     private val balanceItemsAdapter = BalanceItemsAdapter(this)
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/main/MainViewPagerAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/main/MainViewPagerAdapter.kt
@@ -12,9 +12,9 @@ import io.horizontalsystems.bankwallet.modules.transactions.TransactionsFragment
 
 class MainViewPagerAdapter(fragment: Fragment) : FragmentStateAdapter(fragment) {
 
-    private val itemIds = mutableListOf(0, getBalancePageId(BalanceViewType.NoAccounts), 2, 3)
+    private val itemIds = mutableListOf(0, getBalancePageId(BalanceViewType.Balance), 2, 3)
 
-    var balancePageType: BalanceViewType = BalanceViewType.NoAccounts
+    var balancePageType: BalanceViewType = BalanceViewType.Balance
         set(value) {
             if (field == value) return
             field = value


### PR DESCRIPTION
Set the default balance page type to Balance instead of NoAccounts. When turning back to MainFragment it creates a new instance of MainViewPagerAdapter. So initializing the adapter with the BalanceFragment uses the prev instance of BalanceFragment.

#3864