### PR TITLE
Zcash/update sdk 1.3.0 beta16

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -193,13 +193,7 @@ dependencies {
 
 
     //Zcash SDK
-    def zcashVersion = "1.2.1-beta04"
-    def zcashDependencyMainNet = "cash.z.ecc.android:zcash-android-sdk-mainnet:$zcashVersion"
-    def zcashDependencyTestNet = "cash.z.ecc.android:zcash-android-sdk-testnet:$zcashVersion"
-    releaseImplementation zcashDependencyMainNet
-    appcenterImplementation zcashDependencyMainNet
-    apptestnetImplementation zcashDependencyTestNet
-    debugImplementation zcashDependencyMainNet
+    implementation "cash.z.ecc.android:zcash-android-sdk:1.3.0-beta16"
 
     // WalletConnect
     implementation 'com.github.horizontalsystems:wallet-connect-kotlin:918c099'

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/App.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/App.kt
@@ -177,7 +177,7 @@ class App : CoreApp() {
 
         connectivityManager = ConnectivityManager(backgroundManager)
 
-        val zcashBirthdayProvider = ZcashBirthdayProvider(this)
+        val zcashBirthdayProvider = ZcashBirthdayProvider(this, buildConfigProvider.testMode)
         restoreSettingsManager = RestoreSettingsManager(restoreSettingsStorage, zcashBirthdayProvider)
 
         val adapterFactory = AdapterFactory(instance, buildConfigProvider.testMode, ethereumKitManager, binanceSmartChainKitManager, binanceKitManager, backgroundManager, restoreSettingsManager)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/Exceptions.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/Exceptions.kt
@@ -5,6 +5,7 @@ import io.horizontalsystems.bankwallet.core.providers.Translator
 import io.horizontalsystems.ethereumkit.api.jsonrpc.JsonRpc
 import io.horizontalsystems.ethereumkit.core.AddressValidator
 import retrofit2.adapter.rxjava2.HttpException
+import java.lang.RuntimeException
 
 class UnsupportedAccountException : Exception()
 class WrongAccountTypeForThisProvider : Exception()
@@ -14,6 +15,9 @@ class EthereumKitNotCreated() : Exception()
 class NoFeeSendTransactionError() : Exception()
 class InvalidBep2Address : Exception()
 class InvalidContractAddress : Exception()
+class FailedTransaction(errorMessage: String?): RuntimeException(errorMessage) {
+    override fun toString() = message ?: "Transaction failed."
+}
 
 sealed class EvmError(message: String? = null) : Throwable(message) {
     object InsufficientBalanceWithFee : EvmError()

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/zcash/ZcashAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/zcash/ZcashAdapter.kt
@@ -31,7 +31,7 @@ class ZcashAdapter(
     private val confirmationsThreshold = 10
     private val network: ZcashNetwork = if (testMode) ZcashNetwork.Testnet else ZcashNetwork.Mainnet
     private val feeChangeHeight: Long = if (testMode) 1_028_500 else 1_077_550
-    private val lightWalletDHost = if (testMode) "lightwalletd.testnet.electriccoin.co" else "zcash.horizontalsystems.xyz"
+    private val lightWalletDHost = if (testMode) network.defaultHost else "zcash.horizontalsystems.xyz"
     private val lightWalletDPort = 9067
 
     private val synchronizer: Synchronizer

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/zcash/ZcashAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/zcash/ZcashAdapter.kt
@@ -23,6 +23,7 @@ import io.reactivex.subjects.PublishSubject
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.runBlocking
 import java.math.BigDecimal
+import java.util.Date
 
 class ZcashAdapter(
         context: Context,
@@ -47,6 +48,7 @@ class ZcashAdapter(
 
     private var scanProgress: Int = 0
     private var downloadProgress: Int = 0
+    private val today: Date = Date()
 
     init {
         val accountType = (wallet.account.type as? AccountType.Mnemonic) ?: throw UnsupportedAccountException()
@@ -279,7 +281,10 @@ class ZcashAdapter(
         val totalProgress = (downloadProgress + scanProgress) / 2
 
         if (totalProgress < 100) {
-            syncState = AdapterState.Syncing(totalProgress, null)
+            // Workaround: progress doesn't show unless date exists
+            // for Zcash, it's probably better to show progress percentage with a placeholder date
+            // rather than no percentage, because scanning can take a long time
+            syncState = AdapterState.Syncing(totalProgress, today)
         }
     }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/AccountCleaner.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/AccountCleaner.kt
@@ -17,7 +17,7 @@ class AccountCleaner(private val testMode: Boolean) : IAccountCleaner {
         DashAdapter.clear(accountId, testMode)
         EvmAdapter.clear(accountId, testMode)
         Eip20Adapter.clear(accountId, testMode)
-        ZcashAdapter.clear(accountId)
+        ZcashAdapter.clear(accountId, testMode)
     }
 
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/ZcashBirthdayProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/ZcashBirthdayProvider.kt
@@ -2,18 +2,21 @@ package io.horizontalsystems.bankwallet.core.managers
 
 import android.content.Context
 import cash.z.ecc.android.sdk.tool.WalletBirthdayTool
+import cash.z.ecc.android.sdk.type.ZcashNetwork
 
 class ZcashBirthdayProvider(
-        private val context: Context
+        private val context: Context,
+        testMode: Boolean
 ) {
+    private val network = if (testMode) ZcashNetwork.Testnet else ZcashNetwork.Mainnet
     fun getNearestBirthdayHeight(birthdayHeight: Long? = null): Long {
-        val walletBirthday = WalletBirthdayTool.loadNearest(context, birthdayHeight?.toInt())
+        val walletBirthday = WalletBirthdayTool.loadNearest(context, network, birthdayHeight?.toInt())
         return walletBirthday.height.toLong()
     }
 
     @Throws
     fun validateBirthdayHeight(birthdayHeight: Long) {
-        WalletBirthdayTool.loadNearest(context, birthdayHeight.toInt())
+        WalletBirthdayTool.loadNearest(context, network, birthdayHeight.toInt())
     }
 
 }

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -73,7 +73,7 @@
     <string name="Restore_PassphraseDescription">Enter your passphrase that you used when creating this mnemonic phrase.</string>
     <string name="Select_Coins">کیف پول جدید</string>
     <string name="Restore_ZCash_BirthdayHeight">قد تولد</string>
-    <string name="Restore_ZCash_BirthdayHeight_Hint">If you know a birthday height for your Zcash wallet add it below to speedup syncing process.</string>
+    <string name="Restore_ZCash_BirthdayHeight_Hint">If you know a birthday height for your Zcash wallet, add it below to speed up the syncing process.</string>
     <!--Backup-->
     <string name="Backup_Intro_Title">پيشتيباني</string>
     <string name="Backup_Intro_TitleShow">نمایش کلید</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,7 +87,7 @@
     <string name="Select_Coins">Choose Crypto</string>
 
     <string name="Restore_ZCash_BirthdayHeight">Birthday Height</string>
-    <string name="Restore_ZCash_BirthdayHeight_Hint">If you know a birthday height for your Zcash wallet add it below to speedup syncing process.</string>
+    <string name="Restore_ZCash_BirthdayHeight_Hint">If you know a birthday height for your Zcash wallet, add it below to speed up the syncing process.</string>
 
     <!--Backup-->
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,6 @@ allprojects {
         maven { url "https://jitpack.io" }
         jcenter() {
             content {
-                includeModule("cash.z.ecc.android", "zcash-android-sdk-mainnet")
-                includeModule("cash.z.ecc.android", "zcash-android-sdk-testnet")
                 includeModule("me.relex", "circleindicator")
                 includeModule("org.briarproject", "jtorctl")
                 includeModule("org.dashj", "dashj-bls")


### PR DESCRIPTION
Changes to update to the latest Android SDK. This adds quite a lot of [changes and fixes since version 1.2.1-beta04](https://github.com/zcash/zcash-android-wallet-sdk/blob/master/CHANGELOG.md#version-121-beta04-2021-01-05), including migrating to Maven Central from JCenter (this also adds t-addr support and autoshielding support, under the hood)

Tasks to complete before converting this from a DRAFT to a PR:

- [x] Add latest SDK
- [x] Update and fix all breaking changes listed in [migration guide](https://github.com/zcash/zcash-android-wallet-sdk/blob/master/MIGRATIONS.md#migrating-to-version-13-from-12)
- [x] Switch to new lightwalletd.com server for testnet connections
- [x] Remove the use of GlobalScope to prevent leaks and other errors
- [x] Update the Send workflow so that it waits for transactions to complete and also shows errors
- [x] Update the verification-metadata.xml
- [x] Test and verify on testnet both for successful and failed transactions
- [x] Test and verify on mainnet