### PR TITLE
Remove synthetic view as it's going to be deprecated. Use `findViewById()` instead.

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/addtoken/AddTokenFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/addtoken/AddTokenFragment.kt
@@ -7,7 +7,11 @@ import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.ProgressBar
+import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
@@ -15,12 +19,22 @@ import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.bankwallet.core.utils.ModuleField
 import io.horizontalsystems.bankwallet.modules.qrscanner.QRScannerActivity
+import io.horizontalsystems.bankwallet.ui.extensions.AddressInputView
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.helpers.HudHelper
 import io.horizontalsystems.snackbar.SnackbarDuration
-import kotlinx.android.synthetic.main.fragment_add_token.*
 
 class AddTokenFragment : BaseFragment() {
+
+    private lateinit var addressInputView: AddressInputView
+    private lateinit var btnAddToken: Button
+    private lateinit var progressLoading: ProgressBar
+    private lateinit var coinNameTitle: TextView
+    private lateinit var coinNameValue: TextView
+    private lateinit var symbolTitle: TextView
+    private lateinit var symbolValue: TextView
+    private lateinit var decimalTitle: TextView
+    private lateinit var decimalsValue: TextView
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return inflater.inflate(R.layout.fragment_add_token, container, false)
@@ -28,6 +42,17 @@ class AddTokenFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
+        btnAddToken = view.findViewById(R.id.btnAddToken)
+        addressInputView = view.findViewById(R.id.addressInputView)
+        progressLoading = view.findViewById(R.id.progressLoading)
+        coinNameTitle = view.findViewById(R.id.coinNameTitle)
+        coinNameValue = view.findViewById(R.id.coinNameValue)
+        symbolTitle = view.findViewById(R.id.symbolTitle)
+        symbolValue = view.findViewById(R.id.symbolValue)
+        decimalTitle = view.findViewById(R.id.decimalTitle)
+        decimalsValue = view.findViewById(R.id.decimalsValue)
+
         toolbar.setNavigationOnClickListener {
             findNavController().popBackStack()
         }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/backupconfirmkey/BackupConfirmKeyFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/backupconfirmkey/BackupConfirmKeyFragment.kt
@@ -6,17 +6,25 @@ import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
+import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
+import io.horizontalsystems.bankwallet.ui.extensions.InputView
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.helpers.HudHelper
 import io.horizontalsystems.core.helpers.KeyboardHelper
-import kotlinx.android.synthetic.main.fragment_backup_words_confirm.*
 
 class BackupConfirmKeyFragment : BaseFragment() {
     private val viewModel by viewModels<BackupConfirmKeyViewModel> { BackupConfirmKeyModule.Factory(arguments?.getParcelable(BackupConfirmKeyModule.ACCOUNT)!!) }
+
+    private lateinit var toolbar: Toolbar
+    private lateinit var passphrase: InputView
+    private lateinit var passphraseDescription: TextView
+    private lateinit var wordOne: InputView
+    private lateinit var wordTwo: InputView
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_backup_words_confirm, container, false)
@@ -24,6 +32,13 @@ class BackupConfirmKeyFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        toolbar = view.findViewById(R.id.toolbar)
+        passphrase = view.findViewById(R.id.passphrase)
+        passphraseDescription = view.findViewById(R.id.passphraseDescription)
+        wordOne = view.findViewById(R.id.wordOne)
+        wordTwo = view.findViewById(R.id.wordTwo)
+
         toolbar.setNavigationOnClickListener {
             findNavController().popBackStack()
         }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/backupkey/BackupKeyFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/backupkey/BackupKeyFragment.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import androidx.appcompat.widget.Toolbar
 import androidx.navigation.navGraphViewModels
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
@@ -11,10 +13,11 @@ import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.getNavigationResult
 import io.horizontalsystems.pin.PinInteractionType
 import io.horizontalsystems.pin.PinModule
-import kotlinx.android.synthetic.main.fragment_backup_key.*
 
 class BackupKeyFragment : BaseFragment() {
     private val viewModel by navGraphViewModels<BackupKeyViewModel>(R.id.backupKeyFragment) { BackupKeyModule.Factory(arguments?.getParcelable(BackupKeyModule.ACCOUNT)!!) }
+    private lateinit var toolbar: Toolbar
+    private lateinit var buttonShow: Button
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_backup_key, container, false)
@@ -22,6 +25,9 @@ class BackupKeyFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        toolbar = view.findViewById(R.id.toolbar)
+        buttonShow = view.findViewById(R.id.buttonShow)
 
         toolbar.setNavigationOnClickListener {
             findNavController().popBackStack()

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/backupkey/ShowBackupWordsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/backupkey/ShowBackupWordsFragment.kt
@@ -4,15 +4,20 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import androidx.appcompat.widget.Toolbar
 import androidx.navigation.navGraphViewModels
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.bankwallet.modules.backupconfirmkey.BackupConfirmKeyModule
+import io.horizontalsystems.bankwallet.ui.extensions.MnemonicPhraseView
 import io.horizontalsystems.core.findNavController
-import kotlinx.android.synthetic.main.fragment_show_backup_words.*
 
 class ShowBackupWordsFragment : BaseFragment() {
     private val viewModel by navGraphViewModels<BackupKeyViewModel>(R.id.backupKeyFragment)
+    private lateinit var toolbar: Toolbar
+    private lateinit var buttonBackup: Button
+    private lateinit var mnemonicPhraseView: MnemonicPhraseView
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         disallowScreenshot()
@@ -26,6 +31,10 @@ class ShowBackupWordsFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        toolbar = view.findViewById(R.id.toolbar)
+        buttonBackup = view.findViewById(R.id.buttonBackup)
+        mnemonicPhraseView = view.findViewById(R.id.mnemonicPhraseView)
 
         toolbar.setNavigationOnClickListener {
             findNavController().popBackStack()

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceCellAnimator.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceCellAnimator.kt
@@ -7,7 +7,6 @@ import androidx.core.animation.doOnEnd
 import androidx.core.animation.doOnStart
 import androidx.core.view.isVisible
 import io.horizontalsystems.core.measureHeight
-import kotlinx.android.synthetic.main.view_holder_balance_item.*
 
 object BalanceCellAnimator {
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceFragment.kt
@@ -9,12 +9,16 @@ import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.TextView
 import androidx.core.app.ShareCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
+import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.bankwallet.core.setOnSingleClickListener
@@ -35,12 +39,17 @@ import io.horizontalsystems.bankwallet.ui.helpers.TextHelper
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.helpers.HudHelper
 import io.horizontalsystems.views.helpers.LayoutHelper
-import kotlinx.android.synthetic.main.fragment_balance.*
 
 class BalanceFragment : BaseFragment(), BalanceItemsAdapter.Listener, ReceiveFragment.Listener, BackupRequiredDialog.Listener {
 
     private val viewModel by viewModels<BalanceViewModel> { BalanceModule.Factory() }
     private val balanceItemsAdapter = BalanceItemsAdapter(this)
+
+    private lateinit var recyclerCoins: RecyclerView
+    private lateinit var sortButton: Button
+    private lateinit var pullToRefresh: SwipeRefreshLayout
+    private lateinit var toolbarTitle: TextView
+    private lateinit var balanceText: TextView
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_balance, container, false)
@@ -48,6 +57,12 @@ class BalanceFragment : BaseFragment(), BalanceItemsAdapter.Listener, ReceiveFra
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        recyclerCoins = view.findViewById(R.id.recyclerCoins)
+        sortButton = view.findViewById(R.id.sortButton)
+        pullToRefresh = view.findViewById(R.id.pullToRefresh)
+        toolbarTitle = view.findViewById(R.id.toolbarTitle)
+        balanceText = view.findViewById(R.id.balanceText)
 
         recyclerCoins.adapter = balanceItemsAdapter
         recyclerCoins.layoutManager = NpaLinearLayoutManager(context)
@@ -70,7 +85,7 @@ class BalanceFragment : BaseFragment(), BalanceItemsAdapter.Listener, ReceiveFra
             HudHelper.vibrate(requireContext())
         }
 
-        addCoinButton.setOnClickListener {
+        view.findViewById<Button>(R.id.addCoinButton).setOnClickListener {
             viewModel.delegate.onAddCoinClick()
         }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceItemViewHolder.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceItemViewHolder.kt
@@ -2,18 +2,45 @@ package io.horizontalsystems.bankwallet.modules.balance
 
 import android.content.res.ColorStateList
 import android.view.View
+import android.widget.Button
+import android.widget.FrameLayout
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.setCoinImage
 import io.horizontalsystems.bankwallet.core.setOnSingleClickListener
+import io.horizontalsystems.bankwallet.ui.extensions.RotatingCircleProgressView
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.view_holder_balance_item.*
 
 class BalanceItemViewHolder(override val containerView: View, private val listener: BalanceItemsAdapter.Listener) : RecyclerView.ViewHolder(containerView), LayoutContainer {
 
     private var balanceViewItem: BalanceViewItem? = null
+    private var buttonSend: Button
+    private var buttonReceive: Button
+    private var buttonSwap: Button
+    private var iconNotSynced: ImageView
+    private var iconCoin: ImageView
+    private var coinName: TextView
+    private var coinLabel: TextView
+    private var balanceCoin: TextView
+    private var balanceFiat: TextView
+    var balanceCoinLocked: TextView
+    var balanceFiatLocked: TextView
+    private var exchangeRate: TextView
+    private var rateDiff: TextView
+    private var rateDiffIcon: ImageView
+    private var iconProgress: RotatingCircleProgressView
+    private var textSyncing: TextView
+    private var textSyncedUntil: TextView
+    var balanceWrapper: FrameLayout
+    var lockedBalanceWrapper: FrameLayout
+    var buttonsWrapper: ConstraintLayout
+    var border: FrameLayout
+    var rootWrapper: ConstraintLayout
 
     init {
         containerView.setOnClickListener {
@@ -22,35 +49,58 @@ class BalanceItemViewHolder(override val containerView: View, private val listen
             }
         }
 
-        rateDiffWrapper.setOnSingleClickListener {
+        containerView.findViewById<FrameLayout>(R.id.rateDiffWrapper).setOnSingleClickListener {
             balanceViewItem?.let {
                 listener.onChartClicked(it)
             }
         }
 
+        buttonSend = containerView.findViewById(R.id.buttonSend)
         buttonSend.setOnSingleClickListener {
             balanceViewItem?.let {
                 listener.onSendClicked(it)
             }
         }
 
+        buttonReceive = containerView.findViewById(R.id.buttonReceive)
         buttonReceive.setOnSingleClickListener {
             balanceViewItem?.let {
                 listener.onReceiveClicked(it)
             }
         }
 
+        buttonSwap = containerView.findViewById(R.id.buttonSwap)
         buttonSwap.setOnSingleClickListener {
             balanceViewItem?.let {
                 listener.onSwapClicked(it)
             }
         }
 
+        iconNotSynced = containerView.findViewById(R.id.iconNotSynced)
         iconNotSynced.setOnSingleClickListener {
             balanceViewItem?.let {
                 listener.onSyncErrorClicked(it)
             }
         }
+
+        iconCoin = containerView.findViewById(R.id.iconCoin)
+        coinName = containerView.findViewById(R.id.coinName)
+        coinLabel = containerView.findViewById(R.id.coinLabel)
+        balanceCoin = containerView.findViewById(R.id.balanceCoin)
+        balanceFiat = containerView.findViewById(R.id.balanceFiat)
+        balanceCoinLocked = containerView.findViewById(R.id.balanceCoinLocked)
+        balanceFiatLocked = containerView.findViewById(R.id.balanceFiatLocked)
+        exchangeRate = containerView.findViewById(R.id.exchangeRate)
+        rateDiff = containerView.findViewById(R.id.rateDiff)
+        rateDiffIcon = containerView.findViewById(R.id.rateDiffIcon)
+        iconProgress = containerView.findViewById(R.id.iconProgress)
+        textSyncing = containerView.findViewById(R.id.textSyncing)
+        textSyncedUntil = containerView.findViewById(R.id.textSyncedUntil)
+        balanceWrapper = containerView.findViewById(R.id.balanceWrapper)
+        lockedBalanceWrapper = containerView.findViewById(R.id.lockedBalanceWrapper)
+        buttonsWrapper = containerView.findViewById(R.id.buttonsWrapper)
+        border = containerView.findViewById(R.id.border)
+        rootWrapper = containerView.findViewById(R.id.rootWrapper)
 
         BalanceCellAnimator.measureHeights(this)
     }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceNoCoinsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceNoCoinsFragment.kt
@@ -4,13 +4,17 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.TextView
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.bankwallet.modules.manageaccounts.ManageAccountsModule
 import io.horizontalsystems.core.findNavController
-import kotlinx.android.synthetic.main.fragment_no_coins.*
 
 class BalanceNoCoinsFragment : BaseFragment() {
+
+    private lateinit var toolbarTitle: TextView
+    private lateinit var addCoinsButton: Button
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_no_coins, container, false)
@@ -18,6 +22,9 @@ class BalanceNoCoinsFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        toolbarTitle = view.findViewById(R.id.toolbarTitle)
+        addCoinsButton = view.findViewById(R.id.addCoinsButton)
 
         toolbarTitle.text = arguments?.getString(ACCOUNT_NAME) ?: getString(R.string.Balance_Title)
         toolbarTitle.setOnClickListener {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/views/SyncErrorDialog.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/views/SyncErrorDialog.kt
@@ -2,11 +2,11 @@ package io.horizontalsystems.bankwallet.modules.balance.views
 
 import android.os.Bundle
 import android.view.View
+import android.widget.Button
 import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentActivity
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.ui.extensions.BaseBottomSheetDialogFragment
-import kotlinx.android.synthetic.main.fragment_bottom_sync_error.*
 
 class SyncErrorDialog(
         private val listener: Listener,
@@ -19,9 +19,17 @@ class SyncErrorDialog(
         fun onClickReport()
     }
 
+    private lateinit var changeSourceBtn: Button
+    private lateinit var retryBtn: Button
+    private lateinit var reportBtn: Button
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setContentView(R.layout.fragment_bottom_sync_error)
+
+        changeSourceBtn = view.findViewById(R.id.changeSourceBtn)
+        retryBtn = view.findViewById(R.id.retryBtn)
+        reportBtn = view.findViewById(R.id.reportBtn)
 
         setTitle(activity?.getString(R.string.BalanceSyncError_Title))
         setSubtitle(coinName)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/basecurrency/BaseCurrencySettingsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/basecurrency/BaseCurrencySettingsFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.ConcatAdapter
@@ -17,12 +18,13 @@ import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.views.helpers.LayoutHelper
 import io.horizontalsystems.views.inflate
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.fragment_base_currency_settings.*
 import java.util.*
 
 class BaseCurrencySettingsFragment : BaseFragment(), RVAdapter.ViewHolder.Listener {
 
     private val viewModel by viewModels<BaseCurrencySettingsViewModel> { BaseCurrencySettingsModule.Factory() }
+    private lateinit var toolbar: Toolbar
+    private lateinit var recyclerView: RecyclerView
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_base_currency_settings, container, false)
@@ -30,6 +32,10 @@ class BaseCurrencySettingsFragment : BaseFragment(), RVAdapter.ViewHolder.Listen
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        toolbar = view.findViewById(R.id.toolbar)
+        recyclerView = view.findViewById(R.id.recyclerView)
+
         toolbar.setNavigationOnClickListener {
             findNavController().popBackStack()
         }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/coin/CoinFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/coin/CoinFragment.kt
@@ -15,7 +15,11 @@ import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.widget.*
 import androidx.activity.addCallback
+import androidx.appcompat.widget.Toolbar
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.constraintlayout.widget.Group
 import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
 import androidx.core.view.doOnPreDraw
@@ -33,6 +37,8 @@ import io.horizontalsystems.bankwallet.modules.metricchart.MetricChartType
 import io.horizontalsystems.bankwallet.modules.settings.notifications.bottommenu.BottomNotificationMenu
 import io.horizontalsystems.bankwallet.modules.settings.notifications.bottommenu.NotificationMenuMode
 import io.horizontalsystems.bankwallet.modules.transactions.transactionInfo.CoinInfoItemView
+import io.horizontalsystems.bankwallet.ui.extensions.LockableNestedScrollView
+import io.horizontalsystems.bankwallet.ui.extensions.RateDiffView
 import io.horizontalsystems.bankwallet.ui.extensions.createTextView
 import io.horizontalsystems.bankwallet.ui.helpers.AppLayoutHelper
 import io.horizontalsystems.chartview.Chart
@@ -53,8 +59,6 @@ import io.noties.markwon.AbstractMarkwonPlugin
 import io.noties.markwon.Markwon
 import io.noties.markwon.MarkwonSpansFactory
 import io.noties.markwon.core.spans.LastLineSpacingSpan
-import kotlinx.android.synthetic.main.coin_market_details.*
-import kotlinx.android.synthetic.main.fragment_coin.*
 import org.commonmark.node.Heading
 import org.commonmark.node.Paragraph
 import java.math.BigDecimal
@@ -92,12 +96,84 @@ class CoinFragment : BaseFragment(), Chart.Listener, TabLayout.OnTabSelectedList
             Pair(ChartType.MONTHLY24, R.string.CoinPage_TimeDuration_Year2)
     )
 
+    private lateinit var toolbar: Toolbar
+    private lateinit var coinName: TextView
+    private lateinit var coinIcon: ImageView
+    private lateinit var chart: Chart
+    private lateinit var aboutTextToggle: TextView
+    private lateinit var aboutText: TextView
+    private lateinit var scroller: LockableNestedScrollView
+    private lateinit var chartPointsInfo: ConstraintLayout
+    private lateinit var tabLayout: TabLayout
+    private lateinit var marketSpinner: ProgressBar
+    private lateinit var indicatorEMA: CheckBox
+    private lateinit var indicatorMACD: CheckBox
+    private lateinit var indicatorRSI: CheckBox
+    private lateinit var rootView: FrameLayout
+    private lateinit var coinRateDiff: RateDiffView
+    private lateinit var coinRateLast: TextView
+    private lateinit var marketDetails: ConstraintLayout
+    private lateinit var coinRating: ImageButton
+    private lateinit var aboutGroup: Group
+    private lateinit var aboutTitle: TextView
+    private lateinit var pointInfoVolume: TextView
+    private lateinit var pointInfoVolumeTitle: TextView
+    private lateinit var macdHistogram: TextView
+    private lateinit var macdSignal: TextView
+    private lateinit var macdValue: TextView
+    private lateinit var pointInfoDate: TextView
+    private lateinit var pointInfoPrice: TextView
+    private lateinit var coinPerformanceLayout: LinearLayout
+    private lateinit var extraPagesLayout: LinearLayout
+    private lateinit var marketDataLayout: LinearLayout
+    private lateinit var tvlLayout: LinearLayout
+    private lateinit var linksLayout: LinearLayout
+    private lateinit var categoriesText: TextView
+    private lateinit var categoriesGroup: Group
+    private lateinit var platformsLayout: LinearLayout
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return inflater.inflate(R.layout.fragment_coin, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        toolbar = view.findViewById(R.id.toolbar)
+        coinName = view.findViewById(R.id.coinName)
+        coinIcon = view.findViewById(R.id.coinIcon)
+        chart = view.findViewById(R.id.chart)
+        aboutTextToggle = view.findViewById(R.id.aboutTextToggle)
+        aboutText = view.findViewById(R.id.aboutText)
+        scroller = view.findViewById(R.id.scroller)
+        chartPointsInfo = view.findViewById(R.id.chartPointsInfo)
+        tabLayout = view.findViewById(R.id.tabLayout)
+        marketSpinner = view.findViewById(R.id.marketSpinner)
+        indicatorEMA = view.findViewById(R.id.indicatorEMA)
+        indicatorMACD = view.findViewById(R.id.indicatorMACD)
+        indicatorRSI = view.findViewById(R.id.indicatorRSI)
+        rootView = view.findViewById(R.id.rootView)
+        coinRateDiff = view.findViewById(R.id.coinRateDiff)
+        coinRateLast = view.findViewById(R.id.coinRateLast)
+        marketDetails = view.findViewById(R.id.marketDetails)
+        coinRating = view.findViewById(R.id.coinRating)
+        aboutGroup = view.findViewById(R.id.aboutGroup)
+        aboutTitle = view.findViewById(R.id.aboutTitle)
+        pointInfoVolume = view.findViewById(R.id.pointInfoVolume)
+        pointInfoVolumeTitle = view.findViewById(R.id.pointInfoVolumeTitle)
+        macdHistogram = view.findViewById(R.id.macdHistogram)
+        macdSignal = view.findViewById(R.id.macdSignal)
+        macdValue = view.findViewById(R.id.macdValue)
+        pointInfoDate = view.findViewById(R.id.pointInfoDate)
+        pointInfoPrice = view.findViewById(R.id.pointInfoPrice)
+        coinPerformanceLayout = view.findViewById(R.id.coinPerformanceLayout)
+        extraPagesLayout = view.findViewById(R.id.extraPagesLayout)
+        marketDataLayout = view.findViewById(R.id.marketDataLayout)
+        tvlLayout = view.findViewById(R.id.tvlLayout)
+        linksLayout = view.findViewById(R.id.linksLayout)
+        categoriesText = view.findViewById(R.id.categoriesText)
+        categoriesGroup = view.findViewById(R.id.categoriesGroup)
+        platformsLayout = view.findViewById(R.id.platformsLayout)
 
         toolbar.title = coinCode
         toolbar.setNavigationOnClickListener {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/coin/coininvestors/CoinInvestorCategoryAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/coin/coininvestors/CoinInvestorCategoryAdapter.kt
@@ -2,13 +2,12 @@ package io.horizontalsystems.bankwallet.modules.coin.coininvestors
 
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.modules.coin.InvestorItem
 import io.horizontalsystems.views.inflate
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.view_holder_coin_investors_section_header.*
-import kotlinx.android.synthetic.main.view_holder_coin_fund_item.*
 
 class CoinInvestorCategoryAdapter(private val items: List<InvestorItem>, private val listener: Listener) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
@@ -49,9 +48,9 @@ class CoinInvestorCategoryAdapter(private val items: List<InvestorItem>, private
 class ViewHolderCoinInvestorsItem(override val containerView: View) : RecyclerView.ViewHolder(containerView), LayoutContainer {
 
     fun bind(item: InvestorItem.Fund, onClick: () -> Unit) {
-        title.text = item.name
-        subtitle.text = item.cleanedUrl
-        backgroundView.setBackgroundResource(item.position.getBackground())
+        containerView.findViewById<TextView>(R.id.title).text = item.name
+        containerView.findViewById<TextView>(R.id.subtitle).text = item.cleanedUrl
+        containerView.findViewById<View>(R.id.backgroundView).setBackgroundResource(item.position.getBackground())
         containerView.setOnClickListener {
             onClick.invoke()
         }
@@ -62,6 +61,6 @@ class ViewHolderCoinInvestorsSectionHeader(override val containerView: View)
     : RecyclerView.ViewHolder(containerView), LayoutContainer {
 
     fun bind(item: InvestorItem.Header) {
-        sectionTitle.text = item.title
+        containerView.findViewById<TextView>(R.id.sectionTitle).text = item.title
     }
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/coin/coininvestors/CoinInvestorsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/coin/coininvestors/CoinInvestorsFragment.kt
@@ -6,12 +6,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.widget.Toolbar
 import androidx.navigation.navGraphViewModels
+import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.bankwallet.modules.coin.CoinViewModel
 import io.horizontalsystems.core.findNavController
-import kotlinx.android.synthetic.main.fragment_coin_investors.*
 
 class CoinInvestorsFragment : BaseFragment(), CoinInvestorCategoryAdapter.Listener {
 
@@ -24,6 +25,8 @@ class CoinInvestorsFragment : BaseFragment(), CoinInvestorCategoryAdapter.Listen
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
+
         toolbar.title = getString(R.string.CoinPage_FundsInvested)
         toolbar.setNavigationOnClickListener {
             findNavController().popBackStack()
@@ -31,7 +34,7 @@ class CoinInvestorsFragment : BaseFragment(), CoinInvestorCategoryAdapter.Listen
 
         coinViewModel.coinInvestors.observe(viewLifecycleOwner, {
             val investorsAdapter = CoinInvestorCategoryAdapter(it, this)
-            recyclerView.adapter = investorsAdapter
+            view.findViewById<RecyclerView>(R.id.recyclerView).adapter = investorsAdapter
         })
     }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/coin/coinmarkets/CoinMarketItemAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/coin/coinmarkets/CoinMarketItemAdapter.kt
@@ -3,14 +3,14 @@ package io.horizontalsystems.bankwallet.modules.coin.coinmarkets
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.isVisible
+import android.widget.TextView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.modules.coin.MarketTickerViewItem
+import io.horizontalsystems.bankwallet.ui.extensions.PicassoRoundedImageView
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.view_holder_market_ticker.*
 
 class CoinMarketItemAdapter : ListAdapter<MarketTickerViewItem, ViewHolderMarketTicker>(diffCallback) {
 
@@ -38,16 +38,17 @@ class CoinMarketItemAdapter : ListAdapter<MarketTickerViewItem, ViewHolderMarket
 class ViewHolderMarketTicker(override val containerView: View) : RecyclerView.ViewHolder(containerView), LayoutContainer {
 
     fun bind(item: MarketTickerViewItem) {
-        icon.loadImage(item.imageUrl)
+        containerView.findViewById<PicassoRoundedImageView>(R.id.icon).loadImage(item.imageUrl)
 
-        title.text = item.title
+        containerView.findViewById<TextView>(R.id.title).text = item.title
 
-        subtitle.text = item.subtitle
+        containerView.findViewById<TextView>(R.id.subtitle).text = item.subtitle
 
-        rate.text = item.value
+        containerView.findViewById<TextView>(R.id.rate).text = item.value
 
-        marketFieldCaption.text = "Vol"
+        containerView.findViewById<TextView>(R.id.marketFieldCaption).text = "Vol"
 
+        val marketFieldValue = containerView.findViewById<TextView>(R.id.marketFieldValue)
         marketFieldValue.text = item.subvalue
         marketFieldValue.setTextColor(containerView.resources.getColor(R.color.grey, containerView.context.theme))
     }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/coin/coinmarkets/CoinMarketsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/coin/coinmarkets/CoinMarketsFragment.kt
@@ -4,12 +4,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.widget.Toolbar
 import androidx.navigation.navGraphViewModels
+import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.bankwallet.modules.coin.CoinViewModel
 import io.horizontalsystems.core.findNavController
-import kotlinx.android.synthetic.main.fragment_coin_markets.*
 
 class CoinMarketsFragment : BaseFragment() {
 
@@ -22,6 +23,8 @@ class CoinMarketsFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
+
         toolbar.title = getString(R.string.CoinMarket_Title, coinViewModel.coinCode)
         toolbar.setNavigationOnClickListener {
             findNavController().popBackStack()
@@ -29,7 +32,7 @@ class CoinMarketsFragment : BaseFragment() {
 
         val marketItemsAdapter = CoinMarketItemAdapter()
 
-        recyclerView.adapter = marketItemsAdapter
+        view.findViewById<RecyclerView>(R.id.recyclerView).adapter = marketItemsAdapter
 
         coinViewModel.coinMarkets.observe(viewLifecycleOwner, {
             marketItemsAdapter.submitList(it)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/createaccount/CreateAccountFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/createaccount/CreateAccountFragment.kt
@@ -4,17 +4,21 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
+import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.bankwallet.core.setOnSingleClickListener
+import io.horizontalsystems.bankwallet.ui.extensions.InputView
 import io.horizontalsystems.bankwallet.ui.selector.SelectorOptionTextViewHolderFactory
 import io.horizontalsystems.bankwallet.ui.selector.SelectorPopupDialog
 import io.horizontalsystems.bankwallet.ui.selector.ViewItemWrapper
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.helpers.HudHelper
-import kotlinx.android.synthetic.main.fragment_create_account.*
+import io.horizontalsystems.views.SettingsView
+import io.horizontalsystems.views.SettingsViewSwitch
 
 class CreateAccountFragment : BaseFragment() {
     private val viewModel by viewModels<CreateAccountViewModel> { CreateAccountModule.Factory() }
@@ -25,6 +29,13 @@ class CreateAccountFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
+        val kind = view.findViewById<SettingsView>(R.id.kind)
+        val passphrase = view.findViewById<InputView>(R.id.passphrase)
+        val passphraseConfirm = view.findViewById<InputView>(R.id.passphraseConfirm)
+        val passphraseDescription = view.findViewById<TextView>(R.id.passphraseDescription)
+
         toolbar.setNavigationOnClickListener {
             findNavController().popBackStack()
         }
@@ -83,7 +94,7 @@ class CreateAccountFragment : BaseFragment() {
             dialog.show(childFragmentManager, "selector_dialog")
         }
 
-        passphraseToggle.setOnCheckedChangeListenerSingle {
+        view.findViewById<SettingsViewSwitch>(R.id.passphraseToggle).setOnCheckedChangeListenerSingle {
             viewModel.onTogglePassphrase(it)
         }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/enablecoins/EnableCoinsDialog.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/enablecoins/EnableCoinsDialog.kt
@@ -2,10 +2,11 @@ package io.horizontalsystems.bankwallet.modules.enablecoins
 
 import android.os.Bundle
 import android.view.View
+import android.widget.Button
+import android.widget.TextView
 import androidx.fragment.app.FragmentActivity
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.ui.extensions.BaseBottomSheetDialogFragment
-import kotlinx.android.synthetic.main.fragment_enable_coins.*
 
 class EnableCoinsDialog(private val listener: Listener, private val tokenType: String) : BaseBottomSheetDialogFragment() {
 
@@ -19,13 +20,13 @@ class EnableCoinsDialog(private val listener: Listener, private val tokenType: S
 
         setTitle(activity?.getString(R.string.EnalbeToken_Title))
         setSubtitle(tokenType)
-        alertText.text = getString(R.string.EnalbeToken_Description, tokenType)
+        view.findViewById<TextView>(R.id.alertText).text = getString(R.string.EnalbeToken_Description, tokenType)
 
         val icon = getIcon(tokenType)
 
         setHeaderIcon(icon)
 
-        enableBtn.setOnClickListener {
+        view.findViewById<Button>(R.id.enableBtn).setOnClickListener {
             listener.onClickEnable()
             dismiss()
         }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/intro/IntroActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/intro/IntroActivity.kt
@@ -3,6 +3,8 @@ package io.horizontalsystems.bankwallet.modules.intro
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.widget.Button
+import android.widget.ImageSwitcher
 import android.widget.ImageView
 import androidx.activity.viewModels
 import androidx.core.content.ContextCompat
@@ -10,16 +12,22 @@ import androidx.viewpager.widget.ViewPager
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseActivity
 import io.horizontalsystems.bankwallet.modules.main.MainModule
-import kotlinx.android.synthetic.main.activity_intro.*
+import me.relex.circleindicator.CircleIndicator
 
 class IntroActivity : BaseActivity() {
 
     val viewModel by viewModels<IntroViewModel> { IntroModule.Factory() }
+    private lateinit var viewPager: ViewPager
+    private lateinit var btnNext: Button
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         setContentView(R.layout.activity_intro)
+
+        viewPager = findViewById(R.id.viewPager)
+        val imageSwitcher = findViewById<ImageSwitcher>(R.id.imageSwitcher)
+        btnNext = findViewById(R.id.btnNext)
 
         val viewPagerAdapter = IntroViewPagerAdapter(supportFragmentManager)
         val pagesCount = viewPagerAdapter.count
@@ -54,7 +62,7 @@ class IntroActivity : BaseActivity() {
         imageSwitcher.setFactory { ImageView(applicationContext) }
         imageSwitcher.setImageResource(images[0])
 
-        circleIndicator.setViewPager(viewPager)
+        findViewById<CircleIndicator>(R.id.circleIndicator).setViewPager(viewPager)
 
         btnNext.setOnClickListener {
             if (viewPager.currentItem < pagesCount - 1) {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/intro/IntroSlideFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/intro/IntroSlideFragment.kt
@@ -4,10 +4,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import io.horizontalsystems.bankwallet.R
-import kotlinx.android.synthetic.main.fragment_slide_intro.*
 
 class IntroSlideFragment : Fragment() {
 
@@ -21,11 +21,12 @@ class IntroSlideFragment : Fragment() {
         val titleResId = requireArguments().getInt(TITLE_KEY)
         val descriptionResId = requireArguments().getInt(DESCRIPTION_KEY)
 
+        val title = view.findViewById<TextView>(R.id.title)
         title.isVisible = titleResId != 0
         if (titleResId != 0) {
             title.text = getString(titleResId)
         }
-        description.text = getString(descriptionResId)
+        view.findViewById<TextView>(R.id.description).text = getString(descriptionResId)
     }
 
     companion object {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/main/MainFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/main/MainFragment.kt
@@ -12,8 +12,10 @@ import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
+import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.bottomnavigation.BottomNavigationItemView
 import com.google.android.material.bottomnavigation.BottomNavigationMenuView
+import com.google.android.material.bottomnavigation.BottomNavigationView
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.bankwallet.core.managers.RateAppManager
@@ -22,35 +24,41 @@ import io.horizontalsystems.bankwallet.modules.markdown.MarkdownFragment
 import io.horizontalsystems.bankwallet.modules.rateapp.RateAppDialogFragment
 import io.horizontalsystems.bankwallet.modules.rooteddevice.RootedDeviceActivity
 import io.horizontalsystems.core.findNavController
-import kotlinx.android.synthetic.main.fragment_main.*
-import kotlinx.android.synthetic.main.fragment_main.view.*
 
 class MainFragment : BaseFragment(), RateAppDialogFragment.Listener {
 
     private val viewModel by viewModels<MainViewModel>{ MainModule.Factory() }
     private var bottomBadgeView: View? = null
+    private lateinit var viewPager: ViewPager2
+    private lateinit var screenSecureDim: View
+    private lateinit var bottomNavigation: BottomNavigationView
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val view = inflater.inflate(R.layout.fragment_main, container, false)
 
-        view.viewPager.offscreenPageLimit = 1
-        view.viewPager.adapter = MainViewPagerAdapter(childFragmentManager, viewLifecycleOwner.lifecycle)
+        viewPager = view.findViewById(R.id.viewPager)
+        screenSecureDim = view.findViewById(R.id.screenSecureDim)
 
-        view.viewPager.isUserInputEnabled = false
+        viewPager.offscreenPageLimit = 1
+        viewPager.adapter = MainViewPagerAdapter(childFragmentManager, viewLifecycleOwner.lifecycle)
 
-        view.bottomNavigation.setOnNavigationItemSelectedListener {
+        viewPager.isUserInputEnabled = false
+
+        bottomNavigation = view.findViewById(R.id.bottomNavigation)
+
+        bottomNavigation.setOnNavigationItemSelectedListener {
             when (it.itemId) {
-                R.id.navigation_market -> view.viewPager.setCurrentItem(0, false)
-                R.id.navigation_balance -> view.viewPager.setCurrentItem(1, false)
-                R.id.navigation_transactions -> view.viewPager.setCurrentItem(2, false)
-                R.id.navigation_settings -> view.viewPager.setCurrentItem(3, false)
+                R.id.navigation_market -> viewPager.setCurrentItem(0, false)
+                R.id.navigation_balance -> viewPager.setCurrentItem(1, false)
+                R.id.navigation_transactions -> viewPager.setCurrentItem(2, false)
+                R.id.navigation_settings -> viewPager.setCurrentItem(3, false)
             }
             true
         }
 
         arguments?.getInt(ACTIVE_TAB_KEY)?.let { position ->
-            view.bottomNavigation.menu.getItem(position).isChecked = true
-            view.viewPager.setCurrentItem(position, false)
+            bottomNavigation.menu.getItem(position).isChecked = true
+            viewPager.setCurrentItem(position, false)
         }
 
         return view
@@ -77,7 +85,7 @@ class MainFragment : BaseFragment(), RateAppDialogFragment.Listener {
         viewModel.openPlayMarketLiveEvent.observe(viewLifecycleOwner, Observer {
             openAppInPlayMarket()
         })
-6
+
         viewModel.hideContentLiveData.observe(viewLifecycleOwner, Observer { hide ->
             screenSecureDim.isVisible = hide
         })

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/manageaccount/ManageAccountFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/manageaccount/ManageAccountFragment.kt
@@ -7,6 +7,11 @@ import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.EditText
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
@@ -23,9 +28,8 @@ import io.horizontalsystems.bankwallet.ui.helpers.TextHelper
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.helpers.HudHelper
 import io.horizontalsystems.views.ListPosition
+import io.horizontalsystems.views.SettingsView
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.fragment_manage_account.*
-import kotlinx.android.synthetic.main.view_holder_account_setting_view.*
 
 class ManageAccountFragment : BaseFragment(), UnlinkConfirmationDialog.Listener {
     private val viewModel by viewModels<ManageAccountViewModel> { ManageAccountModule.Factory(arguments?.getString(ACCOUNT_ID_KEY)!!) }
@@ -37,6 +41,11 @@ class ManageAccountFragment : BaseFragment(), UnlinkConfirmationDialog.Listener 
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
+        val name = view.findViewById<EditText>(R.id.name)
+        val actionButton = view.findViewById<SettingsView>(R.id.actionButton)
+        val additionalInfoItems = view.findViewById<RecyclerView>(R.id.additionalInfoItems)
 
         saveMenuItem = toolbar.menu.findItem(R.id.menuSave)
 
@@ -69,7 +78,7 @@ class ManageAccountFragment : BaseFragment(), UnlinkConfirmationDialog.Listener 
         }
         name.addTextChangedListener(textWatcher)
 
-        unlinkButton.setOnSingleClickListener {
+        view.findViewById<Button>(R.id.unlinkButton).setOnSingleClickListener {
             val confirmationList = listOf(
                     getString(R.string.ManageAccount_Delete_ConfirmationRemove),
                     getString(R.string.ManageAccount_Delete_ConfirmationDisable),
@@ -156,8 +165,11 @@ class AdditionalInfoAdapter(
 
 class AdditionalInfoViewHolder(override val containerView: View) : RecyclerView.ViewHolder(containerView), LayoutContainer {
     fun bind(additionViewItem: ManageAccountViewModel.AdditionalViewItem, position: ListPosition) {
-        icon.setCoinImage(additionViewItem.coinType)
-        title.text = additionViewItem.title
+        containerView.findViewById<ImageView>(R.id.icon).setCoinImage(additionViewItem.coinType)
+        containerView.findViewById<TextView>(R.id.title).text = additionViewItem.title
+
+        val decoratedText = containerView.findViewById<TextView>(R.id.decoratedText)
+
         decoratedText.text = additionViewItem.value
         containerView.setBackgroundResource(position.getBackground())
         decoratedText.setOnClickListener {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/manageaccount/dialogs/BackupRequiredDialog.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/manageaccount/dialogs/BackupRequiredDialog.kt
@@ -2,12 +2,12 @@ package io.horizontalsystems.bankwallet.modules.manageaccount.dialogs
 
 import android.os.Bundle
 import android.view.View
+import android.widget.Button
 import androidx.core.os.bundleOf
 import androidx.fragment.app.FragmentManager
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.entities.Account
 import io.horizontalsystems.bankwallet.ui.extensions.BaseBottomSheetDialogFragment
-import kotlinx.android.synthetic.main.fragment_bottom_backup_required.*
 
 class BackupRequiredDialog : BaseBottomSheetDialogFragment() {
 
@@ -26,7 +26,7 @@ class BackupRequiredDialog : BaseBottomSheetDialogFragment() {
         setSubtitle(account?.name)
         setHeaderIcon(R.drawable.ic_attention_red_24)
 
-        backupButton.setOnClickListener {
+        view.findViewById<Button>(R.id.backupButton).setOnClickListener {
             account?.let { listener?.onClickBackup(account) }
             dismiss()
         }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/manageaccount/dialogs/UnlinkConfirmationDialog.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/manageaccount/dialogs/UnlinkConfirmationDialog.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.CheckBox
 import androidx.core.os.bundleOf
 import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -13,8 +15,6 @@ import io.horizontalsystems.bankwallet.ui.extensions.BaseBottomSheetDialogFragme
 import io.horizontalsystems.views.inflate
 import kotlinx.android.extensions.LayoutContainer
 import kotlinx.android.parcel.Parcelize
-import kotlinx.android.synthetic.main.fragment_bottom_confirm_unlink.*
-import kotlinx.android.synthetic.main.view_holder_confirmation.*
 
 class UnlinkConfirmationDialog : BaseBottomSheetDialogFragment(), ConfirmationsAdapter.Listener {
 
@@ -24,6 +24,7 @@ class UnlinkConfirmationDialog : BaseBottomSheetDialogFragment(), ConfirmationsA
 
     private var listener: Listener? = null
     private var checkboxItems = listOf<CheckBoxItem>()
+    private lateinit var confirmButton: Button
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -32,6 +33,9 @@ class UnlinkConfirmationDialog : BaseBottomSheetDialogFragment(), ConfirmationsA
         setTitle(getString(R.string.ManageKeys_Delete_Title))
         setSubtitle(requireArguments().getString(ACCOUNT_NAME))
         setHeaderIcon(R.drawable.ic_attention_red_24)
+
+        confirmButton = view.findViewById<Button>(R.id.confirmButton)
+        val recyclerView = view.findViewById<RecyclerView>(R.id.recyclerView)
 
         confirmButton.setOnClickListener {
             listener?.onUnlinkConfirm()
@@ -104,6 +108,8 @@ class ConfirmationsAdapter(private var listener: Listener, private val confirmat
 class ViewHolderConfirmation(
         override val containerView: View, private val listener: ConfirmationsAdapter.Listener
 ) : RecyclerView.ViewHolder(containerView), LayoutContainer {
+
+    private val confirmationCheckBox: CheckBox = containerView.findViewById(R.id.confirmationCheckBox)
 
     init {
         confirmationCheckBox.setOnCheckedChangeListener { _, isChecked ->

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/manageaccounts/ManageAccountsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/manageaccounts/ManageAccountsFragment.kt
@@ -4,6 +4,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.ConcatAdapter
@@ -17,14 +20,10 @@ import io.horizontalsystems.bankwallet.modules.manageaccounts.ManageAccountsModu
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.views.ListPosition
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.fragment_manage_accounts.*
-import kotlinx.android.synthetic.main.view_holder_manage_account_action.*
-import kotlinx.android.synthetic.main.view_holder_manage_account_action.backgroundView
-import kotlinx.android.synthetic.main.view_holder_manage_account_action.title
-import kotlinx.android.synthetic.main.view_holder_manage_account_item.*
 
 class ManageAccountsFragment : BaseFragment(), AccountViewHolder.Listener {
     private val viewModel by viewModels<ManageAccountsViewModel> { ManageAccountsModule.Factory(arguments?.getParcelable(ManageAccountsModule.MODE)!!) }
+    private lateinit var recyclerView: RecyclerView
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_manage_accounts, container, false)
@@ -32,6 +31,9 @@ class ManageAccountsFragment : BaseFragment(), AccountViewHolder.Listener {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
+        recyclerView = view.findViewById(R.id.recyclerView)
 
         toolbar.menu.findItem(R.id.menuCancel)?.isVisible = viewModel.isCloseButtonVisible
         toolbar.setOnMenuItemClickListener { item ->
@@ -118,13 +120,14 @@ class AccountViewHolder(override val containerView: View, val listener: Listener
     }
 
     fun bind(account: AccountViewItem, position: ListPosition) {
-        title.text = account.title
-        subtitle.text = account.subtitle
+        containerView.findViewById<TextView>(R.id.title).text = account.title
+        containerView.findViewById<TextView>(R.id.subtitle).text = account.subtitle
+        val backgroundView = containerView.findViewById<View>(R.id.backgroundView)
 
         backgroundView.setBackgroundResource(position.getBackground())
-        radioImage.setImageResource(if (account.selected) R.drawable.ic_radion else R.drawable.ic_radioff)
-        attentionIcon.isVisible = account.alert
-        editIcon.setOnClickListener {
+        containerView.findViewById<ImageView>(R.id.radioImage).setImageResource(if (account.selected) R.drawable.ic_radion else R.drawable.ic_radioff)
+        containerView.findViewById<ImageView>(R.id.attentionIcon).isVisible = account.alert
+        containerView.findViewById<ImageView>(R.id.editIcon).setOnClickListener {
             listener.onEdit(account)
         }
 
@@ -179,8 +182,9 @@ class ActionsAdapter(
 
 class ActionViewHolder(override val containerView: View) : RecyclerView.ViewHolder(containerView), LayoutContainer {
     fun bind(action: ActionViewItem, position: ListPosition) {
-        icon.setImageResource(action.icon)
-        title.setText(action.title)
+        containerView.findViewById<ImageView>(R.id.icon).setImageResource(action.icon)
+        containerView.findViewById<TextView>(R.id.title).setText(action.title)
+        val backgroundView = containerView.findViewById<View>(R.id.backgroundView)
         backgroundView.setBackgroundResource(position.getBackground())
         backgroundView.setOnSingleClickListener { action.callback() }
     }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/managewallets/view/AddTokenDialog.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/managewallets/view/AddTokenDialog.kt
@@ -2,10 +2,10 @@ package io.horizontalsystems.bankwallet.modules.managewallets.view
 
 import android.os.Bundle
 import android.view.View
+import android.widget.Button
 import androidx.fragment.app.FragmentActivity
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.ui.extensions.BaseBottomSheetDialogFragment
-import kotlinx.android.synthetic.main.fragment_bottom_add_token.*
 
 class AddTokenDialog(private val listener: Listener)
     : BaseBottomSheetDialogFragment() {
@@ -16,9 +16,17 @@ class AddTokenDialog(private val listener: Listener)
         fun onClickAddBep2Token()
     }
 
+    private lateinit var erc20TokensBtn: Button
+    private lateinit var bep20TokensBtn: Button
+    private lateinit var bep2TokensBtn: Button
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setContentView(R.layout.fragment_bottom_add_token)
+
+        erc20TokensBtn = view.findViewById(R.id.erc20TokensBtn)
+        bep20TokensBtn = view.findViewById(R.id.bep20TokensBtn)
+        bep2TokensBtn = view.findViewById(R.id.bep2TokensBtn)
 
         setTitle(activity?.getString(R.string.AddTokenDialog_Title))
         setSubtitle(getString(R.string.AddTokenDialog_Subtitle))

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/managewallets/view/ManageWalletsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/managewallets/view/ManageWalletsFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.View
 import androidx.activity.addCallback
+import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import io.horizontalsystems.bankwallet.R
@@ -17,7 +18,6 @@ import io.horizontalsystems.bankwallet.ui.extensions.ZcashBirthdayHeightDialog
 import io.horizontalsystems.bankwallet.ui.extensions.coinlist.CoinListBaseFragment
 import io.horizontalsystems.coinkit.models.Coin
 import io.horizontalsystems.core.findNavController
-import kotlinx.android.synthetic.main.fragment_manage_wallets.*
 
 class ManageWalletsFragment : CoinListBaseFragment() {
 
@@ -31,6 +31,8 @@ class ManageWalletsFragment : CoinListBaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
 
         toolbar.inflateMenu(R.menu.manage_wallets_menu)
         toolbar.setOnMenuItemClickListener { item ->

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/markdown/MarkdownBlockViewHolder.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/markdown/MarkdownBlockViewHolder.kt
@@ -5,21 +5,20 @@ import android.text.method.LinkMovementMethod
 import android.text.style.ClickableSpan
 import android.text.style.URLSpan
 import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.constraintlayout.widget.ConstraintSet.TOP
+import androidx.constraintlayout.widget.Group
 import androidx.core.text.getSpans
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import com.squareup.picasso.Callback
 import com.squareup.picasso.Picasso
+import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.views.helpers.LayoutHelper
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.view_holder_markdown_h1.*
-import kotlinx.android.synthetic.main.view_holder_markdown_h2.*
-import kotlinx.android.synthetic.main.view_holder_markdown_h3.*
-import kotlinx.android.synthetic.main.view_holder_markdown_image.*
-import kotlinx.android.synthetic.main.view_holder_markdown_paragraph.*
 import org.apache.commons.io.FilenameUtils
 import java.net.URL
 
@@ -35,7 +34,7 @@ class ViewHolderH1(override val containerView: View) : MarkdownBlockViewHolder(c
     override fun bind(item: MarkdownBlock) {
         if (item !is MarkdownBlock.Heading1) return
 
-        h1.text = item.text
+        containerView.findViewById<TextView>(R.id.h1).text = item.text
     }
 }
 
@@ -43,7 +42,7 @@ class ViewHolderH2(override val containerView: View) : MarkdownBlockViewHolder(c
     override fun bind(item: MarkdownBlock) {
         if (item !is MarkdownBlock.Heading2) return
 
-        h2.text = item.text
+        containerView.findViewById<TextView>(R.id.h2).text = item.text
     }
 }
 
@@ -51,7 +50,7 @@ class ViewHolderH3(override val containerView: View) : MarkdownBlockViewHolder(c
     override fun bind(item: MarkdownBlock) {
         if (item !is MarkdownBlock.Heading3) return
 
-        h3.text = item.text
+        containerView.findViewById<TextView>(R.id.h3).text = item.text
     }
 }
 
@@ -61,6 +60,10 @@ class ViewHolderImage(override val containerView: View) : MarkdownBlockViewHolde
             "p" to "9:16",
             "s" to "1:1"
     )
+
+    private val placeholder = containerView.findViewById<Group>(R.id.placeholder)
+    private val image = containerView.findViewById<ImageView>(R.id.image)
+    private val imageCaption = containerView.findViewById<TextView>(R.id.imageCaption)
 
     override fun bind(item: MarkdownBlock) {
         if (item !is MarkdownBlock.Image) return
@@ -102,6 +105,9 @@ class ViewHolderImage(override val containerView: View) : MarkdownBlockViewHolde
 class ViewHolderParagraph(override val containerView: View, private val listener: MarkdownContentAdapter.Listener, private val handleRelativeUrl: Boolean) : MarkdownBlockViewHolder(containerView), LayoutContainer {
     private val blockQuoteVerticalPadding = LayoutHelper.dp(12f, containerView.context)
     private val listItemIndent = LayoutHelper.dp(24f, containerView.context)
+    private val paragraph = containerView.findViewById<TextView>(R.id.paragraph)
+    private val listItemMarker = containerView.findViewById<TextView>(R.id.listItemMarker)
+    private val quoted = containerView.findViewById<Group>(R.id.quoted)
 
     override fun bind(item: MarkdownBlock) {
         if (item !is MarkdownBlock.Paragraph) return

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/markdown/MarkdownFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/markdown/MarkdownFragment.kt
@@ -4,18 +4,22 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
+import androidx.appcompat.widget.Toolbar
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
+import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.core.findNavController
-import kotlinx.android.synthetic.main.fragment_markdown.*
 
 class MarkdownFragment : BaseFragment(), MarkdownContentAdapter.Listener {
 
     private lateinit var contentAdapter: MarkdownContentAdapter
+    private lateinit var toolbar: Toolbar
+    private lateinit var error: TextView
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return inflater.inflate(R.layout.fragment_markdown, container, false)
@@ -23,6 +27,9 @@ class MarkdownFragment : BaseFragment(), MarkdownContentAdapter.Listener {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        toolbar = view.findViewById(R.id.toolbar)
+        error = view.findViewById(R.id.error)
 
         if (arguments?.getBoolean(showAsClosablePopupKey) == true){
             toolbar.inflateMenu(R.menu.markdown_viewer_menu)
@@ -48,7 +55,7 @@ class MarkdownFragment : BaseFragment(), MarkdownContentAdapter.Listener {
         val viewModel by viewModels<MarkdownViewModel> { MarkdownModule.Factory(markdownUrl, gitReleaseUrl) }
 
         contentAdapter = MarkdownContentAdapter(this, handleRelativeUrl)
-        rvBlocks.adapter = contentAdapter
+        view.findViewById<RecyclerView>(R.id.rvBlocks).adapter = contentAdapter
 
         observe(viewModel)
     }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/MarketFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/MarketFragment.kt
@@ -4,12 +4,14 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.widget.Toolbar
 import androidx.navigation.navGraphViewModels
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewpager2.widget.ViewPager2
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseWithSearchFragment
 import io.horizontalsystems.bankwallet.modules.transactions.FilterAdapter
 import io.horizontalsystems.core.findNavController
-import kotlinx.android.synthetic.main.fragment_market.*
 
 class MarketFragment : BaseWithSearchFragment(), FilterAdapter.Listener {
     private val marketViewModel by navGraphViewModels<MarketViewModel>(R.id.mainFragment) { MarketModule.Factory() }
@@ -20,6 +22,9 @@ class MarketFragment : BaseWithSearchFragment(), FilterAdapter.Listener {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        val recyclerTags = view.findViewById<RecyclerView>(R.id.recyclerTags)
+        val viewPager = view.findViewById<ViewPager2>(R.id.viewPager)
 
         val filterAdapter = FilterAdapter(this)
         recyclerTags.adapter = filterAdapter
@@ -39,7 +44,7 @@ class MarketFragment : BaseWithSearchFragment(), FilterAdapter.Listener {
             filterAdapter.setFilters(marketViewModel.tabs.map { it.filterItem() }, tab.filterItem())
         }
 
-        toolbar.setOnMenuItemClickListener { item ->
+        view.findViewById<Toolbar>(R.id.toolbar).setOnMenuItemClickListener { item ->
             when (item.itemId) {
                 R.id.search -> {
                     findNavController().navigate(R.id.mainFragment_to_marketSearchFragment)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/MarketItemsAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/MarketItemsAdapter.kt
@@ -4,6 +4,8 @@ import android.content.res.ColorStateList
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.core.view.isVisible
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
@@ -14,7 +16,6 @@ import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.App
 import io.horizontalsystems.bankwallet.ui.helpers.AppLayoutHelper
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.view_holder_market_item.*
 import java.math.BigDecimal
 
 class MarketItemsAdapter(
@@ -80,6 +81,13 @@ class MarketItemsAdapter(
 
 class ViewHolderMarketItem(override val containerView: View, private val listener: Listener) : RecyclerView.ViewHolder(containerView), LayoutContainer {
     private var item: MarketViewItem? = null
+    private val icon = containerView.findViewById<ImageView>(R.id.icon)
+    private val rank = containerView.findViewById<TextView>(R.id.rank)
+    private val title = containerView.findViewById<TextView>(R.id.title)
+    private val subtitle = containerView.findViewById<TextView>(R.id.subtitle)
+    private val rate = containerView.findViewById<TextView>(R.id.rate)
+    private val marketFieldCaption = containerView.findViewById<TextView>(R.id.marketFieldCaption)
+    private val marketFieldValue = containerView.findViewById<TextView>(R.id.marketFieldValue)
 
     interface Listener {
         fun onItemClick(marketViewItem: MarketViewItem)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/MarketLoadingAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/MarketLoadingAdapter.kt
@@ -3,6 +3,8 @@ package io.horizontalsystems.bankwallet.modules.market
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ProgressBar
+import android.widget.TextView
 import androidx.annotation.StringRes
 import androidx.core.view.isVisible
 import androidx.lifecycle.LifecycleOwner
@@ -12,7 +14,6 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.view_holder_market_loading.*
 
 class MarketLoadingAdapter(
         loadingLiveData: LiveData<Boolean>,
@@ -95,6 +96,8 @@ sealed class MarketLoadingState {
 class ViewHolderMarketLoading(override val containerView: View, onErrorClick: () -> Unit) : RecyclerView.ViewHolder(containerView), LayoutContainer {
 
     private var marketLoadingState: MarketLoadingState? = null
+    private val progressBar = containerView.findViewById<ProgressBar>(R.id.progressBar)
+    private val error = containerView.findViewById<TextView>(R.id.error)
 
     init {
         containerView.setOnClickListener {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/advancedsearch/MarketAdvancedSearchFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/advancedsearch/MarketAdvancedSearchFragment.kt
@@ -4,18 +4,22 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.ProgressBar
+import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
 import androidx.navigation.navGraphViewModels
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.bankwallet.core.setOnSingleClickListener
+import io.horizontalsystems.bankwallet.ui.extensions.MarketFilterSwitchView
+import io.horizontalsystems.bankwallet.ui.extensions.MarketFilterView
 import io.horizontalsystems.bankwallet.ui.selector.ItemViewHolder
 import io.horizontalsystems.bankwallet.ui.selector.ItemViewHolderFactory
 import io.horizontalsystems.bankwallet.ui.selector.SelectorBottomSheetDialog
 import io.horizontalsystems.bankwallet.ui.selector.SelectorItemViewHolderFactory
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.helpers.HudHelper
-import kotlinx.android.synthetic.main.fragment_market_search_filter.*
 
 class MarketAdvancedSearchFragment : BaseFragment() {
 
@@ -23,11 +27,32 @@ class MarketAdvancedSearchFragment : BaseFragment() {
         MarketAdvancedSearchModule.Factory()
     }
 
+    private lateinit var filterCoinList: MarketFilterView
+    private lateinit var filterMarketCap: MarketFilterView
+    private lateinit var filterVolume: MarketFilterView
+    private lateinit var filterPeriod: MarketFilterView
+    private lateinit var filterPriceChange: MarketFilterView
+    private lateinit var filterOutperformedBtc: MarketFilterSwitchView
+    private lateinit var filterOutperformedEth: MarketFilterSwitchView
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_market_search_filter, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
+        filterCoinList = view.findViewById(R.id.filterCoinList)
+        filterMarketCap = view.findViewById(R.id.filterMarketCap)
+        filterVolume = view.findViewById(R.id.filterVolume)
+        filterPeriod = view.findViewById(R.id.filterPeriod)
+        filterPriceChange = view.findViewById(R.id.filterPriceChange)
+        filterOutperformedBtc = view.findViewById(R.id.filterOutperformedBtc)
+        filterOutperformedEth = view.findViewById(R.id.filterOutperformedEth)
+        val filterOutperformedBnb = view.findViewById<MarketFilterSwitchView>(R.id.filterOutperformedBnb)
+        val filterPriceCloseToAth = view.findViewById<MarketFilterSwitchView>(R.id.filterPriceCloseToAth)
+        val filterPriceCloseToAtl = view.findViewById<MarketFilterSwitchView>(R.id.filterPriceCloseToAtl)
+        val submit = view.findViewById<Button>(R.id.submit)
+
         toolbar.setNavigationOnClickListener {
             findNavController().popBackStack()
         }
@@ -173,7 +198,7 @@ class MarketAdvancedSearchFragment : BaseFragment() {
         }
 
         marketAdvancedSearchViewModel.loadingLiveData.observe(viewLifecycleOwner) {
-            progressBar.isVisible = it
+            view.findViewById<ProgressBar>(R.id.progressBar).isVisible = it
         }
     }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/advancedsearch/MarketAdvancedSearchResultsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/advancedsearch/MarketAdvancedSearchResultsFragment.kt
@@ -4,26 +4,29 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.navigation.navGraphViewModels
 import androidx.recyclerview.widget.ConcatAdapter
+import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
+import io.horizontalsystems.bankwallet.modules.coin.CoinFragment
 import io.horizontalsystems.bankwallet.modules.market.*
 import io.horizontalsystems.bankwallet.modules.market.list.MarketListViewModel
-import io.horizontalsystems.bankwallet.modules.coin.CoinFragment
 import io.horizontalsystems.bankwallet.ui.extensions.MarketListHeaderView
 import io.horizontalsystems.bankwallet.ui.extensions.SelectorDialog
 import io.horizontalsystems.bankwallet.ui.extensions.SelectorItem
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.helpers.HudHelper
-import kotlinx.android.synthetic.main.fragment_market_advanced_search_results.*
 
 class MarketAdvancedSearchResultsFragment : BaseFragment(), MarketListHeaderView.Listener, ViewHolderMarketItem.Listener {
 
     private val marketSearchFilterViewModel by navGraphViewModels<MarketAdvancedSearchViewModel>(R.id.marketAdvancedSearchFragment)
     private val marketListViewModel by viewModels<MarketListViewModel> { MarketAdvancedSearchResultsModule.Factory(marketSearchFilterViewModel.service) }
+    private lateinit var marketListHeader: MarketListHeaderView
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_market_advanced_search_results, container, false)
@@ -32,7 +35,11 @@ class MarketAdvancedSearchResultsFragment : BaseFragment(), MarketListHeaderView
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        toolbar.setNavigationOnClickListener {
+        marketListHeader = view.findViewById<MarketListHeaderView>(R.id.marketListHeader)
+        val coinRatesRecyclerView = view.findViewById<RecyclerView>(R.id.coinRatesRecyclerView)
+        val pullToRefresh = view.findViewById<SwipeRefreshLayout>(R.id.pullToRefresh)
+
+        view.findViewById<Toolbar>(R.id.toolbar).setNavigationOnClickListener {
             findNavController().popBackStack()
         }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/discovery/MarketDiscoveryFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/discovery/MarketDiscoveryFragment.kt
@@ -7,17 +7,19 @@ import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.navigation.navGraphViewModels
 import androidx.recyclerview.widget.ConcatAdapter
+import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import com.google.android.material.tabs.TabLayout
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
+import io.horizontalsystems.bankwallet.modules.coin.CoinFragment
 import io.horizontalsystems.bankwallet.modules.market.*
 import io.horizontalsystems.bankwallet.modules.market.list.MarketListViewModel
-import io.horizontalsystems.bankwallet.modules.coin.CoinFragment
 import io.horizontalsystems.bankwallet.ui.extensions.MarketListHeaderView
 import io.horizontalsystems.bankwallet.ui.extensions.SelectorDialog
 import io.horizontalsystems.bankwallet.ui.extensions.SelectorItem
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.helpers.HudHelper
-import kotlinx.android.synthetic.main.fragment_market_discovery.*
 
 class MarketDiscoveryFragment : BaseFragment(), MarketListHeaderView.Listener, ViewHolderMarketItem.Listener, MarketCategoriesAdapter.Listener {
 
@@ -26,6 +28,7 @@ class MarketDiscoveryFragment : BaseFragment(), MarketListHeaderView.Listener, V
     private val marketDiscoveryViewModel by viewModels<MarketDiscoveryViewModel> { vmFactory }
     private val marketListViewModel by viewModels<MarketListViewModel> { vmFactory }
     private val marketViewModel by navGraphViewModels<MarketViewModel>(R.id.mainFragment)
+    private lateinit var marketListHeader: MarketListHeaderView
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_market_discovery, container, false)
@@ -33,6 +36,11 @@ class MarketDiscoveryFragment : BaseFragment(), MarketListHeaderView.Listener, V
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        marketListHeader = view.findViewById(R.id.marketListHeader)
+        val coinRatesRecyclerView = view.findViewById<RecyclerView>(R.id.coinRatesRecyclerView)
+        val pullToRefresh = view.findViewById<SwipeRefreshLayout>(R.id.pullToRefresh)
+        val tabLayout = view.findViewById<TabLayout>(R.id.tabLayout)
 
         marketListHeader.listener = this
         marketListHeader.setSortingField(marketListViewModel.sortingField)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/favorites/MarketFavoritesFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/favorites/MarketFavoritesFragment.kt
@@ -8,21 +8,22 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
+import io.horizontalsystems.bankwallet.modules.coin.CoinFragment
 import io.horizontalsystems.bankwallet.modules.market.*
 import io.horizontalsystems.bankwallet.modules.market.list.MarketListViewModel
-import io.horizontalsystems.bankwallet.modules.coin.CoinFragment
 import io.horizontalsystems.bankwallet.ui.extensions.MarketListHeaderView
 import io.horizontalsystems.bankwallet.ui.extensions.SelectorDialog
 import io.horizontalsystems.bankwallet.ui.extensions.SelectorItem
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.helpers.HudHelper
-import kotlinx.android.synthetic.main.fragment_market_favorites.*
 
 class MarketFavoritesFragment : BaseFragment(), MarketListHeaderView.Listener, ViewHolderMarketItem.Listener {
 
     private val marketListViewModel by viewModels<MarketListViewModel> { MarketFavoritesModule.Factory() }
+    private lateinit var marketListHeader: MarketListHeaderView
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_market_favorites, container, false)
@@ -30,6 +31,10 @@ class MarketFavoritesFragment : BaseFragment(), MarketListHeaderView.Listener, V
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        marketListHeader = view.findViewById(R.id.marketListHeader)
+        val coinRatesRecyclerView = view.findViewById<RecyclerView>(R.id.coinRatesRecyclerView)
+        val pullToRefresh = view.findViewById<SwipeRefreshLayout>(R.id.pullToRefresh)
 
         marketListHeader.listener = this
         marketListHeader.setSortingField(marketListViewModel.sortingField)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/metrics/MarketMetricsAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/metrics/MarketMetricsAdapter.kt
@@ -2,6 +2,7 @@ package io.horizontalsystems.bankwallet.modules.market.metrics
 
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.core.view.isVisible
 import androidx.lifecycle.LifecycleOwner
@@ -10,9 +11,10 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.App
+import io.horizontalsystems.bankwallet.ui.extensions.MarketMetricSmallView
+import io.horizontalsystems.bankwallet.ui.extensions.PriceGradientView
 import io.horizontalsystems.views.inflate
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.view_holder_market_totals.*
 import java.math.BigDecimal
 
 class MarketMetricsAdapter(private val viewModel: MarketMetricsViewModel, viewLifecycleOwner: LifecycleOwner)
@@ -57,6 +59,17 @@ class MarketMetricsAdapter(private val viewModel: MarketMetricsViewModel, viewLi
 data class MarketMetricsWrapper(val marketMetrics: MarketMetrics?, val loading: Boolean, val showSyncError: Boolean)
 
 class MarketMetricsViewHolder(override val containerView: View) : RecyclerView.ViewHolder(containerView), LayoutContainer {
+
+    private val diffCircle = containerView.findViewById<PriceGradientView>(R.id.diffCircle)
+    private val btcDominance = containerView.findViewById<MarketMetricSmallView>(R.id.btcDominance)
+    private val volume24h = containerView.findViewById<MarketMetricSmallView>(R.id.volume24h)
+    private val defiCap = containerView.findViewById<MarketMetricSmallView>(R.id.defiCap)
+    private val defiTvl = containerView.findViewById<MarketMetricSmallView>(R.id.defiTvl)
+    private val marketCapTitle = containerView.findViewById<TextView>(R.id.marketCapTitle)
+    private val diffPercentage = containerView.findViewById<TextView>(R.id.diffPercentage)
+    private val marketCapValue = containerView.findViewById<TextView>(R.id.marketCapValue)
+    private val progressBar = containerView.findViewById<ProgressBar>(R.id.progressBar)
+    private val error = containerView.findViewById<TextView>(R.id.error)
 
     fun bind(
             data: MarketMetricsWrapper?,

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/overview/MarketOverviewFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/overview/MarketOverviewFragment.kt
@@ -10,6 +10,8 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Transformations
 import androidx.navigation.navGraphViewModels
 import androidx.recyclerview.widget.ConcatAdapter
+import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.bankwallet.modules.coin.CoinFragment
@@ -26,7 +28,6 @@ import io.horizontalsystems.bankwallet.modules.metricchart.MetricChartFragment
 import io.horizontalsystems.bankwallet.modules.metricchart.MetricChartType
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.helpers.HudHelper
-import kotlinx.android.synthetic.main.fragment_overview.*
 
 class MarketOverviewFragment : BaseFragment(), ViewHolderMarketOverviewItem.Listener, ViewHolderMarketPostItem.Listener {
 
@@ -83,6 +84,8 @@ class MarketOverviewFragment : BaseFragment(), ViewHolderMarketOverviewItem.List
 
 
         val poweredByAdapter = PoweredByAdapter(marketOverviewViewModel.showPoweredByLiveData, viewLifecycleOwner)
+        val coinRatesRecyclerView = view.findViewById<RecyclerView>(R.id.coinRatesRecyclerView)
+        val pullToRefresh = view.findViewById<SwipeRefreshLayout>(R.id.pullToRefresh)
 
         coinRatesRecyclerView.adapter = ConcatAdapter(
                 marketMetricsAdapter,

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/overview/ViewHolderMarketOverviewItem.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/overview/ViewHolderMarketOverviewItem.kt
@@ -4,6 +4,9 @@ import android.content.res.ColorStateList
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
@@ -15,13 +18,20 @@ import io.horizontalsystems.bankwallet.modules.market.getTextColor
 import io.horizontalsystems.bankwallet.ui.helpers.AppLayoutHelper
 import io.horizontalsystems.views.ListPosition
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.view_holder_market_overview_item.*
 import java.math.BigDecimal
 
 class ViewHolderMarketOverviewItem(override val containerView: View, private val listener: Listener)
     : RecyclerView.ViewHolder(containerView), LayoutContainer {
 
     private var item: MarketViewItem? = null
+    private val icon = containerView.findViewById<ImageView>(R.id.icon)
+    private val rank = containerView.findViewById<TextView>(R.id.rank)
+    private val title = containerView.findViewById<TextView>(R.id.title)
+    private val subtitle = containerView.findViewById<TextView>(R.id.subtitle)
+    private val rate = containerView.findViewById<TextView>(R.id.rate)
+    private val marketFieldCaption = containerView.findViewById<TextView>(R.id.marketFieldCaption)
+    private val marketFieldValue = containerView.findViewById<TextView>(R.id.marketFieldValue)
+    private val rootView = containerView.findViewById<ConstraintLayout>(R.id.rootView)
 
     interface Listener {
         fun onItemClick(marketViewItem: MarketViewItem)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/posts/ViewHolderMarketPostItem.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/posts/ViewHolderMarketPostItem.kt
@@ -3,16 +3,20 @@ package io.horizontalsystems.bankwallet.modules.market.posts
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.modules.market.overview.MarketOverviewModule
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.view_holder_market_post.*
 
 class ViewHolderMarketPostItem(override val containerView: View, private val listener: Listener)
     : RecyclerView.ViewHolder(containerView), LayoutContainer {
 
     private var item: MarketOverviewModule.PostViewItem? = null
+    private val postTitle = containerView.findViewById<TextView>(R.id.postTitle)
+    private val postSource = containerView.findViewById<TextView>(R.id.postSource)
+    private val postBody = containerView.findViewById<TextView>(R.id.postBody)
+    private val postTime = containerView.findViewById<TextView>(R.id.postTime)
 
     interface Listener {
         fun onPostClick(postViewItem: MarketOverviewModule.PostViewItem)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/search/CoinDataItemsAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/search/CoinDataItemsAdapter.kt
@@ -2,6 +2,8 @@ package io.horizontalsystems.bankwallet.modules.market.search
 
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
@@ -13,12 +15,15 @@ import io.horizontalsystems.bankwallet.ui.helpers.AppLayoutHelper
 import io.horizontalsystems.coinkit.models.CoinType
 import io.horizontalsystems.views.inflate
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.view_holder_market_item.*
 
 class CoinDataItemsAdapter(private val onItemClick: (CoinDataViewItem) -> Unit) : ListAdapter<CoinDataViewItem, CoinDataItemsAdapter.ViewHolder>(diffCallback) {
 
     class ViewHolder(override val containerView: View, onItemClick: (CoinDataViewItem) -> Unit) : RecyclerView.ViewHolder(containerView), LayoutContainer {
         private var item: CoinDataViewItem? = null
+        private val icon = containerView.findViewById<ImageView>(R.id.icon)
+        private val title = containerView.findViewById<TextView>(R.id.title)
+        private val subtitle = containerView.findViewById<TextView>(R.id.subtitle)
+        private val rank = containerView.findViewById<TextView>(R.id.rank)
 
         init {
             itemView.setOnSingleClickListener {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/search/MarketSearchFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/search/MarketSearchFragment.kt
@@ -6,7 +6,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
+import android.widget.LinearLayout
 import androidx.appcompat.widget.SearchView
+import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.ConcatAdapter
@@ -19,7 +21,6 @@ import io.horizontalsystems.bankwallet.modules.market.favorites.EmptyListAdapter
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.helpers.KeyboardHelper
 import io.horizontalsystems.views.inflate
-import kotlinx.android.synthetic.main.fragment_market_search.*
 
 class MarketSearchFragment : BaseFragment() {
 
@@ -30,9 +31,13 @@ class MarketSearchFragment : BaseFragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        toolbar.setNavigationOnClickListener {
+        view.findViewById<Toolbar>(R.id.toolbar).setNavigationOnClickListener {
             findNavController().popBackStack()
         }
+
+        val advancedSearch = view.findViewById<LinearLayout>(R.id.advancedSearch)
+        val searchView = view.findViewById<SearchView>(R.id.searchView)
+        val rvItems = view.findViewById<RecyclerView>(R.id.rvItems)
 
         advancedSearch.setOnSingleClickListener {
             findNavController().navigate(R.id.marketSearchFragment_to_marketAdvancedSearchFragment, null, navOptions())

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/metricchart/MetricChartFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/metricchart/MetricChartFragment.kt
@@ -2,7 +2,10 @@ package io.horizontalsystems.bankwallet.modules.metricchart
 
 import android.os.Bundle
 import android.view.View
+import android.widget.TextView
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.constraintlayout.widget.Group
 import androidx.core.os.bundleOf
 import androidx.core.view.isInvisible
 import androidx.fragment.app.FragmentManager
@@ -10,12 +13,12 @@ import androidx.fragment.app.viewModels
 import com.google.android.material.tabs.TabLayout
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.ui.extensions.BaseBottomSheetDialogFragment
+import io.horizontalsystems.bankwallet.ui.extensions.RateDiffView
 import io.horizontalsystems.bankwallet.ui.extensions.createTextView
 import io.horizontalsystems.chartview.Chart
 import io.horizontalsystems.chartview.ChartView
 import io.horizontalsystems.chartview.models.PointInfo
 import io.horizontalsystems.core.helpers.HudHelper
-import kotlinx.android.synthetic.main.fragment_market_global.*
 
 class MetricChartFragment : BaseBottomSheetDialogFragment(), Chart.Listener, TabLayout.OnTabSelectedListener {
 
@@ -31,17 +34,29 @@ class MetricChartFragment : BaseBottomSheetDialogFragment(), Chart.Listener, Tab
 
     private val viewModel by viewModels<MetricChartViewModel> { MetricChartModule.Factory(metricChartType) }
 
+    private lateinit var tabLayout: TabLayout
+    private lateinit var chartPointsInfo: Group
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         setContentView(R.layout.fragment_market_global)
+
+        val chart = view.findViewById<Chart>(R.id.chart)
+        val topValue = view.findViewById<TextView>(R.id.topValue)
+        val diffValue = view.findViewById<RateDiffView>(R.id.diffValue)
+        val rootView = view.findViewById<ConstraintLayout>(R.id.rootView)
+        val pointInfoDate = view.findViewById<TextView>(R.id.pointInfoDate)
+        val pointInfoValue = view.findViewById<TextView>(R.id.pointInfoValue)
+        tabLayout = view.findViewById(R.id.tabLayout)
+        chartPointsInfo = view.findViewById(R.id.chartPointsInfo)
 
         setTitle(getString(viewModel.title))
         setSubtitle(getString(R.string.MarketGlobalMetrics_Chart))
         setHeaderIconDrawable(context?.let { AppCompatResources.getDrawable(it, R.drawable.ic_chart_24) })
 
         viewModel.description?.let {
-            descriptionText.text = getString(it)
+            view.findViewById<TextView>(R.id.descriptionText).text = getString(it)
         }
         chart.setListener(this)
         setChartTabs()

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/onboarding/OnboardingFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/onboarding/OnboardingFragment.kt
@@ -4,10 +4,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.core.findNavController
-import kotlinx.android.synthetic.main.fragment_no_wallet.*
 
 class OnboardingFragment: BaseFragment() {
 
@@ -17,10 +17,10 @@ class OnboardingFragment: BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        btnCreate.setOnClickListener {
+        view.findViewById<Button>(R.id.btnCreate).setOnClickListener {
             findNavController().navigate(R.id.createAccountFragment, null, navOptions())
         }
-        btnRestore.setOnClickListener {
+        view.findViewById<Button>(R.id.btnRestore).setOnClickListener {
             findNavController().navigate(R.id.restoreMnemonicFragment, null, navOptions())
         }
     }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/qrscanner/QRScannerActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/qrscanner/QRScannerActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.view.View
+import android.widget.Button
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.google.zxing.MultiFormatReader
@@ -14,17 +15,18 @@ import com.google.zxing.client.android.DecodeHintManager
 import com.google.zxing.client.android.Intents
 import com.google.zxing.integration.android.IntentIntegrator
 import com.journeyapps.barcodescanner.BarcodeCallback
+import com.journeyapps.barcodescanner.BarcodeView
 import com.journeyapps.barcodescanner.DefaultDecoderFactory
 import com.journeyapps.barcodescanner.camera.CameraSettings
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.utils.ModuleField
 import io.horizontalsystems.core.helpers.HudHelper
-import kotlinx.android.synthetic.main.activity_qr_scanner.*
 import pub.devrel.easypermissions.AfterPermissionGranted
 import pub.devrel.easypermissions.EasyPermissions
 
 class QRScannerActivity : AppCompatActivity(), EasyPermissions.PermissionCallbacks {
 
+    private lateinit var barcodeView: BarcodeView
     private val callback = BarcodeCallback {
         barcodeView.pause()
         //slow down fast transition to new window
@@ -38,13 +40,15 @@ class QRScannerActivity : AppCompatActivity(), EasyPermissions.PermissionCallbac
 
         setContentView(R.layout.activity_qr_scanner)
 
-        setSupportActionBar(toolbar)
+        barcodeView = findViewById(R.id.barcodeView)
+
+        setSupportActionBar(findViewById(R.id.toolbar))
         supportActionBar?.title = ""
 
         val oldFlags = window.decorView.systemUiVisibility
         window.decorView.systemUiVisibility = oldFlags or View.SYSTEM_UI_FLAG_LAYOUT_STABLE or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
 
-        cancelButton.setOnClickListener {
+        findViewById<Button>(R.id.cancelButton).setOnClickListener {
             onBackPressed()
         }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/receive/ReceiveFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/receive/ReceiveFragment.kt
@@ -2,6 +2,9 @@ package io.horizontalsystems.bankwallet.modules.receive
 
 import android.os.Bundle
 import android.view.View
+import android.widget.Button
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import io.horizontalsystems.bankwallet.R
@@ -11,11 +14,13 @@ import io.horizontalsystems.bankwallet.ui.helpers.AppLayoutHelper
 import io.horizontalsystems.bankwallet.ui.helpers.TextHelper
 import io.horizontalsystems.core.helpers.HudHelper
 import io.horizontalsystems.snackbar.SnackbarGravity
-import kotlinx.android.synthetic.main.view_bottom_sheet_receive.*
 
 class ReceiveFragment: BaseBottomSheetDialogFragment() {
 
     private var listener: Listener? = null
+    private lateinit var receiveAddressView: TextView
+    private lateinit var receiverHint: TextView
+    private lateinit var imgQrCode: ImageView
 
     interface Listener {
         fun shareReceiveAddress(address: String)
@@ -31,6 +36,10 @@ class ReceiveFragment: BaseBottomSheetDialogFragment() {
 
         setContentView(R.layout.view_bottom_sheet_receive)
 
+        receiveAddressView = view.findViewById(R.id.receiveAddressView)
+        receiverHint = view.findViewById(R.id.receiverHint)
+        imgQrCode = view.findViewById(R.id.imgQrCode)
+
         val wallet = arguments?.getParcelable<Wallet>(WALLET_KEY) ?: run { dismiss(); return }
 
         setTitle(activity?.getString(R.string.Deposit_Title, wallet.coin.code))
@@ -42,7 +51,7 @@ class ReceiveFragment: BaseBottomSheetDialogFragment() {
         observeRouter(presenter.router as ReceiveRouter)
         presenter.viewDidLoad()
 
-        btnShare.setOnClickListener { presenter.onShareClick() }
+        view.findViewById<Button>(R.id.btnShare).setOnClickListener { presenter.onShareClick() }
         receiveAddressView.setOnClickListener { presenter.onAddressClick() }
     }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/restore/restoreselectcoins/RestoreSelectCoinsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/restore/restoreselectcoins/RestoreSelectCoinsFragment.kt
@@ -3,6 +3,7 @@ package io.horizontalsystems.bankwallet.modules.restore.restoreselectcoins
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
+import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -17,7 +18,6 @@ import io.horizontalsystems.coinkit.models.Coin
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.helpers.HudHelper
 import io.horizontalsystems.snackbar.SnackbarDuration
-import kotlinx.android.synthetic.main.fragment_manage_wallets.*
 
 class RestoreSelectCoinsFragment : CoinListBaseFragment() {
 
@@ -32,6 +32,8 @@ class RestoreSelectCoinsFragment : CoinListBaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
 
         toolbar.inflateMenu(R.menu.restore_select_coin_menu)
         toolbar.setOnMenuItemClickListener { item ->

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/restoremnemonic/RestoreMnemonicFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/restoremnemonic/RestoreMnemonicFragment.kt
@@ -11,6 +11,9 @@ import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.widget.EditText
+import android.widget.TextView
+import androidx.appcompat.widget.Toolbar
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
@@ -19,21 +22,20 @@ import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.bankwallet.core.utils.Utils
 import io.horizontalsystems.bankwallet.modules.restore.restoreselectcoins.RestoreSelectCoinsFragment.Companion.ACCOUNT_TYPE_KEY
+import io.horizontalsystems.bankwallet.ui.extensions.InputView
 import io.horizontalsystems.core.CoreApp
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.helpers.HudHelper
 import io.horizontalsystems.core.helpers.KeyboardHelper
 import io.horizontalsystems.hdwalletkit.Mnemonic
-import kotlinx.android.synthetic.main.fragment_create_account.*
-import kotlinx.android.synthetic.main.fragment_restore_mnemonic.*
-import kotlinx.android.synthetic.main.fragment_restore_mnemonic.passphrase
-import kotlinx.android.synthetic.main.fragment_restore_mnemonic.passphraseDescription
-import kotlinx.android.synthetic.main.fragment_restore_mnemonic.passphraseToggle
-import kotlinx.android.synthetic.main.fragment_restore_mnemonic.toolbar
-import kotlinx.android.synthetic.main.view_input_address.view.*
+import io.horizontalsystems.views.SettingsViewSwitch
 
 class RestoreMnemonicFragment : BaseFragment() {
     private val viewModel by viewModels<RestoreMnemonicViewModel> { RestoreMnemonicModule.Factory() }
+    private lateinit var wordsInput: EditText
+    private lateinit var passphrase: InputView
+    private lateinit var passphraseDescription: TextView
+    private lateinit var passphraseToggle: SettingsViewSwitch
 
     private val textWatcher = object : TextWatcher {
         override fun afterTextChanged(s: Editable) {
@@ -56,6 +58,13 @@ class RestoreMnemonicFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        wordsInput = view.findViewById(R.id.wordsInput)
+        val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
+        passphrase = view.findViewById(R.id.passphrase)
+        passphraseDescription = view.findViewById(R.id.passphraseDescription)
+        passphraseToggle = view.findViewById(R.id.passphraseToggle)
+
         toolbar.setNavigationOnClickListener {
             findNavController().popBackStack()
         }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/rooteddevice/RootedDeviceActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/rooteddevice/RootedDeviceActivity.kt
@@ -1,10 +1,10 @@
 package io.horizontalsystems.bankwallet.modules.rooteddevice
 
 import android.os.Bundle
+import android.widget.Button
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import io.horizontalsystems.bankwallet.R
-import kotlinx.android.synthetic.main.activity_rooted_device.*
 
 class RootedDeviceActivity : AppCompatActivity() {
 
@@ -14,7 +14,7 @@ class RootedDeviceActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_rooted_device)
 
-        understandButton.setOnClickListener {
+        findViewById<Button>(R.id.understandButton).setOnClickListener {
             viewModel.ignoreRootedDeviceWarningButtonClicked()
         }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/SendActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/SendActivity.kt
@@ -3,6 +3,8 @@ package io.horizontalsystems.bankwallet.modules.send
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.widget.LinearLayout
+import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.commit
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -14,30 +16,32 @@ import io.horizontalsystems.bankwallet.modules.send.submodules.SendSubmoduleFrag
 import io.horizontalsystems.bankwallet.modules.send.submodules.address.SendAddressFragment
 import io.horizontalsystems.bankwallet.modules.send.submodules.amount.SendAmountFragment
 import io.horizontalsystems.bankwallet.modules.send.submodules.confirmation.ConfirmationFragment
-import io.horizontalsystems.bankwallet.modules.send.submodules.fee.SendFeeInfoFragment
 import io.horizontalsystems.bankwallet.modules.send.submodules.fee.SendFeeFragment
+import io.horizontalsystems.bankwallet.modules.send.submodules.fee.SendFeeInfoFragment
 import io.horizontalsystems.bankwallet.modules.send.submodules.hodler.SendHodlerFragment
 import io.horizontalsystems.bankwallet.modules.send.submodules.memo.SendMemoFragment
 import io.horizontalsystems.bankwallet.modules.send.submodules.sendbutton.ProceedButtonView
 import io.horizontalsystems.bankwallet.ui.helpers.AppLayoutHelper
 import io.horizontalsystems.core.helpers.HudHelper
 import io.horizontalsystems.snackbar.SnackbarDuration
-import kotlinx.android.synthetic.main.activity_send.*
 
 class SendActivity : BaseActivity() {
 
     private lateinit var mainPresenter: SendPresenter
 
     private var proceedButtonView: ProceedButtonView? = null
+    private lateinit var sendLinearLayout: LinearLayout
 
     override fun onCreate(savedInstanceState: Bundle?) {
         // prevent fragment recreations by passing null to onCreate
         super.onCreate(null)
         setContentView(R.layout.activity_send)
 
-       overridePendingTransition(R.anim.slide_from_bottom, R.anim.slide_to_top)
+        overridePendingTransition(R.anim.slide_from_bottom, R.anim.slide_to_top)
 
         val wallet: Wallet = intent.getParcelableExtra(WALLET) ?: run { finish(); return }
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
+        sendLinearLayout = findViewById(R.id.sendLinearLayout)
 
         toolbar.title = getString(R.string.Send_Title, wallet.coin.code)
         toolbar.navigationIcon = AppLayoutHelper.getCoinDrawable(this, wallet.coin.type)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/submodules/amount/SendAmountFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/submodules/amount/SendAmountFragment.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ProgressBar
+import android.widget.TextView
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
@@ -13,7 +15,8 @@ import io.horizontalsystems.bankwallet.core.App
 import io.horizontalsystems.bankwallet.entities.Wallet
 import io.horizontalsystems.bankwallet.modules.send.SendModule
 import io.horizontalsystems.bankwallet.modules.send.submodules.SendSubmoduleFragment
-import kotlinx.android.synthetic.main.view_amount_input.*
+import io.horizontalsystems.bankwallet.ui.extensions.AmountInputView
+import io.horizontalsystems.views.ViewState
 
 class SendAmountFragment(
         private val wallet: Wallet,
@@ -22,6 +25,10 @@ class SendAmountFragment(
     : SendSubmoduleFragment() {
 
     private val presenter by activityViewModels<SendAmountPresenter> { SendAmountModule.Factory(wallet, sendHandler) }
+    private lateinit var availableBalanceValue: TextView
+    private lateinit var processSpinner: ProgressBar
+    private lateinit var txtHintError: TextView
+    private lateinit var background: ViewState
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.view_amount_input, container, false)
@@ -33,6 +40,12 @@ class SendAmountFragment(
 
         val presenterView = presenter.view as SendAmountView
         presenter.moduleDelegate = amountModuleDelegate
+
+        val amountInput = view.findViewById<AmountInputView>(R.id.amountInput)
+        availableBalanceValue = view.findViewById(R.id.availableBalanceValue)
+        processSpinner = view.findViewById(R.id.processSpinner)
+        txtHintError = view.findViewById(R.id.txtHintError)
+        background = view.findViewById(R.id.background)
 
         amountInput.onTextChangeCallback = { _, new -> presenter.onAmountChange(new ?: "") }
         amountInput.onTapSecondaryCallback = { presenter.onSwitchClick() }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/submodules/confirmation/ConfirmationFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/submodules/confirmation/ConfirmationFragment.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout
+import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Observer
 import io.horizontalsystems.bankwallet.R
@@ -17,7 +19,6 @@ import io.horizontalsystems.bankwallet.modules.send.submodules.confirmation.subv
 import io.horizontalsystems.bankwallet.modules.send.submodules.confirmation.subviews.ConfirmationSecondaryView
 import io.horizontalsystems.bankwallet.modules.send.submodules.confirmation.subviews.ConfirmationSendButtonView
 import io.horizontalsystems.core.helpers.HudHelper
-import kotlinx.android.synthetic.main.fragment_confirmation.*
 import java.net.UnknownHostException
 
 class ConfirmationFragment(private var sendPresenter: SendPresenter?) : BaseFragment() {
@@ -34,6 +35,10 @@ class ConfirmationFragment(private var sendPresenter: SendPresenter?) : BaseFrag
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
+        val confirmationLinearLayout = view.findViewById<LinearLayout>(R.id.confirmationLinearLayout)
+
         toolbar.setNavigationOnClickListener {
             parentFragmentManager.popBackStack()
         }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/submodules/confirmation/subviews/ConfirmationPrimaryView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/submodules/confirmation/subviews/ConfirmationPrimaryView.kt
@@ -2,17 +2,42 @@ package io.horizontalsystems.bankwallet.modules.send.submodules.confirmation.sub
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.View
+import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.modules.send.submodules.confirmation.SendConfirmationModule
-import kotlinx.android.synthetic.main.view_confirmation_primary_item_view.view.*
 
 class ConfirmationPrimaryView : ConstraintLayout {
 
+    private var primaryName: TextView
+    private var primaryAmount: TextView
+    private var secondaryName: TextView
+    private var secondaryAmount: TextView
+    private var domainValue: TextView
+    private var domainTitle: TextView
+    private var borderDomain: TextView
+    private var receiverValue: TextView
+    private var borderMemo: View
+    private var memoLayout: ConstraintLayout
+    private var memoValue: TextView
+
     init {
-        inflate(context, R.layout.view_confirmation_primary_item_view, this)
+        val rootView = inflate(context, R.layout.view_confirmation_primary_item_view, this)
+        primaryName = rootView.findViewById(R.id.primaryName)
+        primaryAmount = rootView.findViewById(R.id.primaryAmount)
+        secondaryName = rootView.findViewById(R.id.secondaryName)
+        secondaryAmount = rootView.findViewById(R.id.secondaryAmount)
+        domainValue = rootView.findViewById(R.id.domainValue)
+        domainTitle = rootView.findViewById(R.id.domainTitle)
+        borderDomain = rootView.findViewById(R.id.borderDomain)
+        receiverValue = rootView.findViewById(R.id.receiverValue)
+        borderMemo = rootView.findViewById(R.id.borderMemo)
+        memoLayout = rootView.findViewById(R.id.memoLayout)
+        memoValue = rootView.findViewById(R.id.memoValue)
     }
+
 
     constructor(context: Context) : super(context)
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/submodules/confirmation/subviews/ConfirmationSecondaryView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/submodules/confirmation/subviews/ConfirmationSecondaryView.kt
@@ -2,18 +2,32 @@ package io.horizontalsystems.bankwallet.modules.send.submodules.confirmation.sub
 
 import android.content.Context
 import android.util.AttributeSet
+import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.stringResId
 import io.horizontalsystems.bankwallet.modules.send.submodules.confirmation.SendConfirmationModule
 import io.horizontalsystems.core.helpers.DateHelper
-import kotlinx.android.synthetic.main.view_confirmation_secondary_item_view.view.*
 
 class ConfirmationSecondaryView : ConstraintLayout {
 
+    private var feeLayout: LinearLayout
+    private var feeValue: TextView
+    private var timeWrapper: LinearLayout
+    private var timeValue: TextView
+    private var lockTimeWrapper: LinearLayout
+    private var textLockTime: TextView
+
     init {
-        inflate(context, R.layout.view_confirmation_secondary_item_view, this)
+        val rootView = inflate(context, R.layout.view_confirmation_secondary_item_view, this)
+        feeLayout = rootView.findViewById(R.id.feeLayout)
+        feeValue = rootView.findViewById(R.id.feeValue)
+        timeWrapper = rootView.findViewById(R.id.timeWrapper)
+        timeValue = rootView.findViewById(R.id.timeValue)
+        lockTimeWrapper = rootView.findViewById(R.id.lockTimeWrapper)
+        textLockTime = rootView.findViewById(R.id.textLockTime)
     }
 
     constructor(context: Context) : super(context)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/submodules/confirmation/subviews/ConfirmationSendButtonView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/submodules/confirmation/subviews/ConfirmationSendButtonView.kt
@@ -2,16 +2,25 @@ package io.horizontalsystems.bankwallet.modules.send.submodules.confirmation.sub
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.View
+import android.widget.ProgressBar
+import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.modules.send.submodules.confirmation.SendConfirmationModule
-import kotlinx.android.synthetic.main.view_button_with_progressbar.view.*
 
 class ConfirmationSendButtonView : ConstraintLayout {
 
+    private var buttonTextView: TextView
+    private var progressBar: ProgressBar
+    private var buttonWrapper: View
+
     init {
-        inflate(context, R.layout.view_button_with_progressbar, this)
+        val rootView = inflate(context, R.layout.view_button_with_progressbar, this)
+        buttonTextView = rootView.findViewById(R.id.buttonTextView)
+        progressBar = rootView.findViewById(R.id.progressBar)
+        buttonWrapper = rootView.findViewById(R.id.buttonWrapper)
     }
 
     constructor(context: Context) : super(context)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/submodules/fee/SendFeeFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/submodules/fee/SendFeeFragment.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
+import androidx.constraintlayout.widget.Group
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
@@ -18,7 +20,6 @@ import io.horizontalsystems.bankwallet.ui.extensions.SelectorItem
 import io.horizontalsystems.bankwallet.ui.helpers.TextHelper
 import io.horizontalsystems.coinkit.models.Coin
 import io.horizontalsystems.seekbar.FeeSeekBar
-import kotlinx.android.synthetic.main.view_send_fee.*
 
 class SendFeeFragment(
         private val coin: Coin,
@@ -28,6 +29,16 @@ class SendFeeFragment(
     : SendSubmoduleFragment() {
 
     private val presenter by activityViewModels<SendFeePresenter> { SendFeeModule.Factory(coin, sendHandler, feeModuleDelegate, customPriorityUnit) }
+    private lateinit var txError: TextView
+    private lateinit var txFeeLoading: TextView
+    private lateinit var customFeeSeekBar: FeeSeekBar
+    private lateinit var speedViews: Group
+    private lateinit var txFeePrimary: TextView
+    private lateinit var txFeeSecondary: TextView
+    private lateinit var txSpeedMenu: TextView
+    private lateinit var feeError: TextView
+    private lateinit var lowFeeWarning: TextView
+    private lateinit var txFeeTitle: TextView
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.view_send_fee, container, false)
@@ -38,13 +49,23 @@ class SendFeeFragment(
         super.onViewCreated(view, savedInstanceState)
 
         val presenterView = presenter.view as SendFeeView
+        txError = view.findViewById(R.id.txError)
+        txFeeLoading = view.findViewById(R.id.txFeeLoading)
+        customFeeSeekBar = view.findViewById(R.id.customFeeSeekBar)
+        speedViews = view.findViewById(R.id.speedViews)
+        txFeePrimary = view.findViewById(R.id.txFeePrimary)
+        txFeeSecondary = view.findViewById(R.id.txFeeSecondary)
+        txSpeedMenu = view.findViewById(R.id.txSpeedMenu)
+        feeError = view.findViewById(R.id.feeError)
+        lowFeeWarning = view.findViewById(R.id.lowFeeWarning)
+        txFeeTitle = view.findViewById(R.id.txFeeTitle)
 
         txError.isVisible = false
 
-        txSpeedMenuClickArea.setOnClickListener {
+        view.findViewById<View>(R.id.txSpeedMenuClickArea).setOnClickListener {
             presenter.onClickFeeRatePriority()
         }
-        feeInfoImageClickArea.setOnClickListener {
+        view.findViewById<View>(R.id.feeInfoImageClickArea).setOnClickListener {
             (activity as? SendActivity)?.showFeeInfo()
         }
         txFeeLoading.isVisible = false

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/submodules/fee/SendFeeInfoFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/submodules/fee/SendFeeInfoFragment.kt
@@ -4,9 +4,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.widget.Toolbar
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
-import kotlinx.android.synthetic.main.fragment_fee_info.*
 
 class SendFeeInfoFragment : BaseFragment() {
 
@@ -16,7 +16,7 @@ class SendFeeInfoFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        toolbar.setOnMenuItemClickListener { item ->
+        view.findViewById<Toolbar>(R.id.toolbar).setOnMenuItemClickListener { item ->
             when (item.itemId) {
                 R.id.menuClose -> {
                     parentFragmentManager.popBackStack()

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/submodules/hodler/SendHodlerFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/submodules/hodler/SendHodlerFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Observer
 import io.horizontalsystems.bankwallet.R
@@ -12,7 +13,6 @@ import io.horizontalsystems.bankwallet.modules.send.SendModule
 import io.horizontalsystems.bankwallet.modules.send.submodules.SendSubmoduleFragment
 import io.horizontalsystems.bankwallet.ui.extensions.SelectorDialog
 import io.horizontalsystems.bankwallet.ui.extensions.SelectorItem
-import kotlinx.android.synthetic.main.view_hodler_input.*
 
 class SendHodlerFragment(
         private val hodlerModuleDelegate: SendHodlerModule.IHodlerModuleDelegate,
@@ -29,6 +29,7 @@ class SendHodlerFragment(
         super.onViewCreated(view, savedInstanceState)
 
         val presenterView = presenter.view as SendHodlerView
+        val lockTimeMenu = view.findViewById<TextView>(R.id.lockTimeMenu)
 
         view.setOnClickListener {
             presenter.onClickLockTimeInterval()

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/submodules/memo/SendMemoFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/submodules/memo/SendMemoFragment.kt
@@ -7,12 +7,12 @@ import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.EditText
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Observer
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.modules.send.SendModule
 import io.horizontalsystems.bankwallet.modules.send.submodules.SendSubmoduleFragment
-import kotlinx.android.synthetic.main.view_send_memo.*
 
 
 class SendMemoFragment(private val maxLength: Int,
@@ -27,6 +27,7 @@ class SendMemoFragment(private val maxLength: Int,
         super.onViewCreated(view, savedInstanceState)
 
         val presenterView = presenter.view as SendMemoView
+        val memoInput = view.findViewById<EditText>(R.id.memoInput)
 
         memoInput.addTextChangedListener(object : TextWatcher {
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/submodules/sendbutton/ProceedButtonView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/submodules/sendbutton/ProceedButtonView.kt
@@ -2,15 +2,18 @@ package io.horizontalsystems.bankwallet.modules.send.submodules.sendbutton
 
 import android.content.Context
 import android.util.AttributeSet
+import android.widget.Button
 import androidx.constraintlayout.widget.ConstraintLayout
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.setOnSingleClickListener
-import kotlinx.android.synthetic.main.view_button_proceed.view.*
 
 class ProceedButtonView : ConstraintLayout {
 
+    private var btnProceed: Button
+
     init {
-        inflate(context, R.layout.view_button_proceed, this)
+        val rootView = inflate(context, R.layout.view_button_proceed, this)
+        btnProceed = rootView.findViewById(R.id.btnProceed)
     }
 
     constructor(context: Context) : super(context)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/sendevm/SendEvmFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/sendevm/SendEvmFragment.kt
@@ -5,7 +5,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.ProgressBar
+import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.navigation.navGraphViewModels
@@ -18,13 +22,11 @@ import io.horizontalsystems.bankwallet.modules.qrscanner.QRScannerActivity
 import io.horizontalsystems.bankwallet.modules.sendevm.confirmation.SendEvmConfirmationModule
 import io.horizontalsystems.bankwallet.modules.swap.tradeoptions.Caution
 import io.horizontalsystems.bankwallet.modules.swap.tradeoptions.RecipientAddressViewModel
+import io.horizontalsystems.bankwallet.ui.extensions.AddressInputView
+import io.horizontalsystems.bankwallet.ui.extensions.AmountInputView
 import io.horizontalsystems.bankwallet.ui.helpers.AppLayoutHelper
 import io.horizontalsystems.core.findNavController
-import kotlinx.android.synthetic.main.fragment_send_evm.*
-import kotlinx.android.synthetic.main.fragment_send_evm.amountInput
-import kotlinx.android.synthetic.main.fragment_send_evm.availableBalanceValue
-import kotlinx.android.synthetic.main.fragment_send_evm.background
-import kotlinx.android.synthetic.main.fragment_send_evm.txtHintError
+import io.horizontalsystems.views.ViewState
 
 class SendEvmFragment : BaseFragment() {
 
@@ -34,6 +36,9 @@ class SendEvmFragment : BaseFragment() {
     private val availableBalanceViewModel by viewModels<SendAvailableBalanceViewModel> { vmFactory }
     private val amountViewModel by viewModels<AmountInputViewModel> { vmFactory }
     private val recipientAddressViewModel by viewModels<RecipientAddressViewModel> { vmFactory }
+
+    private lateinit var txtHintError: TextView
+    private lateinit var background: ViewState
 
     private val qrScannerResultLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
         when (result.resultCode) {
@@ -53,6 +58,14 @@ class SendEvmFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
+        val availableBalanceSpinner = view.findViewById<ProgressBar>(R.id.availableBalanceSpinner)
+        val availableBalanceValue = view.findViewById<TextView>(R.id.availableBalanceValue)
+        val amountInput = view.findViewById<AmountInputView>(R.id.amountInput)
+        val btnProceed = view.findViewById<Button>(R.id.btnProceed)
+        txtHintError = view.findViewById(R.id.txtHintError)
+        background = view.findViewById(R.id.background)
 
         toolbar.title = getString(R.string.Send_Title, wallet.coin.code)
         toolbar.navigationIcon = AppLayoutHelper.getCoinDrawable(requireContext(), wallet.coin.type)
@@ -102,7 +115,7 @@ class SendEvmFragment : BaseFragment() {
             setAmountInputCaution(caution)
         })
 
-        recipientAddressInputView.setViewModel(recipientAddressViewModel, viewLifecycleOwner, {
+        view.findViewById<AddressInputView>(R.id.recipientAddressInputView).setViewModel(recipientAddressViewModel, viewLifecycleOwner, {
             val intent = QRScannerActivity.getIntentForFragment(this)
             qrScannerResultLauncher.launch(intent)
         })

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/sendevm/confirmation/SendEvmConfirmationFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/sendevm/confirmation/SendEvmConfirmationFragment.kt
@@ -6,6 +6,8 @@ import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.viewModels
 import androidx.navigation.navGraphViewModels
 import io.horizontalsystems.bankwallet.R
@@ -16,6 +18,7 @@ import io.horizontalsystems.bankwallet.core.setOnSingleClickListener
 import io.horizontalsystems.bankwallet.modules.sendevm.SendEvmData
 import io.horizontalsystems.bankwallet.modules.sendevm.SendEvmModule
 import io.horizontalsystems.bankwallet.modules.sendevm.SendEvmViewModel
+import io.horizontalsystems.bankwallet.modules.sendevmtransaction.SendEvmTransactionView
 import io.horizontalsystems.bankwallet.modules.sendevmtransaction.SendEvmTransactionViewModel
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.helpers.HudHelper
@@ -23,7 +26,6 @@ import io.horizontalsystems.ethereumkit.models.Address
 import io.horizontalsystems.ethereumkit.models.TransactionData
 import io.horizontalsystems.snackbar.CustomSnackbar
 import io.horizontalsystems.snackbar.SnackbarDuration
-import kotlinx.android.synthetic.main.fragment_confirmation_send_evm.*
 
 class SendEvmConfirmationFragment : BaseFragment() {
 
@@ -54,7 +56,10 @@ class SendEvmConfirmationFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        toolbar.setOnMenuItemClickListener { item ->
+
+        val sendButton = view.findViewById<Button>(R.id.sendButton)
+
+        view.findViewById<Toolbar>(R.id.toolbar).setOnMenuItemClickListener { item ->
             when (item.itemId) {
                 R.id.menuCancel -> {
                     findNavController().popBackStack()
@@ -85,7 +90,7 @@ class SendEvmConfirmationFragment : BaseFragment() {
             findNavController().popBackStack()
         })
 
-        sendEvmTransactionView.init(
+        view.findViewById<SendEvmTransactionView>(R.id.sendEvmTransactionView).init(
                 sendViewModel,
                 feeViewModel,
                 viewLifecycleOwner,

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/sendevmtransaction/SendEvmTransactionView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/sendevmtransaction/SendEvmTransactionView.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.LifecycleOwner
@@ -11,19 +12,25 @@ import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.ethereum.EthereumFeeViewModel
 import io.horizontalsystems.bankwallet.core.setOnSingleClickListener
+import io.horizontalsystems.bankwallet.ui.FeeSelectorView
 import io.horizontalsystems.bankwallet.ui.helpers.TextHelper
 import io.horizontalsystems.core.helpers.HudHelper
 import io.horizontalsystems.views.ListPosition
 import io.horizontalsystems.views.inflate
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.view_holder_title_value_hex.*
-import kotlinx.android.synthetic.main.view_send_evm_transaction.view.*
 
 class SendEvmTransactionView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0)
     : ConstraintLayout(context, attrs, defStyleAttr) {
 
+    private var feeSelectorView: FeeSelectorView
+    private var recyclerView: RecyclerView
+    private var error: TextView
+
     init {
-        inflate(context, R.layout.view_send_evm_transaction, this)
+        val rootView = inflate(context, R.layout.view_send_evm_transaction, this)
+        feeSelectorView = rootView.findViewById(R.id.feeSelectorView)
+        recyclerView = rootView.findViewById(R.id.recyclerView)
+        error = rootView.findViewById(R.id.error)
     }
 
     fun init(
@@ -122,6 +129,11 @@ class SendEvmTransactionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>(
     }
 
     class SubheadViewHolder(override val containerView: View) : RecyclerView.ViewHolder(containerView), LayoutContainer {
+
+        private val titleTextView = containerView.findViewById<TextView>(R.id.titleTextView)
+        private val valueTextView = containerView.findViewById<TextView>(R.id.valueTextView)
+        private val backgroundView = containerView.findViewById<View>(R.id.backgroundView)
+
         fun bind(item: ViewItem.Subhead, position: ListPosition) {
             titleTextView.text = item.title
             valueTextView.text = item.value
@@ -135,6 +147,11 @@ class SendEvmTransactionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>(
     }
 
     class TitleValueHexViewHolder(override val containerView: View) : RecyclerView.ViewHolder(containerView), LayoutContainer {
+
+        private val titleTextView = containerView.findViewById<TextView>(R.id.titleTextView)
+        private val valueTextView = containerView.findViewById<TextView>(R.id.valueTextView)
+        private val backgroundView = containerView.findViewById<View>(R.id.backgroundView)
+
         fun bind(title: String, valueTitle: String, value: String, position: ListPosition) {
             titleTextView.text = title
             valueTextView.text = valueTitle
@@ -153,6 +170,11 @@ class SendEvmTransactionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>(
     }
 
     class TitleValueViewHolder(override val containerView: View) : RecyclerView.ViewHolder(containerView), LayoutContainer {
+
+        private val titleTextView = containerView.findViewById<TextView>(R.id.titleTextView)
+        private val valueTextView = containerView.findViewById<TextView>(R.id.valueTextView)
+        private val backgroundView = containerView.findViewById<View>(R.id.backgroundView)
+
         fun bind(title: String, value: String, type: ValueType, position: ListPosition) {
             titleTextView.text = title
             valueTextView.text = value

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/about/AboutFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/about/AboutFragment.kt
@@ -7,15 +7,17 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
+import androidx.appcompat.widget.Toolbar
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import io.horizontalsystems.bankwallet.R
-import io.horizontalsystems.bankwallet.core.BaseFragment
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.BuildConfig
+import io.horizontalsystems.bankwallet.R
+import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.bankwallet.modules.markdown.MarkdownFragment
 import io.horizontalsystems.bankwallet.modules.settings.main.MainSettingsAdapter
 import io.horizontalsystems.bankwallet.modules.settings.main.SettingsMenuItem
@@ -23,8 +25,6 @@ import io.horizontalsystems.core.helpers.HudHelper
 import io.horizontalsystems.views.ListPosition
 import io.horizontalsystems.views.inflate
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.fragment_about.*
-import kotlinx.android.synthetic.main.view_holder_about_app_header.*
 
 class AboutFragment : BaseFragment() {
 
@@ -37,7 +37,7 @@ class AboutFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        toolbar.setNavigationOnClickListener {
+        view.findViewById<Toolbar>(R.id.toolbar).setNavigationOnClickListener {
             findNavController().popBackStack()
         }
 
@@ -89,7 +89,7 @@ class AboutFragment : BaseFragment() {
 
         val headerAdapter = AboutAppHeaderAdapter(getAppVersion())
 
-        aboutRecyclerview.adapter = ConcatAdapter(headerAdapter, menuItemsAdapter)
+        view.findViewById<RecyclerView>(R.id.aboutRecyclerview).adapter = ConcatAdapter(headerAdapter, menuItemsAdapter)
 
         //observe LiveData
 
@@ -162,6 +162,8 @@ class AboutAppHeaderAdapter(private val appVersion: String) : RecyclerView.Adapt
     }
 
     class HeaderViewHolder(override val containerView: View) : RecyclerView.ViewHolder(containerView), LayoutContainer {
+
+        private val versionNameText = containerView.findViewById<TextView>(R.id.versionNameText)
 
         fun bind(version: String) {
             versionNameText.text = version

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/appstatus/AppStatusFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/appstatus/AppStatusFragment.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
+import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import io.horizontalsystems.bankwallet.R
@@ -11,12 +13,12 @@ import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.helpers.DateHelper
 import io.horizontalsystems.core.helpers.HudHelper
-import kotlinx.android.synthetic.main.fragment_app_status.*
 import java.util.*
 
 class AppStatusFragment : BaseFragment() {
 
     private val presenter by viewModels<AppStatusPresenter> { AppStatusModule.Factory() }
+    private lateinit var textAppStatus: TextView
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_app_status, container, false)
@@ -24,6 +26,10 @@ class AppStatusFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
+        textAppStatus = view.findViewById(R.id.textAppStatus)
+
         toolbar.setNavigationOnClickListener {
             findNavController().popBackStack()
         }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/experimental/ExperimentalFeaturesFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/experimental/ExperimentalFeaturesFragment.kt
@@ -4,13 +4,14 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.bankwallet.core.setOnSingleClickListener
 import io.horizontalsystems.core.findNavController
-import kotlinx.android.synthetic.main.fragment_experimental_features.*
+import io.horizontalsystems.views.SettingsView
 
 class ExperimentalFeaturesFragment : BaseFragment() {
 
@@ -22,7 +23,7 @@ class ExperimentalFeaturesFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        toolbar.setNavigationOnClickListener {
+        view.findViewById<Toolbar>(R.id.toolbar).setNavigationOnClickListener {
             findNavController().popBackStack()
         }
 
@@ -32,7 +33,7 @@ class ExperimentalFeaturesFragment : BaseFragment() {
             findNavController().navigate(R.id.experimentalFeaturesFragment_to_bitcoinHodlingFragment, null, navOptions())
         })
 
-        bitcoinHodling.setOnSingleClickListener {
+        view.findViewById<SettingsView>(R.id.bitcoinHodling).setOnSingleClickListener {
             presenter.didTapBitcoinHodling()
         }
     }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/experimental/bitcoinhodling/BitcoinHodlingFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/experimental/bitcoinhodling/BitcoinHodlingFragment.kt
@@ -4,12 +4,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.core.findNavController
-import kotlinx.android.synthetic.main.fragment_bitcoin_hodling.*
+import io.horizontalsystems.views.SettingsViewSwitch
 
 class BitcoinHodlingFragment : BaseFragment() {
 
@@ -21,11 +22,12 @@ class BitcoinHodlingFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        toolbar.setNavigationOnClickListener {
+        view.findViewById<Toolbar>(R.id.toolbar).setNavigationOnClickListener {
             findNavController().popBackStack()
         }
 
         val hodlingView = presenter.view as BitcoinHodlingView
+        val switchLockTime = view.findViewById<SettingsViewSwitch>(R.id.switchLockTime)
 
         hodlingView.lockTimeEnabledLiveEvent.observe(viewLifecycleOwner, Observer { enabled ->
             switchLockTime.setChecked(enabled)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/faq/FaqFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/faq/FaqFragment.kt
@@ -4,6 +4,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ProgressBar
+import android.widget.TextView
+import androidx.appcompat.widget.Toolbar
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
@@ -15,19 +18,19 @@ import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.bankwallet.entities.Faq
-import io.horizontalsystems.bankwallet.modules.settings.guides.ErrorAdapter
 import io.horizontalsystems.bankwallet.modules.markdown.MarkdownFragment
+import io.horizontalsystems.bankwallet.modules.settings.guides.ErrorAdapter
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.views.ListPosition
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.fragment_faq_list.*
-import kotlinx.android.synthetic.main.view_holder_faq_item.*
 
 class FaqListFragment: BaseFragment(), FaqListAdapter.Listener {
 
     private val viewModel by viewModels<FaqViewModel> { FaqModule.Factory() }
     private val adapter = FaqListAdapter(this)
     private val errorAdapter = ErrorAdapter()
+    private lateinit var faqListRecyclerview: RecyclerView
+    private lateinit var toolbarSpinner: ProgressBar
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_faq_list, container, false)
@@ -36,7 +39,10 @@ class FaqListFragment: BaseFragment(), FaqListAdapter.Listener {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        toolbar.setNavigationOnClickListener {
+        faqListRecyclerview = view.findViewById(R.id.faqListRecyclerview)
+        toolbarSpinner = view.findViewById(R.id.toolbarSpinner)
+
+        view.findViewById<Toolbar>(R.id.toolbar).setNavigationOnClickListener {
             findNavController().popBackStack()
         }
 
@@ -102,6 +108,7 @@ class FaqListAdapter(private val listener: Listener) : ListAdapter<FaqItem, View
 
 class ViewHolderFaq(override val containerView: View, listener: FaqListAdapter.Listener) : RecyclerView.ViewHolder(containerView), LayoutContainer {
     private var faqItem: FaqItem? = null
+    private val faqTitleText = containerView.findViewById<TextView>(R.id.faqTitleText)
 
     init {
         containerView.setOnClickListener {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/guides/ErrorAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/guides/ErrorAdapter.kt
@@ -2,12 +2,12 @@ package io.horizontalsystems.bankwallet.modules.settings.guides
 
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.LocalizedException
 import io.horizontalsystems.views.inflate
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.view_holder_error.*
 import java.net.UnknownHostException
 
 class ErrorAdapter : RecyclerView.Adapter<ErrorViewHolder>() {
@@ -34,6 +34,8 @@ class ErrorAdapter : RecyclerView.Adapter<ErrorViewHolder>() {
 }
 
 class ErrorViewHolder(override val containerView: View) : RecyclerView.ViewHolder(containerView), LayoutContainer {
+    private val message = containerView.findViewById<TextView>(R.id.message)
+
     fun bind(error: Throwable) {
         message.text =  when (error) {
             is UnknownHostException -> containerView.context.getString(R.string.Hud_Text_NoInternet)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/guides/GuidesFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/guides/GuidesFragment.kt
@@ -4,20 +4,21 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ProgressBar
+import androidx.appcompat.widget.Toolbar
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import io.horizontalsystems.core.findNavController
 import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.bankwallet.entities.Guide
 import io.horizontalsystems.bankwallet.modules.markdown.MarkdownFragment
 import io.horizontalsystems.bankwallet.modules.transactions.FilterAdapter
-import kotlinx.android.synthetic.main.fragment_guides.*
-import kotlinx.android.synthetic.main.fragment_guides.toolbar
+import io.horizontalsystems.core.findNavController
 
 class GuidesFragment : BaseFragment(), GuidesAdapter.Listener, FilterAdapter.Listener {
 
@@ -25,6 +26,9 @@ class GuidesFragment : BaseFragment(), GuidesAdapter.Listener, FilterAdapter.Lis
     private val errorAdapter = ErrorAdapter()
     private val guidesAdapter = GuidesAdapter(this)
     private val filterAdapter = FilterAdapter(this)
+    private lateinit var recyclerTags: RecyclerView
+    private lateinit var recyclerGuides: RecyclerView
+    private lateinit var toolbarSpinner: ProgressBar
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_guides, container, false)
@@ -33,9 +37,13 @@ class GuidesFragment : BaseFragment(), GuidesAdapter.Listener, FilterAdapter.Lis
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        toolbar.setNavigationOnClickListener {
+        view.findViewById<Toolbar>(R.id.toolbar).setNavigationOnClickListener {
             findNavController().popBackStack()
         }
+
+        recyclerTags = view.findViewById(R.id.recyclerTags)
+        recyclerGuides = view.findViewById(R.id.recyclerGuides)
+        toolbarSpinner = view.findViewById(R.id.toolbarSpinner)
 
         recyclerTags.adapter = filterAdapter
         recyclerGuides.adapter = ConcatAdapter(errorAdapter, guidesAdapter)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/guides/ViewHolderGuide.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/guides/ViewHolderGuide.kt
@@ -1,13 +1,15 @@
 package io.horizontalsystems.bankwallet.modules.settings.guides
 
 import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.squareup.picasso.Picasso
+import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.setOnSingleClickListener
 import io.horizontalsystems.bankwallet.entities.Guide
 import io.horizontalsystems.core.helpers.DateHelper
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.view_holder_guide_preview.*
 
 class ViewHolderGuide(override val containerView: View, private val listener: ClickListener) : RecyclerView.ViewHolder(containerView), LayoutContainer {
 
@@ -16,6 +18,9 @@ class ViewHolderGuide(override val containerView: View, private val listener: Cl
     }
 
     private var guide: Guide? = null
+    private val title = containerView.findViewById<TextView>(R.id.title)
+    private val date = containerView.findViewById<TextView>(R.id.date)
+    private val image = containerView.findViewById<ImageView>(R.id.image)
 
     init {
         containerView.setOnSingleClickListener {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/main/MainSettingsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/main/MainSettingsFragment.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.BuildConfig
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
@@ -18,11 +19,11 @@ import io.horizontalsystems.bankwallet.modules.walletconnect.list.WalletConnectL
 import io.horizontalsystems.core.getNavigationResult
 import io.horizontalsystems.languageswitcher.LanguageSettingsFragment
 import io.horizontalsystems.views.ListPosition
-import kotlinx.android.synthetic.main.fragment_settings.*
 
 class MainSettingsFragment : BaseFragment() {
 
     private val presenter by viewModels<MainSettingsPresenter> { MainSettingsModule.Factory() }
+    private lateinit var settingsRecyclerView: RecyclerView
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_settings, container, false)
@@ -30,6 +31,8 @@ class MainSettingsFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        settingsRecyclerView = view.findViewById(R.id.settingsRecyclerView)
 
         subscribeToRouterEvents(presenter.router as MainSettingsRouter)
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/notifications/NotificationsFragment.kt
@@ -5,6 +5,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.FrameLayout
+import android.widget.TextView
+import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
@@ -16,10 +20,9 @@ import io.horizontalsystems.bankwallet.modules.settings.notifications.bottommenu
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.views.ListPosition
 import io.horizontalsystems.views.SettingsViewDropdown
+import io.horizontalsystems.views.SettingsViewSwitch
 import io.horizontalsystems.views.inflate
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.fragment_notifications.*
-import kotlinx.android.synthetic.main.view_holder_notification_coin_name.*
 
 
 class NotificationsFragment : BaseFragment(), NotificationItemsAdapter.Listener {
@@ -27,6 +30,13 @@ class NotificationsFragment : BaseFragment(), NotificationItemsAdapter.Listener 
     private val viewModel by viewModels<NotificationsViewModel> { NotificationsModule.Factory() }
 
     private lateinit var notificationItemsAdapter: NotificationItemsAdapter
+    private lateinit var buttonAndroidSettings: Button
+    private lateinit var deactivateAll: FrameLayout
+    private lateinit var notifications: RecyclerView
+    private lateinit var switchNotification: SettingsViewSwitch
+    private lateinit var textDescription: TextView
+    private lateinit var textWarning: TextView
+    private lateinit var deactivateAllText: TextView
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_notifications, container, false)
@@ -34,9 +44,17 @@ class NotificationsFragment : BaseFragment(), NotificationItemsAdapter.Listener 
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        toolbar.setNavigationOnClickListener {
+        view.findViewById<Toolbar>(R.id.toolbar).setNavigationOnClickListener {
             findNavController().popBackStack()
         }
+
+        buttonAndroidSettings = view.findViewById(R.id.buttonAndroidSettings)
+        deactivateAll = view.findViewById(R.id.deactivateAll)
+        notifications = view.findViewById(R.id.notifications)
+        switchNotification = view.findViewById(R.id.switchNotification)
+        textDescription = view.findViewById(R.id.textDescription)
+        textWarning = view.findViewById(R.id.textWarning)
+        deactivateAllText= view.findViewById(R.id.deactivateAllText)
 
         buttonAndroidSettings.setOnSingleClickListener {
             viewModel.openSettings()
@@ -160,6 +178,8 @@ class NotificationItemsAdapter(private val listener: Listener) : RecyclerView.Ad
 
 class NotificationCoinNameViewHolder(override val containerView: View)
     : RecyclerView.ViewHolder(containerView), LayoutContainer {
+
+    private val coinName = containerView.findViewById<TextView>(R.id.coinName)
 
     fun bind(item: NotificationViewItem) {
         coinName.text = item.coinName

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/notifications/bottommenu/BottomNotificationMenu.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/notifications/bottommenu/BottomNotificationMenu.kt
@@ -3,6 +3,8 @@ package io.horizontalsystems.bankwallet.modules.settings.notifications.bottommen
 import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
@@ -15,9 +17,6 @@ import io.horizontalsystems.bankwallet.ui.extensions.BaseBottomSheetDialogFragme
 import io.horizontalsystems.coinkit.models.CoinType
 import io.horizontalsystems.views.inflate
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.fragment_bottom_notification_menu.*
-import kotlinx.android.synthetic.main.view_holder_notification_menu_item.*
-import kotlinx.android.synthetic.main.view_holder_notification_menu_section_header.*
 
 class BottomNotificationMenu(
         private val mode: NotificationMenuMode,
@@ -38,7 +37,7 @@ class BottomNotificationMenu(
 
         val itemsAdapter = NotificationMenuItemsAdapter(this)
 
-        menuItems.adapter = itemsAdapter
+        view.findViewById<RecyclerView>(R.id.menuItems).adapter = itemsAdapter
 
         viewModel.menuItemsLiveData.observe(viewLifecycleOwner, Observer { menuItems ->
             itemsAdapter.items = menuItems
@@ -115,6 +114,9 @@ class NotificationMenuItemsAdapter(private val listener: Listener) : RecyclerVie
 class NotificationItemViewHolder(override val containerView: View, val onClick: (position: Int) -> Unit)
     : RecyclerView.ViewHolder(containerView), LayoutContainer {
 
+    private val itemTitle = containerView.findViewById<TextView>(R.id.itemTitle)
+    private val checkMark = containerView.findViewById<ImageView>(R.id.checkMark)
+
     init {
         containerView.setOnClickListener {
             onClick(bindingAdapterPosition)
@@ -129,6 +131,9 @@ class NotificationItemViewHolder(override val containerView: View, val onClick: 
 
 class NotificationBigSectionHeaderViewHolder(override val containerView: View)
     : RecyclerView.ViewHolder(containerView), LayoutContainer {
+
+    private val sectionTitle = containerView.findViewById<TextView>(R.id.sectionTitle)
+    private val bigSectionHeader = containerView.findViewById<View>(R.id.bigSectionHeader)
 
     fun bind(item: NotificationMenuViewItem) {
         sectionTitle.setText(item.title)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/SecuritySettingsFragment.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
+import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
@@ -15,7 +17,8 @@ import io.horizontalsystems.core.getNavigationResult
 import io.horizontalsystems.pin.PinInteractionType
 import io.horizontalsystems.pin.PinModule
 import io.horizontalsystems.views.ListPosition
-import kotlinx.android.synthetic.main.fragment_settings_security.*
+import io.horizontalsystems.views.SettingsView
+import io.horizontalsystems.views.SettingsViewSwitch
 
 class SecuritySettingsFragment : BaseFragment() {
 
@@ -27,9 +30,14 @@ class SecuritySettingsFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        toolbar.setNavigationOnClickListener {
+        view.findViewById<Toolbar>(R.id.toolbar).setNavigationOnClickListener {
             findNavController().popBackStack()
         }
+
+        val changePin = view.findViewById<SettingsView>(R.id.changePin)
+        val biometricAuth = view.findViewById<SettingsViewSwitch>(R.id.biometricAuth)
+        val enablePin = view.findViewById<SettingsViewSwitch>(R.id.enablePin)
+        val txtBiometricAuthInfo = view.findViewById<TextView>(R.id.txtBiometricAuthInfo)
 
         viewModel.init()
 
@@ -37,7 +45,7 @@ class SecuritySettingsFragment : BaseFragment() {
             viewModel.delegate.didTapEditPin()
         }
 
-        privacy.setOnSingleClickListener {
+        view.findViewById<SettingsView>(R.id.privacy).setOnSingleClickListener {
             viewModel.delegate.didTapPrivacy()
         }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/privacy/PrivacySettingsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/privacy/PrivacySettingsFragment.kt
@@ -5,10 +5,12 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.ConcatAdapter
+import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.App
 import io.horizontalsystems.bankwallet.core.BaseFragment
@@ -23,7 +25,6 @@ import io.horizontalsystems.bankwallet.ui.extensions.ConfirmationDialog
 import io.horizontalsystems.bankwallet.ui.helpers.AppLayoutHelper
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.views.AlertDialogFragment
-import kotlinx.android.synthetic.main.fragment_settings_privacy.*
 import kotlin.system.exitProcess
 
 class PrivacySettingsFragment :
@@ -42,6 +43,10 @@ class PrivacySettingsFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
+        val concatRecyclerView = view.findViewById<RecyclerView>(R.id.concatRecyclerView)
+
         toolbar.setNavigationOnClickListener {
             findNavController().popBackStack()
         }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/privacy/PrivacySettingsInfoFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/privacy/PrivacySettingsInfoFragment.kt
@@ -4,10 +4,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.widget.Toolbar
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.core.findNavController
-import kotlinx.android.synthetic.main.fragment_privacy_settings_info.*
 
 class PrivacySettingsInfoFragment : BaseFragment() {
 
@@ -17,7 +17,7 @@ class PrivacySettingsInfoFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        toolbar.setOnMenuItemClickListener { item ->
+        view.findViewById<Toolbar>(R.id.toolbar).setOnMenuItemClickListener { item ->
             when (item.itemId) {
                 R.id.closeButton -> {
                     findNavController().popBackStack()

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/privacy/PrivacySettingsTorAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/privacy/PrivacySettingsTorAdapter.kt
@@ -3,14 +3,18 @@ package io.horizontalsystems.bankwallet.modules.settings.security.privacy
 import android.content.res.ColorStateList
 import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.ImageView
+import android.widget.ProgressBar
+import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.switchmaterial.SwitchMaterial
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.managers.TorStatus
 import io.horizontalsystems.views.inflate
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.view_holder_tor_control.*
 
 
 class PrivacySettingsTorAdapter(private val listener: Listener) : RecyclerView.Adapter<PrivacySettingsTorAdapter.TorControlViewHolder>() {
@@ -48,6 +52,12 @@ class PrivacySettingsTorAdapter(private val listener: Listener) : RecyclerView.A
             override val containerView: View,
             private val onSwitch: (isChecked: Boolean) -> Unit
     ) : RecyclerView.ViewHolder(containerView), LayoutContainer {
+
+        private val torControlView = containerView.findViewById<FrameLayout>(R.id.torControlView)
+        private val torConnectionSwitch = containerView.findViewById<SwitchMaterial>(R.id.torConnectionSwitch)
+        private val connectionSpinner = containerView.findViewById<ProgressBar>(R.id.connectionSpinner)
+        private val controlIcon = containerView.findViewById<ImageView>(R.id.controlIcon)
+        private val subtitleText = containerView.findViewById<TextView>(R.id.subtitleText)
 
         init {
             torControlView.setOnClickListener {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/privacy/PrivacySettingsTransactionsStructureAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/privacy/PrivacySettingsTransactionsStructureAdapter.kt
@@ -4,9 +4,9 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
+import io.horizontalsystems.views.SettingsViewDropdown
 import io.horizontalsystems.views.inflate
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.view_holder_transactions_structure.*
 
 
 class PrivacySettingsTransactionsStructureAdapter(private val listener: Listener)
@@ -39,6 +39,8 @@ class PrivacySettingsTransactionsStructureAdapter(private val listener: Listener
             override val containerView: View,
             private val onClick: () -> Unit
     ) : RecyclerView.ViewHolder(containerView), LayoutContainer {
+
+        private val transactionsOrderSetting = containerView.findViewById<SettingsViewDropdown>(R.id.transactionsOrderSetting)
 
         init {
             transactionsOrderSetting.setOnClickListener {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/terms/TermsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/terms/TermsFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.CheckBox
+import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import io.horizontalsystems.bankwallet.R
@@ -12,7 +13,6 @@ import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.bankwallet.core.managers.Term
 import io.horizontalsystems.bankwallet.core.managers.TermsManager
 import io.horizontalsystems.core.findNavController
-import kotlinx.android.synthetic.main.fragment_terms_settings.*
 
 class TermsFragment : BaseFragment() {
 
@@ -24,9 +24,18 @@ class TermsFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        toolbar.setNavigationOnClickListener {
+        view.findViewById<Toolbar>(R.id.toolbar).setNavigationOnClickListener {
             findNavController().popBackStack()
         }
+
+        val checkboxAcademy = view.findViewById<CheckBox>(R.id.checkboxAcademy)
+        val checkboxBackup = view.findViewById<CheckBox>(R.id.checkboxBackup)
+        val checkboxOwner = view.findViewById<CheckBox>(R.id.checkboxOwner)
+        val checkboxRecover = view.findViewById<CheckBox>(R.id.checkboxRecover)
+        val checkboxPhone = view.findViewById<CheckBox>(R.id.checkboxPhone)
+        val checkboxRoot = view.findViewById<CheckBox>(R.id.checkboxRoot)
+        val checkboxBugs = view.findViewById<CheckBox>(R.id.checkboxBugs)
+        val checkboxPin = view.findViewById<CheckBox>(R.id.checkboxPin)
 
         viewModel.termsLiveData.observe(viewLifecycleOwner, Observer { terms ->
             setCheckbox(checkboxAcademy, TermsManager.termIds[0], terms)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/theme/ThemeSwitchFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/theme/ThemeSwitchFragment.kt
@@ -4,7 +4,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.DiffUtil
@@ -16,8 +19,6 @@ import io.horizontalsystems.bankwallet.core.setOnSingleClickListener
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.views.inflate
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.fragment_theme_switcher.*
-import kotlinx.android.synthetic.main.view_holder_theme_switch_item.*
 
 class ThemeSwitchFragment : BaseFragment() {
 
@@ -30,12 +31,12 @@ class ThemeSwitchFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        toolbar.setNavigationOnClickListener {
+        view.findViewById<Toolbar>(R.id.toolbar).setNavigationOnClickListener {
             findNavController().popBackStack()
         }
 
         val adapter = ThemeSwitchAdapter(::onItemClick)
-        recyclerView.adapter = adapter
+        view.findViewById<RecyclerView>(R.id.recyclerView).adapter = adapter
 
         viewModel.itemsLiveData.observe(viewLifecycleOwner) {
             adapter.submitList(it)
@@ -63,6 +64,9 @@ class ThemeSwitchAdapter(private val onItemClick: (ThemeViewItem) -> Unit) : Lis
 
     class ViewHolder(override val containerView: View, onItemClick: (ThemeViewItem) -> Unit) : RecyclerView.ViewHolder(containerView), LayoutContainer {
         private var item: ThemeViewItem? = null
+        private val icon = containerView.findViewById<ImageView>(R.id.icon)
+        private val title = containerView.findViewById<TextView>(R.id.title)
+        private val checkmarkIcon = containerView.findViewById<ImageView>(R.id.checkmarkIcon)
 
         init {
             itemView.setOnSingleClickListener {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/showkey/ShowKeyIntroFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/showkey/ShowKeyIntroFragment.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import androidx.appcompat.widget.Toolbar
 import androidx.navigation.navGraphViewModels
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
@@ -11,7 +13,6 @@ import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.getNavigationResult
 import io.horizontalsystems.pin.PinInteractionType
 import io.horizontalsystems.pin.PinModule
-import kotlinx.android.synthetic.main.fragment_show_key_intro.*
 
 class ShowKeyIntroFragment : BaseFragment() {
     private val viewModel by navGraphViewModels<ShowKeyViewModel>(R.id.showKeyIntroFragment) { ShowKeyModule.Factory(arguments?.getParcelable(ShowKeyModule.ACCOUNT)!!) }
@@ -23,11 +24,11 @@ class ShowKeyIntroFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        toolbar.setNavigationOnClickListener {
+        view.findViewById<Toolbar>(R.id.toolbar).setNavigationOnClickListener {
             findNavController().popBackStack()
         }
 
-        buttonShow.setOnClickListener {
+        view.findViewById<Button>(R.id.buttonShow).setOnClickListener {
             viewModel.onClickShow()
         }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/showkey/ShowKeyMainFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/showkey/ShowKeyMainFragment.kt
@@ -4,14 +4,17 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import androidx.appcompat.widget.Toolbar
 import androidx.navigation.navGraphViewModels
+import androidx.viewpager2.widget.ViewPager2
+import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.bankwallet.modules.showkey.ShowKeyModule.ShowKeyTab
 import io.horizontalsystems.bankwallet.modules.showkey.tabs.ShowKeyTabsAdapter
 import io.horizontalsystems.core.findNavController
-import kotlinx.android.synthetic.main.fragment_show_key_main.*
 
 class ShowKeyMainFragment : BaseFragment() {
     private val viewModel by navGraphViewModels<ShowKeyViewModel>(R.id.showKeyIntroFragment)
@@ -30,9 +33,12 @@ class ShowKeyMainFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        toolbar.setNavigationOnClickListener {
+        view.findViewById<Toolbar>(R.id.toolbar).setNavigationOnClickListener {
             findNavController().popBackStack()
         }
+
+        val viewPager = view.findViewById<ViewPager2>(R.id.viewPager)
+        val tabLayout = view.findViewById<TabLayout>(R.id.tabLayout)
 
         viewPager.adapter = ShowKeyTabsAdapter(showKeyTabs, viewModel.words, viewModel.passphrase, viewModel.privateKeys, childFragmentManager, viewLifecycleOwner.lifecycle)
 
@@ -44,7 +50,7 @@ class ShowKeyMainFragment : BaseFragment() {
             tab.setText(showKeyTabs[position].title)
         }.attach()
 
-        buttonClose.setOnClickListener {
+        view.findViewById<Button>(R.id.buttonClose).setOnClickListener {
             findNavController().popBackStack(R.id.showKeyIntroFragment, true)
         }
     }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/showkey/tabs/ShowPrivateKeyTab.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/showkey/tabs/ShowPrivateKeyTab.kt
@@ -4,14 +4,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.core.os.bundleOf
 import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.bankwallet.modules.showkey.ShowKeyModule
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.fragment_show_private_key_tab.*
-import kotlinx.android.synthetic.main.view_holder_private_key.*
 
 class ShowPrivateKeyFragment : BaseFragment() {
 
@@ -25,7 +24,7 @@ class ShowPrivateKeyFragment : BaseFragment() {
         val privateKeys = arguments?.getParcelableArrayList<ShowKeyModule.PrivateKey>(PRIVATE_KEYS)
                 ?: listOf()
 
-        recyclerView.adapter = PrivateKeysAdapter(privateKeys)
+        view.findViewById<RecyclerView>(R.id.recyclerView).adapter = PrivateKeysAdapter(privateKeys)
     }
 
     companion object {
@@ -62,6 +61,9 @@ class PrivateKeysAdapter(
 class PrivateKeyViewHolder(
         override val containerView: View
 ) : RecyclerView.ViewHolder(containerView), LayoutContainer {
+
+    private val blockchain = containerView.findViewById<TextView>(R.id.blockchain)
+    private val value = containerView.findViewById<TextView>(R.id.value)
 
     fun bind(key: ShowKeyModule.PrivateKey) {
         blockchain.text = key.blockchain

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/showkey/tabs/ShowWordsTab.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/showkey/tabs/ShowWordsTab.kt
@@ -7,7 +7,7 @@ import android.view.ViewGroup
 import androidx.core.os.bundleOf
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
-import kotlinx.android.synthetic.main.fragment_show_words_tab.*
+import io.horizontalsystems.bankwallet.ui.extensions.MnemonicPhraseView
 
 class ShowWordsTab : BaseFragment() {
     private val words: List<String>
@@ -23,7 +23,7 @@ class ShowWordsTab : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        mnemonicPhraseView.populateWords(words, passphrase)
+        view.findViewById<MnemonicPhraseView>(R.id.mnemonicPhraseView).populateWords(words, passphrase)
     }
 
     companion object {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/SwapFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/SwapFragment.kt
@@ -6,27 +6,46 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.ProgressBar
+import android.widget.TextView
+import androidx.appcompat.widget.Toolbar
+import androidx.constraintlayout.widget.Group
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.navGraphViewModels
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
+import io.horizontalsystems.bankwallet.modules.swap.allowance.SwapAllowanceView
 import io.horizontalsystems.bankwallet.modules.swap.allowance.SwapAllowanceViewModel
 import io.horizontalsystems.bankwallet.modules.swap.approve.SwapApproveModule
+import io.horizontalsystems.bankwallet.modules.swap.coincard.SwapCoinCardView
 import io.horizontalsystems.bankwallet.modules.swap.coincard.SwapCoinCardViewModel
 import io.horizontalsystems.bankwallet.modules.swap.confirmation.SwapConfirmationModule
 import io.horizontalsystems.bankwallet.modules.swap.info.SwapInfoFragment.Companion.dexKey
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.getNavigationResult
 import io.horizontalsystems.core.setOnSingleClickListener
-import kotlinx.android.synthetic.main.fragment_swap.*
 
 class SwapFragment : BaseFragment() {
 
     private val vmFactory by lazy { SwapModule.Factory(this, requireArguments().getParcelable(fromCoinKey)!!) }
     private val viewModel by navGraphViewModels<SwapViewModel>(R.id.swapFragment) { vmFactory }
     private val allowanceViewModel by navGraphViewModels<SwapAllowanceViewModel>(R.id.swapFragment) { vmFactory }
+
+    private lateinit var approveButton: Button
+    private lateinit var proceedButton: Button
+    private lateinit var progressBar: ProgressBar
+    private lateinit var commonError: TextView
+    private lateinit var advancedSettingsViews: Group
+    private lateinit var poweredBy: TextView
+    private lateinit var price: TextView
+    private lateinit var priceImpactViews: Group
+    private lateinit var priceImpactValue: TextView
+    private lateinit var guaranteedAmountViews: Group
+    private lateinit var minMaxTitle: TextView
+    private lateinit var minMaxValue: TextView
+    private lateinit var poweredByLine: View
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return inflater.inflate(R.layout.fragment_swap, container, false)
@@ -35,7 +54,7 @@ class SwapFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        toolbar.setOnMenuItemClickListener { item ->
+        view.findViewById<Toolbar>(R.id.toolbar).setOnMenuItemClickListener { item ->
             when (item.itemId) {
                 R.id.menuCancel -> {
                     findNavController().popBackStack()
@@ -49,15 +68,27 @@ class SwapFragment : BaseFragment() {
             }
         }
 
+        proceedButton = view.findViewById(R.id.proceedButton)
+        progressBar= view.findViewById(R.id.progressBar)
+        commonError= view.findViewById(R.id.commonError)
+        poweredBy = view.findViewById(R.id.poweredBy)
+        price = view.findViewById(R.id.price)
+        priceImpactViews = view.findViewById(R.id.priceImpactViews)
+        priceImpactValue = view.findViewById(R.id.priceImpactValue)
+        guaranteedAmountViews = view.findViewById(R.id.guaranteedAmountViews)
+        minMaxTitle = view.findViewById(R.id.minMaxTitle)
+        minMaxValue = view.findViewById(R.id.minMaxValue)
+        poweredByLine = view.findViewById(R.id.poweredByLine)
+
         val fromCoinCardViewModel = ViewModelProvider(this, vmFactory).get(SwapModule.Factory.coinCardTypeFrom, SwapCoinCardViewModel::class.java)
         val fromCoinCardTitle = getString(R.string.Swap_FromAmountTitle)
-        fromCoinCard.initialize(fromCoinCardTitle, fromCoinCardViewModel, this, viewLifecycleOwner)
+        view.findViewById<SwapCoinCardView>(R.id.fromCoinCard).initialize(fromCoinCardTitle, fromCoinCardViewModel, this, viewLifecycleOwner)
 
         val toCoinCardViewModel = ViewModelProvider(this, vmFactory).get(SwapModule.Factory.coinCardTypeTo, SwapCoinCardViewModel::class.java)
         val toCoinCardTile = getString(R.string.Swap_ToAmountTitle)
-        toCoinCard.initialize(toCoinCardTile, toCoinCardViewModel, this, viewLifecycleOwner)
+        view.findViewById<SwapCoinCardView>(R.id.toCoinCard).initialize(toCoinCardTile, toCoinCardViewModel, this, viewLifecycleOwner)
 
-        allowanceView.initialize(allowanceViewModel, viewLifecycleOwner)
+        view.findViewById<SwapAllowanceView>(R.id.allowanceView).initialize(allowanceViewModel, viewLifecycleOwner)
 
         observeViewModel()
 
@@ -67,11 +98,11 @@ class SwapFragment : BaseFragment() {
             }
         }
 
-        switchButton.setOnClickListener {
+        view.findViewById<Button>(R.id.switchButton).setOnClickListener {
             viewModel.onTapSwitch()
         }
 
-        advancedSettings.setOnSingleClickListener {
+        view.findViewById<TextView>(R.id.advancedSettings).setOnSingleClickListener {
             findNavController().navigate(R.id.swapFragment_to_swapTradeOptionsFragment)
         }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/allowance/SwapAllowanceView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/allowance/SwapAllowanceView.kt
@@ -5,17 +5,20 @@ import android.util.AttributeSet
 import android.view.Gravity
 import android.view.View
 import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.lifecycle.LifecycleOwner
 import io.horizontalsystems.bankwallet.R
-import kotlinx.android.synthetic.main.view_swap_allowance.view.*
 
 class SwapAllowanceView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0)
     : LinearLayout(context, attrs, defStyleAttr) {
 
+    private var allowance: TextView
+
     init {
         orientation = HORIZONTAL
         gravity = Gravity.CENTER_VERTICAL
-        inflate(context, R.layout.view_swap_allowance, this)
+        val rootView = inflate(context, R.layout.view_swap_allowance, this)
+        allowance = rootView.findViewById(R.id.allowance)
     }
 
     fun initialize(viewModel: SwapAllowanceViewModel, lifecycleOwner: LifecycleOwner) {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/approve/SwapApproveFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/approve/SwapApproveFragment.kt
@@ -7,6 +7,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.animation.AnimationUtils
+import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
+import androidx.appcompat.widget.Toolbar
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.navigation.navGraphViewModels
@@ -21,7 +25,6 @@ import io.horizontalsystems.bankwallet.modules.swap.approve.confirmation.SwapApp
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.getNavigationResult
 import io.horizontalsystems.core.setNavigationResult
-import kotlinx.android.synthetic.main.fragment_swap_approve.*
 
 class SwapApproveFragment : BaseFragment() {
 
@@ -31,7 +34,7 @@ class SwapApproveFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        toolbar.setOnMenuItemClickListener { item ->
+        view.findViewById<Toolbar>(R.id.toolbar).setOnMenuItemClickListener { item ->
             when (item.itemId) {
                 R.id.menuClose -> {
                     findNavController().popBackStack()
@@ -45,6 +48,9 @@ class SwapApproveFragment : BaseFragment() {
 
         val vmFactory = SwapApproveModule.Factory(approveData)
         val viewModel by navGraphViewModels<SwapApproveViewModel>(R.id.swapApproveFragment) { vmFactory }
+        val amount = view.findViewById<EditText>(R.id.amount)
+        val btnProceed = view.findViewById<Button>(R.id.btnProceed)
+        val amountError = view.findViewById<TextView>(R.id.amountError)
 
         amount.setText(viewModel.amount)
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/approve/confirmation/SwapApproveConfirmationFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/approve/confirmation/SwapApproveConfirmationFragment.kt
@@ -6,6 +6,8 @@ import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import androidx.appcompat.widget.Toolbar
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import androidx.navigation.navGraphViewModels
@@ -18,6 +20,7 @@ import io.horizontalsystems.bankwallet.modules.sendevm.SendEvmData
 import io.horizontalsystems.bankwallet.modules.sendevm.SendEvmModule
 import io.horizontalsystems.bankwallet.modules.sendevm.SendEvmModule.additionalInfoKey
 import io.horizontalsystems.bankwallet.modules.sendevm.SendEvmModule.transactionDataKey
+import io.horizontalsystems.bankwallet.modules.sendevmtransaction.SendEvmTransactionView
 import io.horizontalsystems.bankwallet.modules.sendevmtransaction.SendEvmTransactionViewModel
 import io.horizontalsystems.bankwallet.modules.swap.approve.SwapApproveModule
 import io.horizontalsystems.bankwallet.modules.swap.approve.SwapApproveViewModel
@@ -28,7 +31,6 @@ import io.horizontalsystems.ethereumkit.models.Address
 import io.horizontalsystems.ethereumkit.models.TransactionData
 import io.horizontalsystems.snackbar.CustomSnackbar
 import io.horizontalsystems.snackbar.SnackbarDuration
-import kotlinx.android.synthetic.main.fragment_confirmation_approve_swap.*
 
 class SwapApproveConfirmationFragment : BaseFragment() {
     private val logger = AppLogger("swap-approve")
@@ -58,7 +60,7 @@ class SwapApproveConfirmationFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        toolbar.setOnMenuItemClickListener { item ->
+        view.findViewById<Toolbar>(R.id.toolbar).setOnMenuItemClickListener { item ->
             when (item.itemId) {
                 R.id.menuCancel -> {
                     findNavController().popBackStack()
@@ -67,6 +69,8 @@ class SwapApproveConfirmationFragment : BaseFragment() {
                 else -> false
             }
         }
+
+        val approveButton = view.findViewById<Button>(R.id.approveButton)
 
         sendViewModel.sendEnabledLiveData.observe(viewLifecycleOwner, { enabled ->
             approveButton.isEnabled = enabled
@@ -90,7 +94,7 @@ class SwapApproveConfirmationFragment : BaseFragment() {
             findNavController().popBackStack()
         })
 
-        sendEvmTransactionView.init(
+        view.findViewById<SendEvmTransactionView>(R.id.sendEvmTransactionView).init(
                 sendViewModel,
                 feeViewModel,
                 viewLifecycleOwner,

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/coincard/SwapCoinCardView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/coincard/SwapCoinCardView.kt
@@ -3,6 +3,7 @@ package io.horizontalsystems.bankwallet.modules.swap.coincard
 import android.content.Context
 import android.util.AttributeSet
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.cardview.widget.CardView
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -10,21 +11,34 @@ import androidx.lifecycle.LifecycleOwner
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.modules.swap.SwapModule
 import io.horizontalsystems.bankwallet.modules.swap.coinselect.SelectSwapCoinDialogFragment
+import io.horizontalsystems.bankwallet.ui.extensions.AmountInputView
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.getNavigationLiveData
 import io.horizontalsystems.core.setOnSingleClickListener
 import io.horizontalsystems.views.helpers.LayoutHelper
-import kotlinx.android.synthetic.main.view_card_swap.view.*
 import java.math.BigDecimal
 
 class SwapCoinCardView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0)
     : CardView(context, attrs, defStyleAttr) {
 
+    private var titleTextView: TextView
+    private var selectedToken: TextView
+    private var amountInput: AmountInputView
+    private var balanceValue: TextView
+    private var balanceTitle: TextView
+    private var estimatedLabel: TextView
+
     init {
         radius = LayoutHelper.dpToPx(16f, context)
         layoutParams = LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
         cardElevation = 0f
-        inflate(context, R.layout.view_card_swap, this)
+        val rootView = inflate(context, R.layout.view_card_swap, this)
+        titleTextView = rootView.findViewById(R.id.titleTextView)
+        selectedToken = rootView.findViewById(R.id.selectedToken)
+        amountInput = rootView.findViewById(R.id.amountInput)
+        balanceValue = rootView.findViewById(R.id.balanceValue)
+        balanceTitle = rootView.findViewById(R.id.balanceTitle)
+        estimatedLabel = rootView.findViewById(R.id.estimatedLabel)
     }
 
     fun initialize(title: String, viewModel: SwapCoinCardViewModel, fragment: Fragment, lifecycleOwner: LifecycleOwner) {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/coinselect/SelectSwapCoinDialogFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/coinselect/SelectSwapCoinDialogFragment.kt
@@ -6,14 +6,15 @@ import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.widget.Toolbar
 import androidx.core.os.bundleOf
 import androidx.lifecycle.ViewModelProvider
+import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseWithSearchDialogFragment
 import io.horizontalsystems.bankwallet.modules.swap.SwapModule.CoinBalanceItem
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.setNavigationResult
-import kotlinx.android.synthetic.main.fragment_swap_select_token.*
 
 class SelectSwapCoinDialogFragment : BaseWithSearchDialogFragment() {
 
@@ -27,6 +28,7 @@ class SelectSwapCoinDialogFragment : BaseWithSearchDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
         toolbar.setNavigationOnClickListener {
             findNavController().popBackStack()
         }
@@ -44,7 +46,7 @@ class SelectSwapCoinDialogFragment : BaseWithSearchDialogFragment() {
 
         val adapter = SelectSwapCoinAdapter(onClickItem = { closeWithResult(it, requestId) })
 
-        recyclerView.adapter = adapter
+        view.findViewById<RecyclerView>(R.id.recyclerView).adapter = adapter
 
         viewModel?.coinItemsLivedData?.observe(viewLifecycleOwner, { items ->
             adapter.items = items

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/coinselect/SelectSwapCoinViewHolder.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/coinselect/SelectSwapCoinViewHolder.kt
@@ -1,14 +1,16 @@
 package io.horizontalsystems.bankwallet.modules.swap.coinselect
 
 import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
+import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.App
 import io.horizontalsystems.bankwallet.core.setCoinImage
 import io.horizontalsystems.bankwallet.core.setOnSingleClickListener
 import io.horizontalsystems.bankwallet.modules.swap.SwapModule.CoinBalanceItem
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.view_holder_swap_coin_select.*
 
 class SelectSwapCoinViewHolder(
         override val containerView: View,
@@ -16,6 +18,12 @@ class SelectSwapCoinViewHolder(
 ) : RecyclerView.ViewHolder(containerView), LayoutContainer {
 
     private var coinItem: CoinBalanceItem? = null
+    private val bottomShade = containerView.findViewById<View>(R.id.bottomShade)
+    private val coinIcon = containerView.findViewById<ImageView>(R.id.coinIcon)
+    private val coinTitle = containerView.findViewById<TextView>(R.id.coinTitle)
+    private val coinSubtitle = containerView.findViewById<TextView>(R.id.coinSubtitle)
+    private val coinBalance = containerView.findViewById<TextView>(R.id.coinBalance)
+    private val fiatBalance = containerView.findViewById<TextView>(R.id.fiatBalance)
 
     init {
         containerView.setOnSingleClickListener {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/confirmation/SwapConfirmationFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/confirmation/SwapConfirmationFragment.kt
@@ -6,6 +6,8 @@ import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.Toolbar
 import androidx.fragment.app.viewModels
 import androidx.navigation.navGraphViewModels
 import io.horizontalsystems.bankwallet.R
@@ -17,6 +19,7 @@ import io.horizontalsystems.bankwallet.modules.sendevm.SendEvmData
 import io.horizontalsystems.bankwallet.modules.sendevm.SendEvmModule
 import io.horizontalsystems.bankwallet.modules.sendevm.SendEvmModule.additionalInfoKey
 import io.horizontalsystems.bankwallet.modules.sendevm.SendEvmModule.transactionDataKey
+import io.horizontalsystems.bankwallet.modules.sendevmtransaction.SendEvmTransactionView
 import io.horizontalsystems.bankwallet.modules.sendevmtransaction.SendEvmTransactionViewModel
 import io.horizontalsystems.bankwallet.modules.swap.SwapViewModel
 import io.horizontalsystems.core.findNavController
@@ -25,7 +28,6 @@ import io.horizontalsystems.ethereumkit.models.Address
 import io.horizontalsystems.ethereumkit.models.TransactionData
 import io.horizontalsystems.snackbar.CustomSnackbar
 import io.horizontalsystems.snackbar.SnackbarDuration
-import kotlinx.android.synthetic.main.fragment_confirmation_swap.*
 
 class SwapConfirmationFragment : BaseFragment() {
     private val logger = AppLogger("swap")
@@ -54,7 +56,10 @@ class SwapConfirmationFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        toolbar.setOnMenuItemClickListener { item ->
+
+        val swapButton = view.findViewById<Button>(R.id.swapButton)
+
+        view.findViewById<Toolbar>(R.id.toolbar).setOnMenuItemClickListener { item ->
             when (item.itemId) {
                 R.id.menuCancel -> {
                     findNavController().popBackStack()
@@ -85,7 +90,7 @@ class SwapConfirmationFragment : BaseFragment() {
             findNavController().popBackStack()
         })
 
-        sendEvmTransactionView.init(
+        view.findViewById<SendEvmTransactionView>(R.id.sendEvmTransactionView).init(
                 sendViewModel,
                 feeViewModel,
                 viewLifecycleOwner,

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/info/SwapInfoFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/info/SwapInfoFragment.kt
@@ -6,12 +6,14 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.TextView
+import androidx.appcompat.widget.Toolbar
 import androidx.lifecycle.ViewModelProvider
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.bankwallet.modules.swap.SwapModule
 import io.horizontalsystems.core.findNavController
-import kotlinx.android.synthetic.main.fragment_swap_info.*
 
 class SwapInfoFragment : BaseFragment() {
 
@@ -21,6 +23,10 @@ class SwapInfoFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
+        val btnLink = view.findViewById<Button>(R.id.btnLink)
+
         toolbar.setOnMenuItemClickListener { item ->
             when (item.itemId) {
                 R.id.menuClose -> {
@@ -35,9 +41,9 @@ class SwapInfoFragment : BaseFragment() {
         val viewModel = ViewModelProvider(this, SwapInfoModule.Factory(dex)).get(SwapInfoViewModel::class.java)
 
         toolbar.title = viewModel.title
-        description.text = viewModel.description
-        headerRelated.text = viewModel.dexRelated
-        transactionFeeDescription.text = viewModel.transactionFeeDescription
+        view.findViewById<TextView>(R.id.description).text = viewModel.description
+        view.findViewById<TextView>(R.id.headerRelated).text = viewModel.dexRelated
+        view.findViewById<TextView>(R.id.transactionFeeDescription).text = viewModel.transactionFeeDescription
         btnLink.text = viewModel.linkText
 
         btnLink.setOnClickListener {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/tradeoptions/SwapTradeOptionsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/swap/tradeoptions/SwapTradeOptionsFragment.kt
@@ -5,7 +5,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.viewModels
 import androidx.navigation.navGraphViewModels
 import io.horizontalsystems.bankwallet.R
@@ -15,9 +17,10 @@ import io.horizontalsystems.bankwallet.core.utils.ModuleField
 import io.horizontalsystems.bankwallet.modules.qrscanner.QRScannerActivity
 import io.horizontalsystems.bankwallet.modules.swap.SwapViewModel
 import io.horizontalsystems.bankwallet.modules.swap.tradeoptions.SwapTradeOptionsViewModel.ActionState
+import io.horizontalsystems.bankwallet.ui.extensions.AddressInputView
+import io.horizontalsystems.bankwallet.ui.extensions.InputWithButtonsView
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.helpers.HudHelper
-import kotlinx.android.synthetic.main.fragment_swap_settings.*
 
 class SwapTradeOptionsFragment : BaseFragment() {
     private val swapViewModel by navGraphViewModels<SwapViewModel>(R.id.swapFragment)
@@ -48,7 +51,9 @@ class SwapTradeOptionsFragment : BaseFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        toolbar.setOnMenuItemClickListener { item ->
+        val applyButton = view.findViewById<Button>(R.id.applyButton)
+
+        view.findViewById<Toolbar>(R.id.toolbar).setOnMenuItemClickListener { item ->
             when (item.itemId) {
                 R.id.menuCancel -> {
                     findNavController().popBackStack()
@@ -79,13 +84,13 @@ class SwapTradeOptionsFragment : BaseFragment() {
             }
         }
 
-        recipientAddressInputView.setViewModel(recipientAddressViewModel, viewLifecycleOwner, {
+        view.findViewById<AddressInputView>(R.id.recipientAddressInputView).setViewModel(recipientAddressViewModel, viewLifecycleOwner, {
             val intent = QRScannerActivity.getIntentForFragment(this)
             qrScannerResultLauncher.launch(intent)
         })
 
-        slippageInputView.setViewModel(slippageViewModel, viewLifecycleOwner)
-        deadlineInputView.setViewModel(deadlineViewModel, viewLifecycleOwner)
+        view.findViewById<InputWithButtonsView>(R.id.slippageInputView).setViewModel(slippageViewModel, viewLifecycleOwner)
+        view.findViewById<InputWithButtonsView>(R.id.deadlineInputView).setViewModel(deadlineViewModel, viewLifecycleOwner)
     }
 
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/tor/TorConnectionActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/tor/TorConnectionActivity.kt
@@ -2,6 +2,10 @@ package io.horizontalsystems.bankwallet.modules.tor
 
 import android.annotation.SuppressLint
 import android.os.Bundle
+import android.widget.Button
+import android.widget.ImageView
+import android.widget.ProgressBar
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isInvisible
 import androidx.lifecycle.Observer
@@ -9,17 +13,27 @@ import androidx.lifecycle.ViewModelProvider
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.managers.TorStatus
 import io.horizontalsystems.bankwallet.modules.launcher.LaunchModule
-import kotlinx.android.synthetic.main.activity_tor_connection.*
 import kotlin.system.exitProcess
 
 @SuppressLint("SetTextI18n")
 class TorConnectionActivity : AppCompatActivity() {
 
     private lateinit var presenter: TorStatusPresenter
+    private lateinit var btnRetry: Button
+    private lateinit var txDisableTor: TextView
+    private lateinit var pgTorStatus: ProgressBar
+    private lateinit var imgTorStatusError: ImageView
+    private lateinit var txTorStatus: TextView
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_tor_connection)
+
+        btnRetry = findViewById(R.id.btnRetry)
+        txDisableTor = findViewById(R.id.txDisableTor)
+        pgTorStatus = findViewById(R.id.pgTorStatus)
+        imgTorStatusError = findViewById(R.id.imgTorStatusError)
+        txTorStatus = findViewById(R.id.txTorStatus)
 
         presenter = ViewModelProvider(this, TorStatusModule.Factory()).get(TorStatusPresenter::class.java)
         presenter.viewDidLoad()

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionProgressView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionProgressView.kt
@@ -4,12 +4,14 @@ import android.content.Context
 import android.graphics.drawable.AnimationDrawable
 import android.util.AttributeSet
 import android.widget.FrameLayout
+import android.widget.ProgressBar
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.entities.TransactionType
-import kotlinx.android.synthetic.main.view_transaction_progress.view.*
 
 
 class TransactionProgressView : FrameLayout {
+
+    private lateinit var progressBar: ProgressBar
 
     constructor(context: Context) : super(context) {
         initializeViews()
@@ -24,7 +26,8 @@ class TransactionProgressView : FrameLayout {
     }
 
     private fun initializeViews() {
-        inflate(context, R.layout.view_transaction_progress, this)
+        val rootView = inflate(context, R.layout.view_transaction_progress, this)
+        progressBar = rootView.findViewById(R.id.progressBar)
     }
 
     fun bind(progress: Double = 0.0, type: TransactionType) {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionStatusWithTimeView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionStatusWithTimeView.kt
@@ -2,14 +2,17 @@ package io.horizontalsystems.bankwallet.modules.transactions
 
 import android.content.Context
 import android.util.AttributeSet
+import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.entities.TransactionType
-import kotlinx.android.synthetic.main.view_transaction_status.view.*
 
 
 class TransactionStatusWithTimeView : ConstraintLayout {
+
+    private lateinit var txTime: TextView
+    private lateinit var statusText: TextView
 
     constructor(context: Context) : super(context) {
         initializeViews()
@@ -24,7 +27,9 @@ class TransactionStatusWithTimeView : ConstraintLayout {
     }
 
     private fun initializeViews() {
-        inflate(context, R.layout.view_transaction_status, this)
+        val rootView = inflate(context, R.layout.view_transaction_status, this)
+        txTime = rootView.findViewById(R.id.txTime)
+        statusText = rootView.findViewById(R.id.statusText)
     }
 
     fun bind(transactionStatus: TransactionStatus, type: TransactionType, time: String?) {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionsFragment.kt
@@ -4,6 +4,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.ImageView
+import android.widget.ProgressBar
+import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
@@ -24,9 +28,6 @@ import io.horizontalsystems.bankwallet.ui.extensions.NpaLinearLayoutManager
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.helpers.DateHelper
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.fragment_transactions.*
-import kotlinx.android.synthetic.main.view_holder_filter.*
-import kotlinx.android.synthetic.main.view_holder_transaction.*
 
 class TransactionsFragment : Fragment(), TransactionsAdapter.Listener, FilterAdapter.Listener {
 
@@ -34,12 +35,20 @@ class TransactionsFragment : Fragment(), TransactionsAdapter.Listener, FilterAda
     private val transactionsAdapter = TransactionsAdapter(this)
     private val filterAdapter = FilterAdapter(this)
 
+    private lateinit var recyclerTags: RecyclerView
+    private lateinit var recyclerTransactions: RecyclerView
+    private lateinit var toolbarSpinner: ProgressBar
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_transactions, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        recyclerTags = view.findViewById(R.id.recyclerTags)
+        recyclerTransactions = view.findViewById(R.id.recyclerTransactions)
+        toolbarSpinner = view.findViewById(R.id.toolbarSpinner)
 
         val layoutManager = NpaLinearLayoutManager(context)
         transactionsAdapter.viewModel = viewModel
@@ -162,6 +171,18 @@ class TransactionsAdapter(private var listener: Listener) : ListAdapter<Transact
 }
 
 class ViewHolderTransaction(override val containerView: View, private val l: ClickListener) : ViewHolder(containerView), LayoutContainer {
+
+    private val txValueInFiat = containerView.findViewById<TextView>(R.id.txValueInFiat)
+    private val txValueInCoin = containerView.findViewById<TextView>(R.id.txValueInCoin)
+    private val txTypeIcon = containerView.findViewById<ImageView>(R.id.txTypeIcon)
+    private val txDate = containerView.findViewById<TextView>(R.id.txDate)
+    private val txStatusWithTimeView = containerView.findViewById<TransactionStatusWithTimeView>(R.id.txStatusWithTimeView)
+    private val bottomShade = containerView.findViewById<View>(R.id.bottomShade)
+    private val sentToSelfIcon = containerView.findViewById<ImageView>(R.id.sentToSelfIcon)
+    private val doubleSpendIcon = containerView.findViewById<ImageView>(R.id.doubleSpendIcon)
+    private val bottomIcon = containerView.findViewById<ImageView>(R.id.bottomIcon)
+    private val transactionProgressView = containerView.findViewById<TransactionProgressView>(R.id.transactionProgressView)
+    private val lockIcon = containerView.findViewById<ImageView>(R.id.lockIcon)
 
     interface ClickListener {
         fun onClick(position: Int)
@@ -303,6 +324,8 @@ class FilterAdapter(private var listener: Listener) : Adapter<ViewHolder>(), Vie
 }
 
 class ViewHolderFilter(override val containerView: View, private val l: ClickListener) : ViewHolder(containerView), LayoutContainer {
+
+    private val buttonFilter = containerView.findViewById<Button>(R.id.buttonFilter)
 
     interface ClickListener {
         fun onClickItem(position: Int, width: Int)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/CoinInfoItemView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/CoinInfoItemView.kt
@@ -2,6 +2,9 @@ package io.horizontalsystems.bankwallet.modules.transactions.transactionInfo
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
 import io.horizontalsystems.bankwallet.R
@@ -9,11 +12,22 @@ import io.horizontalsystems.bankwallet.core.setOnSingleClickListener
 import io.horizontalsystems.bankwallet.ui.helpers.TextHelper
 import io.horizontalsystems.core.helpers.HudHelper
 import io.horizontalsystems.views.ListPosition
-import kotlinx.android.synthetic.main.view_coin_info_item.view.*
 
 class CoinInfoItemView : ConstraintLayout {
+
+    private var txtTitle: TextView
+    private var decoratedText: TextView
+    private var valueText: TextView
+    private var iconView: ImageView
+    private var viewBackground: View
+
     init {
-        inflate(context, R.layout.view_coin_info_item, this)
+        val rootView = inflate(context, R.layout.view_coin_info_item, this)
+        txtTitle = rootView.findViewById(R.id.txtTitle)
+        decoratedText = rootView.findViewById(R.id.decoratedText)
+        valueText = rootView.findViewById(R.id.valueText)
+        iconView = rootView.findViewById(R.id.iconView)
+        viewBackground = rootView.findViewById(R.id.viewBackground)
     }
 
     constructor(context: Context) : super(context)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/InfoFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/InfoFragment.kt
@@ -5,6 +5,8 @@ import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
+import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseDialogFragment
@@ -12,7 +14,6 @@ import io.horizontalsystems.bankwallet.ui.helpers.TextHelper
 import io.horizontalsystems.core.dismissOnBackPressed
 import io.horizontalsystems.core.helpers.HudHelper
 import kotlinx.android.parcel.Parcelize
-import kotlinx.android.synthetic.main.fragment_info.*
 
 class InfoFragment : BaseDialogFragment() {
 
@@ -30,6 +31,8 @@ class InfoFragment : BaseDialogFragment() {
             return
         }
 
+        val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
+
         toolbar.title = infoParams.title
         toolbar.setOnMenuItemClickListener { item ->
             when (item.itemId) {
@@ -41,7 +44,9 @@ class InfoFragment : BaseDialogFragment() {
             }
         }
 
-        textDescription.text = infoParams.description
+        view.findViewById<TextView>(R.id.textDescription).text = infoParams.description
+        val itemTxHash = view.findViewById<TransactionInfoItemView>(R.id.itemTxHash)
+        val itemConflictingTxHash = view.findViewById<TransactionInfoItemView>(R.id.itemConflictingTxHash)
 
         infoParams.txHash?.let { txHash ->
             itemTxHash.bindHashId(getString(R.string.Info_DoubleSpend_ThisTx), txHash)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/StatusInfoFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/StatusInfoFragment.kt
@@ -4,10 +4,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.widget.Toolbar
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseDialogFragment
 import io.horizontalsystems.core.dismissOnBackPressed
-import kotlinx.android.synthetic.main.fragment_status_info.*
 
 class StatusInfoFragment : BaseDialogFragment() {
 
@@ -19,6 +19,8 @@ class StatusInfoFragment : BaseDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
 
         toolbar.inflateMenu(R.menu.status_info_menu)
         toolbar.setOnMenuItemClickListener { menuItem ->

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/TransactionDetailsAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/TransactionDetailsAdapter.kt
@@ -2,6 +2,9 @@ package io.horizontalsystems.bankwallet.modules.transactions.transactionInfo
 
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageButton
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
@@ -15,7 +18,6 @@ import io.horizontalsystems.core.helpers.DateHelper
 import io.horizontalsystems.views.helpers.LayoutHelper
 import io.horizontalsystems.views.inflate
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.view_transaction_info_item.*
 
 class TransactionDetailsAdapter(private val viewModel: TransactionInfoViewModel) : RecyclerView.Adapter<TransactionDetailsAdapter.DetailViewHolder>() {
 
@@ -39,6 +41,12 @@ class TransactionDetailsAdapter(private val viewModel: TransactionInfoViewModel)
 
     class DetailViewHolder(override val containerView: View, private val viewModel: TransactionInfoViewModel) : RecyclerView.ViewHolder(containerView), LayoutContainer {
         private val context get() = itemView.context
+        private val txtTitle = containerView.findViewById<TextView>(R.id.txtTitle)
+        private val decoratedText = containerView.findViewById<TextView>(R.id.decoratedText)
+        private val btnAction = containerView.findViewById<ImageButton>(R.id.btnAction)
+        private val valueText = containerView.findViewById<TextView>(R.id.valueText)
+        private val statusInfoIcon = containerView.findViewById<ImageView>(R.id.statusInfoIcon)
+        private val transactionStatusView = containerView.findViewById<TransactionInfoStatusView>(R.id.transactionStatusView)
 
         fun bind(detail: TransactionDetailViewItem) {
             itemView.setOnClickListener(null)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/TransactionInfoFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/TransactionInfoFragment.kt
@@ -7,12 +7,15 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.browser.customtabs.CustomTabColorSchemeParams
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.navGraphViewModels
+import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import io.horizontalsystems.bankwallet.R
@@ -27,13 +30,23 @@ import io.horizontalsystems.core.helpers.HudHelper
 import io.horizontalsystems.core.setOnSingleClickListener
 import io.horizontalsystems.snackbar.CustomSnackbar
 import io.horizontalsystems.snackbar.SnackbarGravity
-import kotlinx.android.synthetic.main.fragment_transaction_info.*
 
 class TransactionInfoFragment : BottomSheetDialogFragment() {
 
     private val viewModelTxs by navGraphViewModels<TransactionsViewModel>(R.id.mainFragment)
     private val viewModel by viewModels<TransactionInfoViewModel>()
     private var snackBar: CustomSnackbar? = null
+    private lateinit var txtViewOnExplorer: TextView
+    private lateinit var closeButton: ImageView
+    private lateinit var rvDetails: RecyclerView
+    private lateinit var txtTitle: TextView
+    private lateinit var txtSubtitle: TextView
+    private lateinit var headerIcon: ImageView
+    private lateinit var sentToSelfIcon: ImageView
+    private lateinit var primaryValue: TextView
+    private lateinit var primaryName: TextView
+    private lateinit var secondaryName: TextView
+    private lateinit var secondaryValue: TextView
 
     override fun getTheme() = R.style.BottomDialog
 
@@ -57,6 +70,18 @@ class TransactionInfoFragment : BottomSheetDialogFragment() {
             viewModel.init(it.record, it.wallet)
             setTransactionInfoDialog()
         }
+
+        txtViewOnExplorer = view.findViewById(R.id.txtViewOnExplorer)
+        closeButton = view.findViewById(R.id.closeButton)
+        rvDetails = view.findViewById(R.id.rvDetails)
+        txtTitle = view.findViewById(R.id.txtTitle)
+        txtSubtitle = view.findViewById(R.id.txtSubtitle)
+        headerIcon = view.findViewById(R.id.headerIcon)
+        sentToSelfIcon = view.findViewById(R.id.sentToSelfIcon)
+        primaryValue = view.findViewById(R.id.primaryValue)
+        primaryName = view.findViewById(R.id.primaryName)
+        secondaryName = view.findViewById(R.id.secondaryName)
+        secondaryValue = view.findViewById(R.id.secondaryValue)
     }
 
     override fun onDismiss(dialog: DialogInterface) {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/TransactionInfoItemView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/TransactionInfoItemView.kt
@@ -2,14 +2,25 @@ package io.horizontalsystems.bankwallet.modules.transactions.transactionInfo
 
 import android.content.Context
 import android.util.AttributeSet
+import android.widget.ImageButton
+import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
 import io.horizontalsystems.bankwallet.R
-import kotlinx.android.synthetic.main.view_transaction_info_item.view.*
 
 class TransactionInfoItemView : ConstraintLayout {
+
+    private var txtTitle: TextView
+    private var decoratedText: TextView
+    private var btnAction: ImageButton
+    private var transactionStatusView: TransactionInfoStatusView
+
     init {
-        inflate(context, R.layout.view_transaction_info_item, this)
+        val rootView = inflate(context, R.layout.view_transaction_info_item, this)
+        txtTitle = rootView.findViewById(R.id.txtTitle)
+        decoratedText = rootView.findViewById(R.id.decoratedText)
+        btnAction = rootView.findViewById(R.id.btnAction)
+        transactionStatusView = rootView.findViewById(R.id.transactionStatusView)
     }
 
     constructor(context: Context) : super(context)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/TransactionInfoStatusView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/transactionInfo/TransactionInfoStatusView.kt
@@ -3,15 +3,19 @@ package io.horizontalsystems.bankwallet.modules.transactions.transactionInfo
 import android.content.Context
 import android.graphics.drawable.AnimationDrawable
 import android.util.AttributeSet
+import android.widget.ProgressBar
+import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.modules.transactions.TransactionStatus
-import kotlinx.android.synthetic.main.view_transaction_info_status.view.*
-import kotlinx.android.synthetic.main.view_transaction_info_status.view.progressBar
-
 
 open class TransactionInfoStatusView : ConstraintLayout {
+
+    private lateinit var progressBar: ProgressBar
+    private lateinit var confirmedText: TextView
+    private lateinit var progressText: TextView
+    private lateinit var failedText: TextView
 
     constructor(context: Context) : super(context) {
         initializeViews()
@@ -26,7 +30,11 @@ open class TransactionInfoStatusView : ConstraintLayout {
     }
 
     private fun initializeViews() {
-        inflate(context, R.layout.view_transaction_info_status, this)
+        val rootView = inflate(context, R.layout.view_transaction_info_status, this)
+        progressBar = rootView.findViewById(R.id.progressBar)
+        confirmedText = rootView.findViewById(R.id.confirmedText)
+        progressText = rootView.findViewById(R.id.progressText)
+        failedText = rootView.findViewById(R.id.failedText)
     }
 
     fun bind(transactionStatus: TransactionStatus, incoming: Boolean) {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/WalletConnectErrorFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/WalletConnectErrorFragment.kt
@@ -2,21 +2,21 @@ package io.horizontalsystems.bankwallet.modules.walletconnect
 
 import android.os.Bundle
 import android.view.View
-import androidx.core.os.bundleOf
+import android.widget.Button
+import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.setOnSingleClickListener
-import kotlinx.android.synthetic.main.fragment_wallet_connect_error.*
 
 class WalletConnectErrorFragment : Fragment(R.layout.fragment_wallet_connect_error) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        message.text = arguments?.getString(MESSAGE_KEY)
+        view.findViewById<TextView>(R.id.message).text = arguments?.getString(MESSAGE_KEY)
 
-        cancelButton.setOnSingleClickListener {
+        view.findViewById<Button>(R.id.cancelButton).setOnSingleClickListener {
             findNavController().popBackStack()
         }
     }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/list/WalletConnectListFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/list/WalletConnectListFragment.kt
@@ -4,6 +4,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
+import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
@@ -11,12 +13,10 @@ import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.bankwallet.core.setOnSingleClickListener
 import io.horizontalsystems.bankwallet.modules.walletconnect.list.WalletConnectListViewModel.WalletConnectViewItem
 import io.horizontalsystems.bankwallet.modules.walletconnect.main.WalletConnectMainModule
+import io.horizontalsystems.bankwallet.ui.extensions.PicassoRoundedImageView
 import io.horizontalsystems.core.findNavController
+import io.horizontalsystems.views.SettingsView
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.fragment_notifications.toolbar
-import kotlinx.android.synthetic.main.fragment_wallet_connect_list.*
-import kotlinx.android.synthetic.main.view_holder_wallet_connect_account.*
-import kotlinx.android.synthetic.main.view_holder_wallet_connect_session.*
 
 class WalletConnectListFragment : BaseFragment(), SessionViewHolder.Listener {
     private val viewModel by viewModels<WalletConnectListViewModel> { WalletConnectListModule.Factory() }
@@ -28,16 +28,16 @@ class WalletConnectListFragment : BaseFragment(), SessionViewHolder.Listener {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        toolbar.setNavigationOnClickListener {
+        view.findViewById<Toolbar>(R.id.toolbar).setNavigationOnClickListener {
             findNavController().popBackStack()
         }
 
-        newConnect.setOnSingleClickListener {
+        view.findViewById<SettingsView>(R.id.newConnect).setOnSingleClickListener {
             startNewConnection()
         }
 
         val walletConnectListAdapter = WalletConnectListAdapter(this)
-        sessionsRecyclerView.adapter = walletConnectListAdapter
+        view.findViewById<RecyclerView>(R.id.sessionsRecyclerView).adapter = walletConnectListAdapter
 
         viewModel.viewItemsLiveData.observe(viewLifecycleOwner, { viewItems ->
             walletConnectListAdapter.items = viewItems
@@ -100,6 +100,8 @@ class WalletConnectListAdapter(
 
 class AccountViewHolder(override val containerView: View) : RecyclerView.ViewHolder(containerView), LayoutContainer {
 
+    private val accountTextView = containerView.findViewById<TextView>(R.id.accountTextView)
+
     fun bind(account: WalletConnectViewItem.Account) {
         accountTextView.text = account.title
     }
@@ -115,6 +117,11 @@ class SessionViewHolder(
         override val containerView: View,
         private val listener: Listener
 ) : RecyclerView.ViewHolder(containerView), LayoutContainer {
+
+    private val titleTextView = containerView.findViewById<TextView>(R.id.titleTextView)
+    private val subtitleTextView = containerView.findViewById<TextView>(R.id.subtitleTextView)
+    private val backgroundView = containerView.findViewById<View>(R.id.backgroundView)
+    private val iconImageView = containerView.findViewById<PicassoRoundedImageView>(R.id.iconImageView)
 
     interface Listener {
         fun onSessionClick(session: WalletConnectViewItem.Session)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/main/DappInfoAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/main/DappInfoAdapter.kt
@@ -3,10 +3,10 @@ package io.horizontalsystems.bankwallet.modules.walletconnect.main
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.view_holder_dapp_item.*
 
 class DappInfoAdapter : RecyclerView.Adapter<DappInfoAdapter.ViewHolder>() {
 
@@ -18,6 +18,9 @@ class DappInfoAdapter : RecyclerView.Adapter<DappInfoAdapter.ViewHolder>() {
     }
 
     class ViewHolder(override val containerView: View) : RecyclerView.ViewHolder(containerView), LayoutContainer {
+
+        private val title = containerView.findViewById<TextView>(R.id.title)
+        private val value = containerView.findViewById<TextView>(R.id.value)
 
         fun bind(dappItemData: DappItemData) {
             title.text = containerView.context.getString(dappItemData.titleStringResId)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/main/WalletConnectMainFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/main/WalletConnectMainFragment.kt
@@ -6,12 +6,18 @@ import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.ProgressBar
+import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.widget.Toolbar
+import androidx.constraintlayout.widget.Group
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.navGraphViewModels
+import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.bankwallet.core.managers.WalletConnectInteractor
@@ -25,7 +31,7 @@ import io.horizontalsystems.bankwallet.modules.walletconnect.WalletConnectViewMo
 import io.horizontalsystems.bankwallet.modules.walletconnect.scanqr.WalletConnectScanQrModule
 import io.horizontalsystems.bankwallet.modules.walletconnect.scanqr.WalletConnectScanQrViewModel
 import io.horizontalsystems.bankwallet.ui.extensions.ConfirmationDialog
-import kotlinx.android.synthetic.main.fragment_wallet_connect_main.*
+import io.horizontalsystems.bankwallet.ui.extensions.PicassoRoundedImageView
 
 class WalletConnectMainFragment : BaseFragment() {
 
@@ -60,6 +66,17 @@ class WalletConnectMainFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
+        val connecting = view.findViewById<ProgressBar>(R.id.connecting)
+        val dappGroup = view.findViewById<Group>(R.id.dappGroup)
+        val dappTitle = view.findViewById<TextView>(R.id.dappTitle)
+        val dappIcon = view.findViewById<PicassoRoundedImageView>(R.id.dappIcon)
+        val cancelButton = view.findViewById<Button>(R.id.cancelButton)
+        val connectButton = view.findViewById<Button>(R.id.connectButton)
+        val disconnectButton = view.findViewById<Button>(R.id.disconnectButton)
+        val dappHint = view.findViewById<TextView>(R.id.dappHint)
+
         toolbar.setOnMenuItemClickListener { item ->
             when (item.itemId) {
                 R.id.menuClose -> {
@@ -100,7 +117,7 @@ class WalletConnectMainFragment : BaseFragment() {
 
 
         val dappInfoAdapter = DappInfoAdapter()
-        dappInfo.adapter = dappInfoAdapter
+        view.findViewById<RecyclerView>(R.id.dappInfo).adapter = dappInfoAdapter
 
         viewModel.connectingLiveData.observe(viewLifecycleOwner, {
             connecting.isVisible = it

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/request/WalletConnectSendEthereumTransactionRequestFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/request/WalletConnectSendEthereumTransactionRequestFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import androidx.activity.addCallback
 import androidx.fragment.app.viewModels
 import androidx.navigation.navGraphViewModels
@@ -12,11 +13,11 @@ import io.horizontalsystems.bankwallet.core.AppLogger
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.bankwallet.core.ethereum.EthereumFeeViewModel
 import io.horizontalsystems.bankwallet.core.setOnSingleClickListener
+import io.horizontalsystems.bankwallet.modules.sendevmtransaction.SendEvmTransactionView
 import io.horizontalsystems.bankwallet.modules.sendevmtransaction.SendEvmTransactionViewModel
 import io.horizontalsystems.bankwallet.modules.walletconnect.WalletConnectViewModel
 import io.horizontalsystems.core.findNavController
 import io.horizontalsystems.core.helpers.HudHelper
-import kotlinx.android.synthetic.main.fragment_wallet_connect_request.*
 
 class WalletConnectSendEthereumTransactionRequestFragment : BaseFragment() {
     private val logger = AppLogger("wallet-connect")
@@ -33,6 +34,9 @@ class WalletConnectSendEthereumTransactionRequestFragment : BaseFragment() {
         val viewModel by viewModels<WalletConnectSendEthereumTransactionRequestViewModel> { vmFactory }
         val sendViewModel by viewModels<SendEvmTransactionViewModel> { vmFactory }
         val feeViewModel by viewModels<EthereumFeeViewModel> { vmFactory }
+
+        val btnApprove = view.findViewById<Button>(R.id.btnApprove)
+        val btnReject = view.findViewById<Button>(R.id.btnReject)
 
         btnApprove.setOnSingleClickListener {
             logger.info("click approve button")
@@ -67,7 +71,7 @@ class WalletConnectSendEthereumTransactionRequestFragment : BaseFragment() {
             HudHelper.showErrorMessage(requireActivity().findViewById(android.R.id.content), it)
         })
 
-        sendEvmTransactionView.init(
+        view.findViewById<SendEvmTransactionView>(R.id.sendEvmTransactionView).init(
                 sendViewModel,
                 feeViewModel,
                 viewLifecycleOwner,

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/FeeInfoFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/FeeInfoFragment.kt
@@ -4,10 +4,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.widget.Toolbar
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseFragment
 import io.horizontalsystems.core.findNavController
-import kotlinx.android.synthetic.main.fragment_fee_info.*
 
 class FeeInfoFragment : BaseFragment() {
 
@@ -17,7 +17,7 @@ class FeeInfoFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        toolbar.setOnMenuItemClickListener { item ->
+        view.findViewById<Toolbar>(R.id.toolbar).setOnMenuItemClickListener { item ->
             when (item.itemId) {
                 R.id.menuClose -> {
                     findNavController().popBackStack()

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/FeeSelectorView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/FeeSelectorView.kt
@@ -3,6 +3,7 @@ package io.horizontalsystems.bankwallet.ui
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
+import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentManager
@@ -16,7 +17,6 @@ import io.horizontalsystems.bankwallet.core.ethereum.SendPriorityViewItem
 import io.horizontalsystems.bankwallet.ui.extensions.SelectorDialog
 import io.horizontalsystems.bankwallet.ui.extensions.SelectorItem
 import io.horizontalsystems.seekbar.FeeSeekBar
-import kotlinx.android.synthetic.main.view_fee_selector.view.*
 
 class FeeSelectorView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0)
     : ConstraintLayout(context, attrs, defStyleAttr) {
@@ -25,8 +25,27 @@ class FeeSelectorView @JvmOverloads constructor(context: Context, attrs: Attribu
     var prioritySelectListener: (position: Int) -> Unit = { }
     var customFeeSeekBarListener: (value: Int) -> Unit = { }
 
+    private var txSpeedMenuClickArea: View
+    private var customFeeSeekBar: FeeSeekBar
+    private var txEstimatedFeeValue: TextView
+    private var txFeeValue: TextView
+    private var txSpeedMenu: TextView
+    private var feeInfoImageClickArea: View
+    private var txEstimatedFeeTitle: TextView
+    private var txFeeTitle: TextView
+    private var warningOfStuck: TextView
+
     init {
-        inflate(context, R.layout.view_fee_selector, this)
+        val rootView = inflate(context, R.layout.view_fee_selector, this)
+        txSpeedMenuClickArea = rootView.findViewById(R.id.txSpeedMenuClickArea)
+        customFeeSeekBar = rootView.findViewById(R.id.customFeeSeekBar)
+        txEstimatedFeeValue = rootView.findViewById(R.id.txEstimatedFeeValue)
+        txFeeValue = rootView.findViewById(R.id.txFeeValue)
+        txSpeedMenu = rootView.findViewById(R.id.txSpeedMenu)
+        feeInfoImageClickArea = rootView.findViewById(R.id.feeInfoImageClickArea)
+        txEstimatedFeeTitle = rootView.findViewById(R.id.txEstimatedFeeTitle)
+        txFeeTitle = rootView.findViewById(R.id.txFeeTitle)
+        warningOfStuck = rootView.findViewById(R.id.warningOfStuck)
 
         txSpeedMenuClickArea.setOnClickListener {
             onTxSpeedClickListener(it)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/AddressInputView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/AddressInputView.kt
@@ -4,6 +4,9 @@ import android.content.Context
 import android.text.Editable
 import android.text.TextWatcher
 import android.util.AttributeSet
+import android.widget.EditText
+import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
 import androidx.lifecycle.LifecycleOwner
@@ -11,8 +14,8 @@ import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.modules.swap.tradeoptions.Caution
 import io.horizontalsystems.bankwallet.modules.swap.tradeoptions.RecipientAddressViewModel
 import io.horizontalsystems.bankwallet.ui.helpers.TextHelper
+import io.horizontalsystems.views.ViewState
 import io.horizontalsystems.views.helpers.LayoutHelper
-import kotlinx.android.synthetic.main.view_input_address.view.*
 
 class AddressInputView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0)
     : ConstraintLayout(context, attrs, defStyleAttr) {
@@ -20,6 +23,13 @@ class AddressInputView @JvmOverloads constructor(context: Context, attrs: Attrib
     private var showQrButton: Boolean = false
     private var onTextChangeCallback: ((text: String?) -> Unit)? = null
     private var onPasteCallback: ((text: String?) -> Unit)? = null
+
+    private lateinit var input: EditText
+    private lateinit var actionsLayout: LinearLayout
+    private var title: TextView
+    private var description: TextView
+    private var error: TextView
+    private var inputBackground: ViewState
 
     private val textWatcher = object : TextWatcher {
         override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
@@ -61,7 +71,13 @@ class AddressInputView @JvmOverloads constructor(context: Context, attrs: Attrib
     }
 
     init {
-        inflate(context, R.layout.view_input_address, this)
+        val rootView = inflate(context, R.layout.view_input_address, this)
+        input = rootView.findViewById(R.id.input)
+        actionsLayout = rootView.findViewById(R.id.actionsLayout)
+        title = rootView.findViewById(R.id.title)
+        description = rootView.findViewById(R.id.description)
+        error = rootView.findViewById(R.id.error)
+        inputBackground = rootView.findViewById(R.id.inputBackground)
 
         val ta = context.obtainStyledAttributes(attrs, R.styleable.AddressInputView)
         try {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/AmountInputView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/AmountInputView.kt
@@ -4,13 +4,16 @@ import android.content.Context
 import android.text.Editable
 import android.text.TextWatcher
 import android.util.AttributeSet
+import android.view.View
 import android.view.animation.AnimationUtils
+import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.fiat.AmountTypeSwitchService
 import io.horizontalsystems.core.helpers.KeyboardHelper
-import kotlinx.android.synthetic.main.view_input_amount.view.*
 
 class AmountInputView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0)
     : ConstraintLayout(context, attrs, defStyleAttr) {
@@ -24,6 +27,12 @@ class AmountInputView @JvmOverloads constructor(context: Context, attrs: Attribu
     var onTextChangeCallback: ((prevText: String?, newText: String?) -> Unit)? = null
     var onTapMaxCallback: (() -> Unit)? = null
     var onTapSecondaryCallback: (() -> Unit)? = null
+
+    private var editTxtAmount: EditText
+    private var btnMax: Button
+    private var topAmountPrefix: TextView
+    private var txtHintInfo: TextView
+    private var secondaryArea: View
 
     private val textWatcher = object : TextWatcher {
         private var prevValue: String? = null
@@ -40,7 +49,12 @@ class AmountInputView @JvmOverloads constructor(context: Context, attrs: Attribu
     }
 
     init {
-        inflate(context, R.layout.view_input_amount, this)
+        val rootView = inflate(context, R.layout.view_input_amount, this)
+        editTxtAmount = rootView.findViewById(R.id.editTxtAmount)
+        btnMax = rootView.findViewById(R.id.btnMax)
+        topAmountPrefix = rootView.findViewById(R.id.topAmountPrefix)
+        txtHintInfo = rootView.findViewById(R.id.txtHintInfo)
+        secondaryArea = rootView.findViewById(R.id.secondaryArea)
 
         editTxtAmount.addTextChangedListener(textWatcher)
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/BottomSheetSelectorDialog.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/BottomSheetSelectorDialog.kt
@@ -5,14 +5,14 @@ import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.TextView
 import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.views.inflate
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.fragment_bottom_selector.*
-import kotlinx.android.synthetic.main.view_holder_setting_with_checkmark_wrapper.*
 
 class BottomSheetSelectorDialog(
         private val title: String,
@@ -31,6 +31,8 @@ class BottomSheetSelectorDialog(
 
         setContentView(R.layout.fragment_bottom_selector)
 
+        val textWarning = view.findViewById<TextView>(R.id.textWarning)
+
         setTitle(title)
         setSubtitle(subtitle)
         setHeaderIconDrawable(icon)
@@ -39,11 +41,11 @@ class BottomSheetSelectorDialog(
 
         textWarning.text = warning
         textWarning.isVisible = warning != null
-        divider.isVisible = warning != null
+        view.findViewById<View>(R.id.divider).isVisible = warning != null
 
-        rvItems.adapter = itemsAdapter
+        view.findViewById<RecyclerView>(R.id.rvItems).adapter = itemsAdapter
 
-        btnDone.setOnClickListener {
+        view.findViewById<Button>(R.id.btnDone).setOnClickListener {
             if (notifyUnchanged || itemsAdapter.selected != selected) {
                 onItemSelected(itemsAdapter.selected)
             }
@@ -98,6 +100,8 @@ class SelectorItemsAdapter(private val items: List<BottomSheetSelectorViewItem>,
 
 class ItemViewHolder(override val containerView: View, val onItemClick: (Int) -> Unit)
     : RecyclerView.ViewHolder(containerView), LayoutContainer {
+
+    private val itemWithCheckmark = containerView.findViewById<ItemWithCheckmark>(R.id.itemWithCheckmark)
 
     init {
         containerView.setOnClickListener {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/BottomSheetSelectorMultipleDialog.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/BottomSheetSelectorMultipleDialog.kt
@@ -5,14 +5,14 @@ import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.TextView
 import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentManager
 import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.views.inflate
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.fragment_bottom_selector.*
-import kotlinx.android.synthetic.main.view_holder_setting_with_checkmark_wrapper.*
 
 class BottomSheetSelectorMultipleDialog(
         private val title: String,
@@ -31,6 +31,9 @@ class BottomSheetSelectorMultipleDialog(
 
         setContentView(R.layout.fragment_bottom_selector)
 
+        val btnDone = view.findViewById<Button>(R.id.btnDone)
+        val textWarning = view.findViewById<TextView>(R.id.textWarning)
+
         setTitle(title)
         setSubtitle(subtitle)
         setHeaderIconDrawable(icon)
@@ -41,9 +44,9 @@ class BottomSheetSelectorMultipleDialog(
 
         textWarning.text = warning
         textWarning.isVisible = warning != null
-        divider.isVisible = warning != null
+        view.findViewById<View>(R.id.divider).isVisible = warning != null
 
-        rvItems.adapter = itemsAdapter
+        view.findViewById<RecyclerView>(R.id.rvItems).adapter = itemsAdapter
 
         btnDone.setOnClickListener {
             if (notifyUnchanged || !equals(itemsAdapter.selected, selected)) {
@@ -106,6 +109,8 @@ class MultipleSelectorItemsAdapter(private val items: List<BottomSheetSelectorVi
 
 class ItemViewHolderMultiple(override val containerView: View, val onItemClick: (Int) -> Unit)
     : RecyclerView.ViewHolder(containerView), LayoutContainer {
+
+    private val itemWithCheckmark = containerView.findViewById<ItemWithCheckmark>(R.id.itemWithCheckmark)
 
     init {
         containerView.setOnClickListener {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/InputView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/InputView.kt
@@ -6,18 +6,27 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.util.AttributeSet
 import android.view.animation.AnimationUtils
+import android.widget.EditText
+import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.modules.swap.tradeoptions.Caution
+import io.horizontalsystems.views.ViewState
 import io.horizontalsystems.views.helpers.LayoutHelper
-import kotlinx.android.synthetic.main.view_input.view.*
 
 class InputView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0)
     : ConstraintLayout(context, attrs, defStyleAttr) {
 
     private var onTextChangeCallback: ((prevText: String?, newText: String?) -> Unit)? = null
     private var onPasteCallback: ((text: String?) -> Unit)? = null
+
+    private lateinit var input: EditText
+    private lateinit var actionsLayout: LinearLayout
+    private var error: TextView
+    private var inputBackground: ViewState
+    private var txtPrefix: TextView
 
     private val textWatcher = object : TextWatcher {
         private var prevValue: String? = null
@@ -47,7 +56,12 @@ class InputView @JvmOverloads constructor(context: Context, attrs: AttributeSet?
     }
 
     init {
-        inflate(context, R.layout.view_input, this)
+        val rootView = inflate(context, R.layout.view_input, this)
+        input = rootView.findViewById(R.id.input)
+        actionsLayout = rootView.findViewById(R.id.actionsLayout)
+        error = rootView.findViewById(R.id.error)
+        inputBackground = rootView.findViewById(R.id.inputBackground)
+        txtPrefix = rootView.findViewById(R.id.txtPrefix)
 
         val ta = context.obtainStyledAttributes(attrs, R.styleable.InputView)
         try {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/InputWithButtonsView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/InputWithButtonsView.kt
@@ -6,12 +6,16 @@ import android.text.TextWatcher
 import android.util.AttributeSet
 import android.view.animation.AnimationUtils
 import android.view.inputmethod.EditorInfo
+import android.widget.Button
+import android.widget.EditText
+import android.widget.ImageButton
+import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
 import androidx.lifecycle.LifecycleOwner
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.modules.swap.tradeoptions.IVerifiedInputViewModel
-import kotlinx.android.synthetic.main.view_input_with_buttons.view.*
+import io.horizontalsystems.views.ViewState
 
 class InputWithButtonsView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0)
     : ConstraintLayout(context, attrs, defStyleAttr) {
@@ -32,8 +36,25 @@ class InputWithButtonsView @JvmOverloads constructor(context: Context, attrs: At
         }
     }
 
+    private var title: TextView
+    private var description: TextView
+    private var input: EditText
+    private var deleteButton: ImageButton
+    private var error: TextView
+    private var inputBackground: ViewState
+    private var inputButtonLeft: Button
+    private var inputButtonRight: Button
+
     init {
-        inflate(context, R.layout.view_input_with_buttons, this)
+        val rootView = inflate(context, R.layout.view_input_with_buttons, this)
+        title = rootView.findViewById(R.id.title)
+        description = rootView.findViewById(R.id.description)
+        input = rootView.findViewById(R.id.input)
+        deleteButton = rootView.findViewById(R.id.deleteButton)
+        error = rootView.findViewById(R.id.error)
+        inputBackground = rootView.findViewById(R.id.inputBackground)
+        inputButtonLeft = rootView.findViewById(R.id.inputButtonLeft)
+        inputButtonRight = rootView.findViewById(R.id.inputButtonRight)
 
         val ta = context.obtainStyledAttributes(attrs, R.styleable.InputWithButtonsView)
         try {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/ItemWithCheckmark.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/ItemWithCheckmark.kt
@@ -3,15 +3,23 @@ package io.horizontalsystems.bankwallet.ui.extensions
 import android.content.Context
 import android.util.AttributeSet
 import android.widget.FrameLayout
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.core.view.isVisible
 import io.horizontalsystems.bankwallet.R
-import kotlinx.android.synthetic.main.view_item_with_checkmark.view.*
 
 class ItemWithCheckmark @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0)
     : FrameLayout(context, attrs, defStyleAttr) {
 
+    private var itemTitle: TextView
+    private var itemSubtitle: TextView
+    private var checkMark: ImageView
+
     init {
-        inflate(context, R.layout.view_item_with_checkmark, this)
+        val rootView = inflate(context, R.layout.view_item_with_checkmark, this)
+        itemTitle = rootView.findViewById(R.id.itemTitle)
+        itemSubtitle = rootView.findViewById(R.id.itemSubtitle)
+        checkMark = rootView.findViewById(R.id.checkMark)
     }
 
     fun bind(title: String, subtitle: String, checked: Boolean) {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/MarketFilterSwitchView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/MarketFilterSwitchView.kt
@@ -5,20 +5,23 @@ import android.util.AttributeSet
 import android.view.Gravity
 import android.widget.CompoundButton
 import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.appcompat.widget.SwitchCompat
 import io.horizontalsystems.bankwallet.R
-import kotlinx.android.synthetic.main.view_market_filter_switch.view.*
 
 class MarketFilterSwitchView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0)
     : LinearLayout(context, attrs, defStyleAttr), CompoundButton.OnCheckedChangeListener {
 
     private var onCheckedChangeListener: CompoundButton.OnCheckedChangeListener? = null
     private var notifyListener = true
+    private var switchView: SwitchCompat
 
     init {
         orientation = HORIZONTAL
         gravity = Gravity.CENTER_VERTICAL
 
-        inflate(context, R.layout.view_market_filter_switch, this)
+        val rootView = inflate(context, R.layout.view_market_filter_switch, this)
+        switchView = rootView.findViewById(R.id.switchView)
 
         switchView.setOnCheckedChangeListener(this)
 
@@ -26,7 +29,7 @@ class MarketFilterSwitchView @JvmOverloads constructor(context: Context, attrs: 
 
         val ta = context.obtainStyledAttributes(attrs, R.styleable.MarketFilterSwitchView)
         try {
-            title.text = ta.getString(R.styleable.MarketFilterSwitchView_title)
+            rootView.findViewById<TextView>(R.id.title).text = ta.getString(R.styleable.MarketFilterSwitchView_title)
             setChecked(ta.getBoolean(R.styleable.MarketFilterSwitchView_checked, false))
         } finally {
             ta.recycle()

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/MarketFilterView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/MarketFilterView.kt
@@ -4,22 +4,25 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.Gravity
 import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.annotation.ColorRes
 import io.horizontalsystems.bankwallet.R
-import kotlinx.android.synthetic.main.view_market_filter.view.*
 
 class MarketFilterView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0)
     : LinearLayout(context, attrs, defStyleAttr) {
+
+    private var value: TextView
 
     init {
         orientation = HORIZONTAL
         gravity = Gravity.CENTER_VERTICAL
 
-        inflate(context, R.layout.view_market_filter, this)
+        val rootView = inflate(context, R.layout.view_market_filter, this)
+        value = rootView.findViewById(R.id.value)
 
         val ta = context.obtainStyledAttributes(attrs, R.styleable.MarketFilterView)
         try {
-            title.text = ta.getString(R.styleable.MarketFilterView_title)
+            rootView.findViewById<TextView>(R.id.title).text = ta.getString(R.styleable.MarketFilterView_title)
             setValueColored(ta.getString(R.styleable.MarketFilterView_value))
         } finally {
             ta.recycle()

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/MarketListHeaderView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/MarketListHeaderView.kt
@@ -2,12 +2,13 @@ package io.horizontalsystems.bankwallet.ui.extensions
 
 import android.content.Context
 import android.util.AttributeSet
+import android.widget.Button
+import android.widget.RadioGroup
 import androidx.constraintlayout.widget.ConstraintLayout
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.setOnSingleClickListener
 import io.horizontalsystems.bankwallet.modules.market.MarketField
 import io.horizontalsystems.bankwallet.modules.market.SortingField
-import kotlinx.android.synthetic.main.view_market_list_header.view.*
 
 class MarketListHeaderView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0)
     : ConstraintLayout(context, attrs, defStyleAttr) {
@@ -20,9 +21,13 @@ class MarketListHeaderView @JvmOverloads constructor(context: Context, attrs: At
     var listener: Listener? = null
 
     private var triggerMarketFieldChangeListener = true
+    private var sortingField: Button
+    private var marketFieldSelector: RadioGroup
 
     init {
-        inflate(context, R.layout.view_market_list_header, this)
+        val rootView = inflate(context, R.layout.view_market_list_header, this)
+        sortingField = rootView.findViewById(R.id.sortingField)
+        marketFieldSelector = rootView.findViewById(R.id.marketFieldSelector)
 
         sortingField.setOnSingleClickListener {
             listener?.onClickSortingField()

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/MarketMetricSmallView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/MarketMetricSmallView.kt
@@ -2,19 +2,29 @@ package io.horizontalsystems.bankwallet.ui.extensions
 
 import android.content.Context
 import android.util.AttributeSet
+import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.App
 import io.horizontalsystems.chartview.ChartData
+import io.horizontalsystems.chartview.ChartMinimal
 import io.horizontalsystems.views.helpers.LayoutHelper
-import kotlinx.android.synthetic.main.view_market_metric_small.view.*
 import java.math.BigDecimal
 
 class MarketMetricSmallView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0)
     : ConstraintLayout(context, attrs, defStyleAttr) {
 
+    private var title: TextView
+    private var value: TextView
+    private var chart: ChartMinimal
+    private var diffPercentage: TextView
+
     init {
-        inflate(context, R.layout.view_market_metric_small, this)
+        val rootView = inflate(context, R.layout.view_market_metric_small, this)
+        title = rootView.findViewById(R.id.title)
+        value = rootView.findViewById(R.id.value)
+        chart = rootView.findViewById(R.id.chart)
+        diffPercentage = rootView.findViewById(R.id.diffPercentage)
 
         val ta = context.obtainStyledAttributes(attrs, R.styleable.MarketMetricSmallView)
         try {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/MnemonicPhraseView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/MnemonicPhraseView.kt
@@ -2,17 +2,37 @@ package io.horizontalsystems.bankwallet.ui.extensions
 
 import android.content.Context
 import android.util.AttributeSet
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.constraintlayout.widget.Group
 import androidx.core.view.isVisible
 import androidx.core.widget.NestedScrollView
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.views.BackupWordView
-import kotlinx.android.synthetic.main.view_mnemonic_phrase.view.*
 
 class MnemonicPhraseView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0)
     : NestedScrollView(context, attrs, defStyleAttr) {
 
+    private var topLeft: LinearLayout
+    private var middleLeft: LinearLayout
+    private var topRight: LinearLayout
+    private var middleRight: LinearLayout
+    private var bottomLeft: LinearLayout
+    private var bottomRight: LinearLayout
+    private var passphraseGroup: Group
+    private var passphraseValue: TextView
+
     init {
-        inflate(context, R.layout.view_mnemonic_phrase, this)
+        val rootView = inflate(context, R.layout.view_mnemonic_phrase, this)
+        topLeft = rootView.findViewById(R.id.topLeft)
+        middleLeft = rootView.findViewById(R.id.middleLeft)
+        topRight = rootView.findViewById(R.id.topRight)
+        middleRight = rootView.findViewById(R.id.middleRight)
+        bottomLeft = rootView.findViewById(R.id.bottomLeft)
+        bottomRight = rootView.findViewById(R.id.bottomRight)
+        passphraseGroup = rootView.findViewById(R.id.passphraseGroup)
+        passphraseValue = rootView.findViewById(R.id.passphraseValue)
+
     }
 
     fun populateWords(words: List<String>, passphrase: String) {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/PriceGradientView.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/PriceGradientView.kt
@@ -10,7 +10,6 @@ import android.widget.ImageView
 import androidx.cardview.widget.CardView
 import androidx.core.graphics.values
 import io.horizontalsystems.bankwallet.R
-import kotlinx.android.synthetic.main.view_price_gradient.view.*
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
@@ -27,8 +26,11 @@ class PriceGradientView @JvmOverloads constructor(context: Context, attrs: Attri
     private val alphaDuration = 600L
     private val translateDuration = 1000L
 
+    private var gradientImage: ImageView
+
     init {
-        inflate(context, R.layout.view_price_gradient, this)
+        val rootView = inflate(context, R.layout.view_price_gradient, this)
+        gradientImage = rootView.findViewById(R.id.gradientImage)
 
         val ta = context.obtainStyledAttributes(attrs, R.styleable.PriceGradientView)
         try {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/SelectorDialog.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/SelectorDialog.kt
@@ -10,7 +10,6 @@ import androidx.fragment.app.DialogFragment
 import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.view_holder_item_selector.*
 
 class SelectorDialog : DialogFragment(), SelectorAdapter.Listener {
 
@@ -78,6 +77,9 @@ class SelectorAdapter(private val list: List<SelectorItem>,
 }
 
 class SelectorOptionViewHolder(override val containerView: View, private val listener: SelectorAdapter.Listener) : RecyclerView.ViewHolder(containerView), LayoutContainer {
+
+    private val itemTitle = containerView.findViewById<TextView>(R.id.itemTitle)
+    private val topDivider = containerView.findViewById<View>(R.id.topDivider)
 
     init {
         containerView.setOnClickListener { listener.onClick(bindingAdapterPosition) }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/SettingItemWithCheckmark.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/SettingItemWithCheckmark.kt
@@ -2,17 +2,28 @@ package io.horizontalsystems.bankwallet.ui.extensions
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.View
 import android.widget.FrameLayout
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.core.view.isVisible
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.views.ListPosition
-import kotlinx.android.synthetic.main.view_settings_item_with_checkmark.view.*
 
 class SettingItemWithCheckmark @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0)
     : FrameLayout(context, attrs, defStyleAttr) {
 
+    private var itemTitle: TextView
+    private var itemSubtitle: TextView
+    private var checkMark: ImageView
+    private var backgroundView: View
+
     init {
-        inflate(context, R.layout.view_settings_item_with_checkmark, this)
+        val rootView = inflate(context, R.layout.view_settings_item_with_checkmark, this)
+        itemTitle = rootView.findViewById(R.id.itemTitle)
+        itemSubtitle = rootView.findViewById(R.id.itemSubtitle)
+        checkMark = rootView.findViewById(R.id.checkMark)
+        backgroundView = rootView.findViewById(R.id.backgroundView)
     }
 
     fun bind(title: String, subtitle: String, checked: Boolean, onClick: () -> Unit, listPosition: ListPosition) {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/coinlist/CoinListAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/coinlist/CoinListAdapter.kt
@@ -2,6 +2,9 @@ package io.horizontalsystems.bankwallet.ui.extensions.coinlist
 
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.appcompat.widget.SwitchCompat
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
@@ -14,7 +17,6 @@ import io.horizontalsystems.coinkit.models.Coin
 import io.horizontalsystems.views.ListPosition
 import io.horizontalsystems.views.inflate
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.view_holder_coin_manage_item.*
 
 class CoinListAdapter(private val listener: Listener) : ListAdapter<CoinViewItem, CoinWithSwitchViewHolder>(diffCallback) {
 
@@ -82,6 +84,15 @@ class CoinWithSwitchViewHolder(
         private val onSwitch: (isChecked: Boolean, position: Int) -> Unit,
         private val onEdit: (position: Int) -> Unit
 ) : RecyclerView.ViewHolder(containerView), LayoutContainer {
+
+    private val toggleSwitch = containerView.findViewById<SwitchCompat>(R.id.toggleSwitch)
+    private val edit = containerView.findViewById<ImageView>(R.id.edit)
+    private val backgroundView = containerView.findViewById<View>(R.id.backgroundView)
+    private val coinIcon = containerView.findViewById<ImageView>(R.id.coinIcon)
+    private val coinTitle = containerView.findViewById<TextView>(R.id.coinTitle)
+    private val coinSubtitle = containerView.findViewById<TextView>(R.id.coinSubtitle)
+    private val coinTypeLabel = containerView.findViewById<TextView>(R.id.coinTypeLabel)
+    private val dividerView = containerView.findViewById<View>(R.id.dividerView)
 
     init {
         containerView.setOnClickListener {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/coinlist/CoinListBaseFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/coinlist/CoinListBaseFragment.kt
@@ -4,8 +4,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ProgressBar
+import androidx.appcompat.widget.Toolbar
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.ConcatAdapter
+import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.BaseWithSearchFragment
 import io.horizontalsystems.bankwallet.modules.blockchainsettings.BlockchainSettingsModule
@@ -13,12 +16,12 @@ import io.horizontalsystems.bankwallet.ui.extensions.BottomSheetSelectorMultiple
 import io.horizontalsystems.bankwallet.ui.helpers.AppLayoutHelper
 import io.horizontalsystems.coinkit.models.Coin
 import io.horizontalsystems.core.findNavController
-import kotlinx.android.synthetic.main.fragment_manage_wallets.*
 
 abstract class CoinListBaseFragment : BaseWithSearchFragment(), CoinListAdapter.Listener {
 
     private lateinit var featuredItemsAdapter: CoinListAdapter
     private lateinit var itemsAdapter: CoinListAdapter
+    private lateinit var progressLoading: ProgressBar
 
     abstract val title: CharSequence
 
@@ -29,6 +32,10 @@ abstract class CoinListBaseFragment : BaseWithSearchFragment(), CoinListAdapter.
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
+        val recyclerView = view.findViewById<RecyclerView>(R.id.recyclerView)
+
         toolbar.title = title
         toolbar.setNavigationOnClickListener {
             findNavController().popBackStack()
@@ -80,7 +87,7 @@ abstract class CoinListBaseFragment : BaseWithSearchFragment(), CoinListAdapter.
                 onItemSelected = { onSelect(it) },
                 onCancelled = { onCancelSelection() },
                 warning = config.description
-                )
+        )
     }
 
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/selector/SelectorBottomSheetDialog.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/selector/SelectorBottomSheetDialog.kt
@@ -3,9 +3,9 @@ package io.horizontalsystems.bankwallet.ui.selector
 import android.os.Bundle
 import android.view.View
 import androidx.annotation.DrawableRes
+import androidx.recyclerview.widget.RecyclerView
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.ui.extensions.BaseBottomSheetDialogFragment
-import kotlinx.android.synthetic.main.dialog_selector.*
 
 class SelectorBottomSheetDialog<ItemClass> : BaseBottomSheetDialogFragment() {
 
@@ -36,7 +36,7 @@ class SelectorBottomSheetDialog<ItemClass> : BaseBottomSheetDialogFragment() {
                 dismiss()
             })
 
-            rvItems.adapter = itemsAdapter
+            view.findViewById<RecyclerView>(R.id.rvItems).adapter = itemsAdapter
         }
     }
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/selector/SelectorItemViewHolder.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/selector/SelectorItemViewHolder.kt
@@ -1,11 +1,17 @@
 package io.horizontalsystems.bankwallet.ui.selector
 
 import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.core.view.isVisible
+import io.horizontalsystems.bankwallet.R
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.view_holder_selector_item.*
 
 class SelectorItemViewHolder<ItemClass>(override val containerView: View) : ItemViewHolder<ViewItemWrapper<ItemClass>>(containerView), LayoutContainer {
+
+    private var title: TextView = containerView.findViewById(R.id.title)
+    private var selectedIcon: ImageView = containerView.findViewById(R.id.selectedIcon)
+
     override fun bind(selected: Boolean) {
         title.text = item?.title
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/selector/SelectorOptionTextViewHolder.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/selector/SelectorOptionTextViewHolder.kt
@@ -1,10 +1,13 @@
 package io.horizontalsystems.bankwallet.ui.selector
 
 import android.view.View
+import android.widget.TextView
+import io.horizontalsystems.bankwallet.R
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.view_holder_item_selector.*
 
 class SelectorOptionTextViewHolder<ItemClass>(override val containerView: View) : ItemViewHolder<ViewItemWrapper<ItemClass>>(containerView), LayoutContainer {
+
+    private val itemTitle = containerView.findViewById<TextView>(R.id.itemTitle)
 
     override fun bind(selected: Boolean) {
         itemTitle.text = item?.title


### PR DESCRIPTION
Dear @rafaelekol , @abdrasulov, @tmedetbekov , @nk-the-crazy 

This PR aims at removal of `Kotlin synthetic` for view binding as it's going to be deprecated soon by `Kotlin` team
(https://kotlinlang.org/docs/whatsnew1420.html#deprecation-of-synthetic-views).

Another option for binding views is using Android Jetpack's View Binding (https://developer.android.com/topic/libraries/view-binding). However, since this belongs Jetpack, I'm not sure if they are deprecating the feature in the future or not.
Hence, for safety I chose the traditional `findViewById()` API to make the codebase sustainable.

I ran the unit tests and did sanity test on the functionalities. Everything seems to work fine.

Kindly take a look and merge this change.
