### PR TITLE
WC confirmation screen text fixes

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/sendevmtransaction/SendEvmTransactionViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/sendevmtransaction/SendEvmTransactionViewModel.kt
@@ -43,6 +43,7 @@ class SendEvmTransactionViewModel(
     val sendFailedLiveData = MutableLiveData<String>()
 
     val viewItemsLiveData = MutableLiveData<List<SectionViewItem>>()
+    val transactionTitleLiveData = MutableLiveData<String>()
 
     init {
         service.stateObservable.subscribeIO { sync(it) }.let { disposable.add(it) }
@@ -74,6 +75,8 @@ class SendEvmTransactionViewModel(
         val decoration = txDataState.dataOrNull?.decoration
         val transactionData = txDataState.dataOrNull?.transactionData
 
+        transactionTitleLiveData.postValue(getTransactionTitle(decoration, transactionData))
+
         var viewItems = when {
             decoration is SwapMethodDecoration || decoration is OneInchMethodDecoration -> {
                 getSwapViewItems(decoration, txDataState.dataOrNull?.additionalInfo)
@@ -95,6 +98,19 @@ class SendEvmTransactionViewModel(
             viewItemsLiveData.postValue(it)
         }
     }
+
+    private fun getTransactionTitle(decoration: ContractMethodDecoration?, transactionData: TransactionData?) =
+        if (decoration == null && transactionData?.input?.isEmpty() == true) {
+            Translator.getString(R.string.WalletConnect_SendRequest_Title)
+        } else {
+            when (decoration) {
+                is TransferMethodDecoration -> Translator.getString(R.string.WalletConnect_SendRequest_Title)
+                is ApproveMethodDecoration -> Translator.getString(R.string.WalletConnect_ApproveRequest_Title)
+                is SwapMethodDecoration,
+                is OneInchMethodDecoration -> Translator.getString(R.string.WalletConnect_SwapRequest_Title)
+                else -> Translator.getString(R.string.WalletConnect_UnknownRequest_Title)
+            }
+        }
 
     private fun sync(sendState: SendEvmTransactionService.SendState) =
             when (sendState) {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/request/sendtransaction/WalletConnectSendEthereumTransactionRequestFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/request/sendtransaction/WalletConnectSendEthereumTransactionRequestFragment.kt
@@ -93,6 +93,10 @@ class WalletConnectSendEthereumTransactionRequestFragment : BaseFragment() {
             }
         )
 
+        sendViewModel.transactionTitleLiveData.observe(viewLifecycleOwner, {
+            toolbar.title = it
+        })
+
         setButtons()
     }
 
@@ -104,9 +108,9 @@ class WalletConnectSendEthereumTransactionRequestFragment : BaseFragment() {
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
-                        title = getString(R.string.Button_Approve),
+                        title = getString(R.string.Button_Confirm),
                         onClick = {
-                            logger.info("click approve button")
+                            logger.info("click confirm button")
                             sendViewModel.send(logger)
                         },
                         enabled = approveEnabled

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="Button_Change">Change</string>
     <string name="Button_Add">Add</string>
     <string name="Button_Approve">Approve</string>
+    <string name="Button_Confirm">Confirm</string>
     <string name="Button_Connect">Connect</string>
     <string name="Button_Reject">Reject</string>
     <string name="Button_Disconnect">Disconnect</string>
@@ -338,6 +339,10 @@
     <!--Wallet Connect-->
     <string name="WalletConnect_Title">Wallet Connect</string>
     <string name="WalletConnect_Request">Request</string>
+    <string name="WalletConnect_SendRequest_Title">Send</string>
+    <string name="WalletConnect_ApproveRequest_Title">Approve</string>
+    <string name="WalletConnect_SwapRequest_Title">Swap</string>
+    <string name="WalletConnect_UnknownRequest_Title">Contract Call</string>
     <string name="WalletConnect_Url">URL</string>
     <string name="WalletConnect_Status">Status</string>
     <string name="WalletConnect_SignedTransactions">Signed Transactions</string>
@@ -349,7 +354,7 @@
     <string name="WalletConnect_Status_Online">Online</string>
     <string name="WalletConnect_Status_Connecting">Connecting…</string>
     <string name="WalletConnect_NewConnect">New Connection</string>
-    <string name="WalletConnect_SignMessageRequest_Title">Sign Request</string>
+    <string name="WalletConnect_SignMessageRequest_Title">Sign</string>
     <string name="WalletConnect_SignMessageRequest_Domain">Domain</string>
     <string name="WalletConnect_SignMessageRequest_ShowMessageTitle">Message to sign</string>
     <string name="WalletConnect_SignMessageRequest_SignMessageHint">Please sign a message to authenticate</string>


### PR DESCRIPTION
- change the title from 'Request' to 'Contract Call' if (unknown). for cases Sign, Swap, Approve show title as Sign / Swap / Approve
 - on ALL WalletConnect confirmation screens change the button text from ' Approve' to 'Confirm'

#4059 