### PR TITLE
Prevent scrolling back and forth when restoring state of filter coin tab

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionsFragment.kt
@@ -102,18 +102,20 @@ class TransactionsFragment : BaseFragment(R.layout.fragment_transactions) {
         )
 
         transactionCoinFilterTabCompose.setContent {
-            val filterCoins by viewModel.filterCoinsLiveData.observeAsState(listOf())
+            val filterCoins by viewModel.filterCoinsLiveData.observeAsState()
 
-            val tabItems = filterCoins.map {
-                TabItem(it.item.coin.code, it.selected, it.item, AppLayoutHelper.getCoinDrawableOrDefaultResId(requireContext(), it.item.coin.type))
-            }
+            filterCoins?.let {
+                val tabItems = it.map {
+                    TabItem(it.item.coin.code, it.selected, it.item, AppLayoutHelper.getCoinDrawableOrDefaultResId(requireContext(), it.item.coin.type))
+                }
 
-            CardTabs(
-                tabItems = tabItems,
-                edgePadding = 16.dp
-            ) {
-                viewModel.setFilterCoin(it)
-                scrollToTopAfterUpdate = true
+                CardTabs(
+                    tabItems = tabItems,
+                    edgePadding = 16.dp
+                ) {
+                    viewModel.setFilterCoin(it)
+                    scrollToTopAfterUpdate = true
+                }
             }
         }
 


### PR DESCRIPTION
When liveData observed as state for composable it emits initial value and then the value of liveData itself. It's true also for case when restoring the view. It results in scrolling to the start and then scrolling to the last position. To prevent this behavior filterCoinsLiveData observed without default value.

#3999