### PR TITLE
Set correct sort order in ManageWallets/RestoreSelectCoins modules

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -204,7 +204,7 @@ dependencies {
     implementation 'com.github.horizontalsystems:blockchain-fee-rate-kit-android:047596b'
     implementation 'com.github.horizontalsystems:binance-chain-kit-android:fe2a3be'
     implementation 'com.github.horizontalsystems:xrates-kit-android:c2664c6'
-    implementation 'com.github.horizontalsystems:market-kit-android:082076f'
+    implementation 'com.github.horizontalsystems:market-kit-android:0228f1c'
 
     // Zcash SDK
     implementation "cash.z.ecc.android:zcash-android-sdk:1.3.0-beta16"

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/managewallets/ManageWalletsService.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/managewallets/ManageWalletsService.kt
@@ -83,10 +83,10 @@ class ManageWalletsService(
     }
 
     private fun sortFullCoins() {
-        fullCoins.sortWith(compareByDescending<FullCoin> {
-            isEnabled(it.coin)
+        fullCoins.sortWith(compareBy<FullCoin> {
+            if (isEnabled(it.coin)) 0 else 1
         }.thenBy {
-            it.coin.marketCapRank
+            it.coin.marketCapRank ?: Int.MAX_VALUE
         }.thenBy {
             it.coin.name.lowercase(Locale.ENGLISH)
         })

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/restore/restoreselectcoins/RestoreSelectCoinsService.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/restore/restoreselectcoins/RestoreSelectCoinsService.kt
@@ -142,10 +142,10 @@ class RestoreSelectCoinsService(
         }
 
     private fun sortFullCoins() {
-        fullCoins.sortWith(compareByDescending<FullCoin> {
-            isEnabled(it.coin)
+        fullCoins.sortWith(compareBy<FullCoin> {
+            if (isEnabled(it.coin)) 0 else 1
         }.thenBy {
-            it.coin.marketCapRank
+            it.coin.marketCapRank ?: Int.MAX_VALUE
         }.thenBy {
             it.coin.name.lowercase(Locale.ENGLISH)
         })

--- a/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/coinlist/CoinListAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/ui/extensions/coinlist/CoinListAdapter.kt
@@ -65,11 +65,11 @@ class CoinListAdapter(private val listener: Listener) :
     companion object {
         private val diffCallback = object : DiffUtil.ItemCallback<CoinViewItem>() {
             override fun areItemsTheSame(oldItem: CoinViewItem, newItem: CoinViewItem): Boolean {
-                return oldItem == newItem
+                return oldItem.fullCoin.coin == newItem.fullCoin.coin
             }
 
             override fun areContentsTheSame(oldItem: CoinViewItem, newItem: CoinViewItem): Boolean {
-                return oldItem == newItem
+                return oldItem.fullCoin.coin == newItem.fullCoin.coin && oldItem.state == newItem.state && oldItem.listPosition == newItem.listPosition
             }
         }
     }
@@ -136,6 +136,6 @@ class CoinWithSwitchViewHolder(
 data class CoinViewItem(val fullCoin: FullCoin, val state: CoinViewItemState, val listPosition: ListPosition)
 
 sealed class CoinViewItemState {
-    class ToggleVisible(val enabled: Boolean, val hasSettings: Boolean) : CoinViewItemState()
+    data class ToggleVisible(val enabled: Boolean, val hasSettings: Boolean) : CoinViewItemState()
     object ToggleHidden : CoinViewItemState()
 }


### PR DESCRIPTION
- order should be first enabled coins, then sorted by ascending marketCapRank, then sorted by ascending coin name

#4162 