### PR TITLE
Allow fragments to be restored from savedInstanceState

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/main/MainActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/main/MainActivity.kt
@@ -13,7 +13,7 @@ import io.horizontalsystems.bankwallet.modules.send.SendActivity
 class MainActivity : BaseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(null) // null prevents fragments restoration on theme switch
+        super.onCreate(savedInstanceState)
 
         setContentView(R.layout.activity_main)
 


### PR DESCRIPTION
It seems that, before app theme switching and language change were not reflected because of fragment's state restoring. But now it is not the case anymore.

#4408 