### PR TITLE
Fix bug in AccountManager.delete()

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/AccountManager.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/AccountManager.kt
@@ -86,7 +86,7 @@ class AccountManager(
         accountsSubject.onNext(accounts)
         accountsDeletedSubject.onNext(Unit)
 
-        if (id == activeAccount?.id) {
+        if (id == cache.activeAccountId) {
             setActiveAccountId(accounts.firstOrNull()?.id)
         }
     }


### PR DESCRIPTION
- get active account id from cache instead of accountAccount object

#4613 