### PR TITLE
Add button rows for watch wallets

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceViewItem.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceViewItem.kt
@@ -252,7 +252,7 @@ class BalanceViewItemFactory {
                 exchangeValue = rateValue(latestRate, showSyncing, currency),
                 diff = item.coinPrice?.diff,
                 expanded = expanded,
-                sendEnabled = state is AdapterState.Synced,
+                sendEnabled = state is AdapterState.Synced && !watchAccount,
                 receiveEnabled = state != null,
                 syncingProgress = getSyncingProgress(state, wallet.token.blockchainType),
                 syncingTextValue = getSyncingText(state, expanded),
@@ -261,7 +261,7 @@ class BalanceViewItemFactory {
                 coinIconVisible = state !is AdapterState.NotSynced,
                 badge = wallet.badge,
                 swapVisible = wallet.token.swappable,
-                swapEnabled = state is AdapterState.Synced,
+                swapEnabled = state is AdapterState.Synced && !watchAccount,
                 mainNet = item.mainNet,
                 errorMessage = (state as? AdapterState.NotSynced)?.error?.message,
                 isWatchAccount = watchAccount

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/BalanceViewModel.kt
@@ -147,7 +147,7 @@ class BalanceViewModel(
     }
 
     fun getWalletForReceive(viewItem: BalanceViewItem) = when {
-        viewItem.wallet.account.isBackedUp -> viewItem.wallet
+        viewItem.wallet.account.isBackedUp || viewItem.isWatchAccount -> viewItem.wallet
         else -> throw BackupRequiredError(viewItem.wallet.account, viewItem.coinTitle)
     }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/ui/BalanceCard.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/ui/BalanceCard.kt
@@ -103,16 +103,9 @@ fun BalanceCard(
             .padding(vertical = 4.dp)
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
-                indication = null
-            ) {
-                if (viewItem.isWatchAccount) {
-                    val coinUid = viewItem.wallet.coin.uid
-                    val arguments = CoinFragment.prepareParams(coinUid)
-                    navController.slideFromRight(R.id.coinFragment, arguments)
-                } else {
-                    viewModel.onItem(viewItem)
-                }
-            }
+                indication = null,
+                onClick = { viewModel.onItem(viewItem) }
+            )
     ) {
         CellMultilineClear {
             Row {


### PR DESCRIPTION
Tapping a coin in the "balance" page of a watch wallet will show the button row, with the "receive" and "chart" buttons enabled.