### PR TITLE
Fix formatting for long wallet names

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/ui/BalanceForAccount.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/ui/BalanceForAccount.kt
@@ -51,7 +51,8 @@ fun BalanceForAccount(navController: NavController, accountViewItem: AccountView
                     title3_leah(
                         text = accountViewItem.name,
                         maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(weight = 1f, fill = false)
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Icon(


### PR DESCRIPTION
Adjust the UI view parameters so that very long wallet names (i.e. those long enough to get truncated) don't result in the dropdown icon being pushed off the screen.