### PR TITLE
Fix biometric prompt window crash

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/keystore/KeyStoreActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/keystore/KeyStoreActivity.kt
@@ -61,7 +61,7 @@ class KeyStoreActivity : BaseActivity() {
             .setDescription(getString(R.string.OSPin_Prompt_Desciption))
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            promptInfo.setAllowedAuthenticators(DEVICE_CREDENTIAL or BIOMETRIC_STRONG)
+            promptInfo.setAllowedAuthenticators(DEVICE_CREDENTIAL)
         } else {
             @Suppress("DEPRECATION")
             promptInfo.setDeviceCredentialAllowed(true)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/keystore/KeyStoreActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/keystore/KeyStoreActivity.kt
@@ -58,6 +58,7 @@ class KeyStoreActivity : BaseActivity() {
         val promptInfo = BiometricPrompt.PromptInfo.Builder()
             .setTitle(getString(R.string.OSPin_Confirm_Title))
             .setDescription(getString(R.string.OSPin_Prompt_Desciption))
+            .setNegativeButtonText("Cancel") // TODO further localization
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             promptInfo.setAllowedAuthenticators(BIOMETRIC_STRONG)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/keystore/KeyStoreActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/keystore/KeyStoreActivity.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
+import androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL
 import androidx.biometric.BiometricPrompt
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -58,10 +59,9 @@ class KeyStoreActivity : BaseActivity() {
         val promptInfo = BiometricPrompt.PromptInfo.Builder()
             .setTitle(getString(R.string.OSPin_Confirm_Title))
             .setDescription(getString(R.string.OSPin_Prompt_Desciption))
-            .setNegativeButtonText("Cancel") // TODO further localization
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            promptInfo.setAllowedAuthenticators(BIOMETRIC_STRONG)
+            promptInfo.setAllowedAuthenticators(DEVICE_CREDENTIAL or BIOMETRIC_STRONG)
         } else {
             @Suppress("DEPRECATION")
             promptInfo.setDeviceCredentialAllowed(true)


### PR DESCRIPTION
Hello,

I have a new finding which probably relates to issue #5515 and #4163.
I figured out the reason why it stops working after 1 day is that keystore needs user authentication by either biometric or pattern defined under [#1](https://github.com/horizontalsystems/unstoppable-wallet-android/blob/58fad2e8dd5a2d1b61dcb37e14ad66bcd0a81eb5/core/src/main/java/io/horizontalsystems/core/security/KeyStoreManager.kt#L28) and [#2](https://github.com/horizontalsystems/unstoppable-wallet-android/blob/58fad2e8dd5a2d1b61dcb37e14ad66bcd0a81eb5/core/src/main/java/io/horizontalsystems/core/security/KeyStoreManager.kt#L99). Next time launch will try to prompt user authentication (in my case, it uses biometric), otherwise it will validate keystore, resulting in throwing user authentication exception. however, it crashes with ```Negative text must be set and non-empty``` illigealargumentexception out of secure-folder runtime. I resolves the crash issue with this modification.
I am unable to try that part in secure-folder runtime, it seems that secure-folder runtime doesn't allow unsigned app installation. Hope to get tested once the change merged into next official release