### PR TITLE
Fix invalidated keystore dialog crash

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/keystore/KeyStoreActivity.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/keystore/KeyStoreActivity.kt
@@ -138,10 +138,6 @@ private fun KeyStoreScreen(
         showBiometricPrompt.invoke()
     }
 
-    if (viewModel.showInvalidKeyWarning) {
-        KeysInvalidatedDialog { viewModel.onCloseInvalidKeyWarning() }
-    }
-
     ComposeAppTheme {
         if (viewModel.showSystemLockWarning) {
             Column(
@@ -152,6 +148,10 @@ private fun KeyStoreScreen(
             ) {
                 NoSystemLockWarning()
             }
+        }
+
+        if (viewModel.showInvalidKeyWarning) {
+            KeysInvalidatedDialog { viewModel.onCloseInvalidKeyWarning() }
         }
     }
 }


### PR DESCRIPTION
The crash error mentioned in #5515 is fixed under this pr
I attached the screenshot as below
![IMAGE 2022-11-29 23:44:03](https://user-images.githubusercontent.com/4001697/204575377-3185e6cc-5811-49d3-80f5-f5efc68dbe58.jpg)
