### PR TITLE
Fix the issue with crash on process restore

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/token/TokenBalanceFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/balance/token/TokenBalanceFragment.kt
@@ -20,7 +20,7 @@ class TokenBalanceFragment : BaseComposeFragment() {
         val wallet = navController.getInput<Wallet>()
         if (wallet == null) {
             Toast.makeText(App.instance, "Wallet is Null", Toast.LENGTH_SHORT).show()
-            navController.popBackStack()
+            navController.popBackStack(R.id.tokenBalanceFragment, true)
             return
         }
         val viewModel by viewModels<TokenBalanceViewModel> { TokenBalanceModule.Factory(wallet) }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactionInfo/TransactionInfoFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactionInfo/TransactionInfoFragment.kt
@@ -46,7 +46,7 @@ class TransactionInfoFragment : BaseComposeFragment() {
     override fun GetContent(navController: NavController) {
         val viewItem = viewModelTxs.tmpItemToShow
         if (viewItem == null) {
-            navController.popBackStack()
+            navController.popBackStack(R.id.transactionInfoFragment, true)
             return
         }
 


### PR DESCRIPTION
#6843

There is a case when the app process is killed and restored by Android OS. When the app is restored it tries to restore all fragments. But the navController is not getting restored and it contains single back stack entry, which is mainFragment.

So if user was in the page like TokenBalanceFragment or TransactionInfoFragment, those fragments are restored. Since they do not get expected data, they call `navController.popBackStack()`. It results in popping off the single mainFragment of the back stack. And the MainFragment tries to create TransactionsViewModel using the mainFragment back stack entry. But the nav controller back stack is empty. That is why it crashes app.

Fixed issue by ensuring that those fragments closes themselves if needed.