### PR TITLE
Fix bottom navigation bar overlapping view

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/basecurrency/BaseCurrencySettingsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/basecurrency/BaseCurrencySettingsFragment.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -118,6 +119,7 @@ private fun BaseCurrencyScreen(
                 Modifier
                     .verticalScroll(rememberScrollState())
                     .padding(paddingValues)
+                    .navigationBarsPadding()
             ) {
                 VSpacer(12.dp)
                 CellUniversalLawrenceSection(viewModel.popularItems) { item ->

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/blockchainsettings/BlockchainSettingsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/blockchainsettings/BlockchainSettingsFragment.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -51,7 +52,9 @@ private fun BlockchainSettingsScreen(
 ) {
 
     Surface(color = ComposeAppTheme.colors.tyler) {
-        Column {
+        Column(
+            modifier = Modifier.navigationBarsPadding()
+        ) {
             AppBar(
                 title = stringResource(R.string.BlockchainSettings_Title),
                 navigationIcon = {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/coin/CoinFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/coin/CoinFragment.kt
@@ -2,6 +2,7 @@ package io.horizontalsystems.bankwallet.modules.coin
 
 import android.os.Parcelable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -136,7 +137,9 @@ fun CoinTabs(
         }
     ) { innerPaddings ->
         Column(
-            modifier = Modifier.padding(innerPaddings)
+            modifier = Modifier
+                .padding(innerPaddings)
+                .navigationBarsPadding()
         ) {
             val selectedTab = tabs[pagerState.currentPage]
             val tabItems = tabs.map {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/evmfee/Composables.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/evmfee/Composables.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -312,7 +313,9 @@ fun ButtonsGroupWithShade(
     ButtonsContent: @Composable (() -> Unit)
 ) {
     Column(
-        modifier = Modifier.offset(y = -(24.dp))
+        modifier = Modifier
+            .offset(y = -(24.dp))
+            .navigationBarsPadding()
     ) {
         Box(
             modifier = Modifier
@@ -325,9 +328,7 @@ fun ButtonsGroupWithShade(
                 )
         )
         Box(
-            modifier = Modifier
-                .background(ComposeAppTheme.colors.tyler)
-                .padding(bottom = 8.dp) // With 24dp offset actual padding will be 32dp
+            modifier = Modifier.background(ComposeAppTheme.colors.tyler)
         ) {
             ButtonsContent()
         }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/markdown/MarkdownFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/markdown/MarkdownFragment.kt
@@ -1,6 +1,7 @@
 package io.horizontalsystems.bankwallet.modules.markdown
 
 import android.os.Parcelable
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
@@ -73,7 +74,9 @@ private fun MarkdownScreen(
         }
     ) {
         MarkdownContent(
-            modifier = Modifier.padding(it),
+            modifier = Modifier
+                .padding(it)
+                .navigationBarsPadding(),
             viewState = viewModel.viewState,
             markdownBlocks = viewModel.markdownBlocks,
             handleRelativeUrl = handleRelativeUrl,

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/category/MarketCategoryFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/category/MarketCategoryFragment.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Scaffold
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -117,7 +118,9 @@ fun CategoryScreen(
         },
     ) { innerPaddings ->
         Column(
-            modifier = Modifier.padding(innerPaddings)
+            modifier = Modifier
+                .padding(innerPaddings)
+                .navigationBarsPadding()
         ) {
             HSSwipeRefresh(
                 refreshing = isRefreshing,

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/etf/EtfFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/etf/EtfFragment.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -106,7 +107,11 @@ fun EtfPage(
     var openPeriodSelector by rememberSaveable { mutableStateOf(false) }
     var openSortingSelector by rememberSaveable { mutableStateOf(false) }
 
-    Column(Modifier.background(color = ComposeAppTheme.colors.tyler)) {
+    Column(
+        Modifier
+            .background(color = ComposeAppTheme.colors.tyler)
+            .navigationBarsPadding()
+    ) {
         AppBar(
             menuItems = listOf(
                 MenuItem(

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/filtersresult/MarketFiltersResultsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/filtersresult/MarketFiltersResultsFragment.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Icon
 import androidx.compose.material.Surface
@@ -86,7 +87,10 @@ private fun SearchResultsScreen(
     var scrollToTopAfterUpdate by rememberSaveable { mutableStateOf(false) }
     var openSortingSelector by rememberSaveable { mutableStateOf(false) }
 
-    Surface(color = ComposeAppTheme.colors.tyler) {
+    Surface(
+        color = ComposeAppTheme.colors.tyler,
+        modifier = Modifier.navigationBarsPadding()
+    ) {
         Column {
             AppBar(
                 title = stringResource(R.string.Market_AdvancedSearch_Results),

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/metricspage/MetricsPageFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/metricspage/MetricsPageFragment.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
@@ -76,7 +77,11 @@ class MetricsPageFragment : BaseComposeFragment() {
     ) {
         val uiState = viewModel.uiState
 
-        Column(Modifier.background(color = ComposeAppTheme.colors.tyler)) {
+        Column(
+            Modifier
+                .background(color = ComposeAppTheme.colors.tyler)
+                .navigationBarsPadding()
+        ) {
             AppBar(
                 menuItems = listOf(
                     MenuItem(

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/platform/MarketPlatformFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/platform/MarketPlatformFragment.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Scaffold
@@ -132,7 +133,9 @@ private fun PlatformScreen(
         },
     ) { innerPaddings ->
         Column(
-            modifier = Modifier.padding(innerPaddings)
+            modifier = Modifier
+                .padding(innerPaddings)
+                .navigationBarsPadding()
         ) {
             HSSwipeRefresh(
                 refreshing = uiState.isRefreshing,

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/search/MarketSearchFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/search/MarketSearchFragment.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -77,7 +78,9 @@ fun MarketSearchScreen(viewModel: MarketSearchViewModel, navController: NavContr
 
     val uiState = viewModel.uiState
 
-    Column {
+    Column(
+        modifier = Modifier.navigationBarsPadding()
+    ) {
         SearchBar(
             title = stringResource(R.string.Market_Search),
             searchHintText = stringResource(R.string.Market_Search),

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/tvl/TvlFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/market/tvl/TvlFragment.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -97,7 +98,11 @@ class TvlFragment : BaseComposeFragment() {
         val isRefreshing by tvlViewModel.isRefreshingLiveData.observeAsState(false)
         val chainSelectorDialogState by tvlViewModel.chainSelectorDialogStateLiveData.observeAsState(SelectorDialogState.Closed)
 
-        Column(modifier = Modifier.background(color = ComposeAppTheme.colors.tyler)) {
+        Column(
+            modifier = Modifier
+                .background(color = ComposeAppTheme.colors.tyler)
+                .navigationBarsPadding()
+        ) {
             AppBar(
                 menuItems = listOf(
                     MenuItem(

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/appearance/AppearanceFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/appearance/AppearanceFragment.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -115,6 +116,7 @@ fun AppearanceScreen(navController: NavController) {
                 modifier = Modifier
                     .fillMaxSize()
                     .verticalScroll(rememberScrollState())
+                    .navigationBarsPadding()
                     .padding(paddingValues),
             ) {
                 VSpacer(height = 12.dp)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/faq/FaqFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/faq/FaqFragment.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -62,7 +63,10 @@ private fun FaqScreen(
     viewModel: FaqViewModel = viewModel(factory = FaqModule.Factory())
 ) {
     val viewState = viewModel.viewState
-    Column(modifier = Modifier.background(color = ComposeAppTheme.colors.tyler)) {
+    Column(modifier = Modifier
+        .background(color = ComposeAppTheme.colors.tyler)
+        .navigationBarsPadding()
+    ) {
         AppBar(
             title = stringResource(R.string.Settings_Faq),
             navigationIcon = {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/guides/GuidesFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/guides/GuidesFragment.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -59,7 +60,11 @@ fun GuidesScreen(navController: NavController) {
     val selectedCategory = uiState.selectedCategory
     val expandedSections = uiState.expandedSections
 
-    Column(modifier = Modifier.background(color = ComposeAppTheme.colors.tyler)) {
+    Column(
+        modifier = Modifier
+            .background(color = ComposeAppTheme.colors.tyler)
+            .navigationBarsPadding()
+    ) {
         AppBar(
             title = stringResource(R.string.Guides_Title),
             navigationIcon = {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/language/LanguageSettingsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/language/LanguageSettingsFragment.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -62,7 +63,9 @@ private fun LanguageScreen(
     }
 
     Column(
-        modifier = Modifier.background(color = ComposeAppTheme.colors.tyler)
+        modifier = Modifier
+            .background(color = ComposeAppTheme.colors.tyler)
+            .navigationBarsPadding()
     ) {
         AppBar(
             title = stringResource(R.string.Settings_Language),

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/privacy/PrivacySettingsFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/privacy/PrivacySettingsFragment.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -128,6 +129,7 @@ fun PrivacyScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .navigationBarsPadding()
             .background(ComposeAppTheme.colors.tyler)
     ) {
         AppBar(

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/usersubscription/ui/SelectSubscriptionScreen.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/usersubscription/ui/SelectSubscriptionScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -84,6 +85,7 @@ fun SelectSubscriptionScreen(
         Box(
             modifier = Modifier
                 .padding(paddingValues)
+                .navigationBarsPadding()
                 .fillMaxSize()
         ) {
             RadialBackground()
@@ -216,7 +218,7 @@ fun SelectSubscriptionScreen(
                             }
                         },
                     )
-                    VSpacer(32.dp)
+                    VSpacer(16.dp)
                 }
             }
 


### PR DESCRIPTION
Adds navigation bar padding to multiple screens for better UI on devices with navigation bars.
- AppearanceFragment
- TvlFragment
- EtfFragment
- SelectSubscriptionScreen
- Composables
- BaseCurrencySettingsFragment
- PrivacySettingsFragment
- MarketPlatformFragment
- MarketFiltersResultsFragment
- GuidesFragment
- LanguageSettingsFragment
- MarkdownFragment
- MarketCategoryFragment
- FaqFragment
- BlockchainSettingsFragment
- MetricsPageFragment
- MarketSearchFragment
- CoinFragment