### PR TITLE
Update MoneroKit and clear Monero data on account deletion

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -311,7 +311,7 @@ dependencies {
     implementation "com.jakewharton.timber:timber:5.0.1"
 
     // Wallet kits
-    implementation 'com.github.horizontalsystems:monero-kit-android:b9c3b09'
+    implementation 'com.github.horizontalsystems:monero-kit-android:13dbc9e'
     implementation 'com.github.horizontalsystems:stellar-kit-android:519533b'
     implementation 'com.github.horizontalsystems:ton-kit-android:dcddd90'
     implementation 'com.github.horizontalsystems:bitcoin-kit-android:7fd8667'

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/MoneroAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/MoneroAdapter.kt
@@ -190,6 +190,10 @@ class MoneroAdapter(
                 App.backgroundManager
             )
         }
+
+        fun clear(walletId: String) {
+            MoneroKit.deleteWallet(App.instance, walletId)
+        }
     }
 }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/AccountCleaner.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/AccountCleaner.kt
@@ -7,6 +7,7 @@ import io.horizontalsystems.bankwallet.core.adapters.DashAdapter
 import io.horizontalsystems.bankwallet.core.adapters.ECashAdapter
 import io.horizontalsystems.bankwallet.core.adapters.Eip20Adapter
 import io.horizontalsystems.bankwallet.core.adapters.EvmAdapter
+import io.horizontalsystems.bankwallet.core.adapters.MoneroAdapter
 import io.horizontalsystems.bankwallet.core.adapters.SolanaAdapter
 import io.horizontalsystems.bankwallet.core.adapters.TronAdapter
 import io.horizontalsystems.bankwallet.core.adapters.zcash.ZcashAdapter
@@ -27,6 +28,7 @@ class AccountCleaner : IAccountCleaner {
         ZcashAdapter.clear(accountId)
         SolanaAdapter.clear(accountId)
         TronAdapter.clear(accountId)
+        MoneroAdapter.clear(accountId)
     }
 
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/MoneroNodeManager.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/MoneroNodeManager.kt
@@ -26,6 +26,7 @@ class MoneroNodeManager(
     val nodesUpdatedFlow = _nodesUpdatedFlow.asSharedFlow()
 
     val defaultNodesInitial = listOf(
+        MoneroNode("opennode.xmr-tw.org:18089", "xmr-tw.org", "opennode.xmr-tw.org:18089/mainnet/xmr-tw.org"),
         MoneroNode("xmr-de.boldsuck.org:18081", "boldsuck.org", "xmr-de.boldsuck.org:18081/mainnet/boldsuck.org"),
         MoneroNode("node.sethforprivacy.com:18089", "sethforprivacy.com", "node.sethforprivacy.com:18089/mainnet/sethforprivacy.com"),
         MoneroNode("node.xmr.rocks:18089", "xmr.rocks", "node.xmr.rocks:18089/mainnet/xmr.rocks"),

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/manageaccount/ManageAccountViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/manageaccount/ManageAccountViewModel.kt
@@ -121,7 +121,7 @@ class ManageAccountViewModel(
                     listOf(KeyAction.PrivateKeys, KeyAction.PublicKeys)
                 }
             }
-            is AccountType.MoneroWatchAccount -> listOf() //TODO
+            is AccountType.MoneroWatchAccount -> listOf()
         }
     }
 


### PR DESCRIPTION
- Update MoneroKit to `13dbc9e`
- Add new default Monero node `opennode.xmr-tw.org`
- Implement Monero data clearing when an account is deleted
#8423 