### PR TITLE
Show Mev-protect only for supported providers

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/SwapConfirmViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/SwapConfirmViewModel.kt
@@ -226,7 +226,7 @@ class SwapConfirmViewModel(
         hasNonceSettings = sendTransactionService.hasNonceSettings,
         swapDefenseSystemMessage = swapDefenseState.systemMessage,
         mevProtectionEnabled = swapDefenseState.mevProtectionEnabled,
-        supportsMevProtection = sendTransactionService.supportsMevProtection,
+        supportsMevProtection = sendTransactionService.supportsMevProtection && swapProvider.supportsMevProtection,
         mevProtectionActionAllowed = swapDefenseState.mevProtectionActionAllowed,
         recipient = recipient,
         slippage = slippage,
@@ -382,7 +382,10 @@ class SwapConfirmViewModel(
                 sendTransactionService,
                 TimerService(),
                 PriceImpactService(PriceImpactLevel.Normal),
-                SwapDefenseSystemService(sendTransactionService.supportsMevProtection, App.paidActionSettingsManager),
+                SwapDefenseSystemService(
+                    sendTransactionService.supportsMevProtection && quote.provider.supportsMevProtection,
+                    App.paidActionSettingsManager
+                ),
                 App.backgroundManager
             )
         }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/BaseUniswapV3Provider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/BaseUniswapV3Provider.kt
@@ -25,6 +25,7 @@ abstract class BaseUniswapV3Provider(dexType: DexType) : IMultiSwapProvider {
     override val type = SwapProviderType.DEX
     override val requireTerms = false
     override val isEvm = true
+    override val supportsMevProtection = true
     private val uniswapV3Kit by lazy { UniswapV3Kit.getInstance(dexType) }
 
     override fun isSingleChainSwap(tokenInBlockchainTypeUid: String, tokenOutBlockchainTypeUid: String) = true

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/IMultiSwapProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/IMultiSwapProvider.kt
@@ -18,6 +18,8 @@ interface IMultiSwapProvider {
         get() = false
     val isEvm: Boolean
         get() = false
+    val supportsMevProtection: Boolean
+        get() = false
     val requireTerms: Boolean
     val riskLevel: RiskLevel
     fun isSingleChainSwap(tokenInBlockchainTypeUid: String, tokenOutBlockchainTypeUid: String): Boolean

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/OneInchProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/OneInchProvider.kt
@@ -28,6 +28,7 @@ object OneInchProvider : IMultiSwapProvider {
     override val icon = R.drawable.swap_provider_1inch
     override val type = SwapProviderType.DEX
     override val isEvm = true
+    override val supportsMevProtection = true
     override val requireTerms = false
     override val riskLevel = RiskLevel.CONTROLLED
     private val oneInchKit by lazy { OneInchKit.getInstance(App.appConfigProvider.oneInchApiKey) }


### PR DESCRIPTION
#9184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced MEV protection support for swaps with improved capability detection across network and provider layers.
  * Added MEV protection support for Uniswap V3 and 1Inch swap providers to reduce MEV risks.
  * Updated swap confirmation logic to ensure MEV protection is only enabled when supported by both the transaction service and the selected swap provider.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/horizontalsystems/unstoppable-wallet-android/pull/9188)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->