### PR TITLE
Make fix for custom rpc in Backup

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/App.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/App.kt
@@ -506,7 +506,6 @@ class App : CoreApp(), WorkConfiguration.Provider, ImageLoaderFactory {
             currencyManager = currencyManager,
             btcBlockchainManager = btcBlockchainManager,
             evmSyncSourceManager = evmSyncSourceManager,
-            evmSyncSourceStorage = evmSyncSourceStorage,
             solanaRpcSourceManager = solanaRpcSourceManager,
             moneroNodeManager = moneroNodeManager,
             moneroNodeStorage = moneroNodeStorage,

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/backuplocal/fullbackup/BackupProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/backuplocal/fullbackup/BackupProvider.kt
@@ -445,19 +445,24 @@ class BackupProvider(
         )
     }
 
-    fun fullBackupItems() =
-        fullBackupItems(
+    fun fullBackupItems(): BackupItems {
+        val customRpcsTotal = evmSyncSourceStorage.getAll().size +
+            moneroNodeManager.customNodes.size +
+            zanoNodeManager.customNodes.size
+        return fullBackupItems(
             accounts = accountManager.accounts,
             watchlist = marketFavoritesManager.getAll().map { it.coinUid },
             contacts = contactsRepository.contacts,
-            customRpcsCount = evmSyncSourceStorage.getAll().ifEmpty { null }?.size
+            customRpcsCount = customRpcsTotal.takeIf { it > 0 }
         )
+    }
 
     fun fullBackupItems(decryptedFullBackup: DecryptedFullBackup): BackupItems {
         val customRpcsCount = if (BackupSection.CustomRpc in decryptedFullBackup.sections) {
             val evmCount = decryptedFullBackup.settings.evmSyncSources.custom.size
             val moneroCount = decryptedFullBackup.settings.moneroNodes?.custom?.size ?: 0
-            (evmCount + moneroCount).takeIf { it > 0 }
+            val zanoCount = decryptedFullBackup.settings.zanoNodes?.custom?.size ?: 0
+            (evmCount + moneroCount + zanoCount).takeIf { it > 0 }
         } else {
             null
         }
@@ -535,14 +540,22 @@ class BackupProvider(
         val solanaSyncSource = SolanaSyncSource(BlockchainType.Solana.uid, solanaRpcSourceManager.rpcSource.name)
 
         val selectedMoneroNode = MoneroNodeBackup(BlockchainType.Monero.uid, moneroNodeManager.currentNode.host, null, null, false)
-        val customMoneroNodes = moneroNodeStorage.getAll().map { nodeRecord ->
-            val password = nodeRecord.password?.let { encrypted(it, passphrase) }
-            MoneroNodeBackup(BlockchainType.Monero.uid, nodeRecord.url, nodeRecord.username, password, false)
+        val customMoneroNodes = if (BackupSection.CustomRpc in sections) {
+            moneroNodeManager.customNodes.map { node ->
+                val password = node.password?.let { encrypted(it, passphrase) }
+                MoneroNodeBackup(BlockchainType.Monero.uid, node.host, node.username, password, node.trusted)
+            }
+        } else {
+            listOf()
         }
         val moneroNodes = MoneroNodes(listOf(selectedMoneroNode), customMoneroNodes)
 
         val selectedZanoNode = ZanoNodeBackup(BlockchainType.Zano.uid, zanoNodeManager.currentNode.host)
-        val customZanoNodes = zanoNodeStorage.getAll().map { ZanoNodeBackup(BlockchainType.Zano.uid, it.url) }
+        val customZanoNodes = if (BackupSection.CustomRpc in sections) {
+            zanoNodeManager.customNodes.map { ZanoNodeBackup(BlockchainType.Zano.uid, it.host) }
+        } else {
+            listOf()
+        }
         val zanoNodes = ZanoNodes(listOf(selectedZanoNode), customZanoNodes)
 
         val chartIndicators = chartIndicators()

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/backuplocal/fullbackup/BackupProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/backuplocal/fullbackup/BackupProvider.kt
@@ -27,7 +27,6 @@ import io.horizontalsystems.bankwallet.core.managers.WalletManager
 import io.horizontalsystems.bankwallet.core.managers.ZanoNodeManager
 import io.horizontalsystems.bankwallet.core.providers.Translator
 import io.horizontalsystems.bankwallet.core.storage.BlockchainSettingsStorage
-import io.horizontalsystems.bankwallet.core.storage.EvmSyncSourceStorage
 import io.horizontalsystems.bankwallet.core.storage.MoneroNodeStorage
 import io.horizontalsystems.bankwallet.core.storage.ZanoNodeStorage
 import io.horizontalsystems.bankwallet.entities.Account
@@ -117,7 +116,6 @@ class BackupProvider(
     private val currencyManager: CurrencyManager,
     private val btcBlockchainManager: BtcBlockchainManager,
     private val evmSyncSourceManager: EvmSyncSourceManager,
-    private val evmSyncSourceStorage: EvmSyncSourceStorage,
     private val solanaRpcSourceManager: SolanaRpcSourceManager,
     private val moneroNodeManager: MoneroNodeManager,
     private val moneroNodeStorage: MoneroNodeStorage,
@@ -446,7 +444,10 @@ class BackupProvider(
     }
 
     fun fullBackupItems(): BackupItems {
-        val customRpcsTotal = evmSyncSourceStorage.getAll().size +
+        val evmAndTronCustomRpcsCount = evmBlockchainManager.allBlockchains.sumOf {
+            evmSyncSourceManager.customSyncSources(it.type).size
+        } + evmSyncSourceManager.customSyncSources(BlockchainType.Tron).size
+        val customRpcsTotal = evmAndTronCustomRpcsCount +
             moneroNodeManager.customNodes.size +
             zanoNodeManager.customNodes.size
         return fullBackupItems(


### PR DESCRIPTION
#9153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup counting to include custom EVM sync sources, Monero nodes, and Zano nodes together.
  * Custom node backups now source current in-memory node lists, ensuring accurate inclusion of custom Monero and Zano nodes.
  * Monero custom node credentials are encrypted in backups; Zano custom node host info is preserved.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/horizontalsystems/unstoppable-wallet-android/pull/9192)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->