### PR TITLE
Add name randomizer to Watch wallet page

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/watchaddress/WatchAddressFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/watchaddress/WatchAddressFragment.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -33,8 +34,10 @@ import io.horizontalsystems.bankwallet.ui.compose.components.FormsInputMultiline
 import io.horizontalsystems.bankwallet.ui.compose.components.HeaderText
 import io.horizontalsystems.bankwallet.ui.compose.components.VSpacer
 import io.horizontalsystems.bankwallet.uiv3.components.HSScaffold
+import io.horizontalsystems.bankwallet.uiv3.components.controls.ButtonSize
 import io.horizontalsystems.bankwallet.uiv3.components.controls.ButtonVariant
 import io.horizontalsystems.bankwallet.uiv3.components.controls.HSButton
+import io.horizontalsystems.bankwallet.uiv3.components.controls.HSIconButton
 import io.horizontalsystems.core.helpers.HudHelper
 import io.horizontalsystems.marketkit.models.BlockchainType
 import kotlinx.coroutines.delay
@@ -121,7 +124,17 @@ fun WatchAddressScreen(navController: NavController, popUpToInclusiveId: Int, in
                 initial = viewModel.accountName,
                 pasteEnabled = false,
                 hint = viewModel.defaultAccountName,
-                onValueChange = viewModel::onEnterAccountName
+                onValueChange = viewModel::onEnterAccountName,
+                trailingContent = {
+                    Box(modifier = Modifier.padding(end = 16.dp)) {
+                        HSIconButton(
+                            variant = ButtonVariant.Secondary,
+                            size = ButtonSize.Small,
+                            icon = painterResource(R.drawable.ic_swap_circle_24),
+                            onClick = viewModel::generateRandomAccountName
+                        )
+                    }
+                }
             )
             VSpacer(32.dp)
             FormsInputMultiline(

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/watchaddress/WatchAddressService.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/watchaddress/WatchAddressService.kt
@@ -27,6 +27,8 @@ class WatchAddressService(
 
     fun nextWatchAccountName() = accountFactory.getNextWatchAccountName()
 
+    fun generateRandomWatchAccountName(): String = accountManager.getRandomWalletName()
+
     fun tokens(accountType: AccountType): List<Token> {
         val tokenQueries = buildList {
             when (accountType) {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/watchaddress/WatchAddressViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/watchaddress/WatchAddressViewModel.kt
@@ -44,7 +44,7 @@ class WatchAddressViewModel(
     private var openBirthdayHeightScreen: Boolean = false
 
     val defaultAccountName = watchAddressService.nextWatchAccountName()
-    var accountName: String = defaultAccountName
+    var accountName: String = watchAddressService.generateRandomWatchAccountName()
         get() = field.ifBlank { defaultAccountName }
         private set
 
@@ -62,6 +62,12 @@ class WatchAddressViewModel(
     fun onEnterAccountName(v: String) {
         accountNameEdited = v.isNotBlank()
         accountName = v
+    }
+
+    fun generateRandomAccountName() {
+        accountName = watchAddressService.generateRandomWatchAccountName()
+        accountNameEdited = true
+        emitState()
     }
 
     fun onEnterInput(v: String) {
@@ -173,7 +179,9 @@ class WatchAddressViewModel(
     private fun setAddress(address: Address) {
         this.address = address
         if (!accountNameEdited) {
-            accountName = address.domain ?: defaultAccountName
+            address.domain?.let {
+                accountName = it
+            }
         }
 
         type = addressType(address)


### PR DESCRIPTION
#9201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Random account name generation: Users can now automatically generate random account names when creating watched addresses. A new button placed in the account name entry field allows users to instantly create a random name with a single tap, eliminating the need for manual entry and making the account setup process faster and more convenient.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/horizontalsystems/unstoppable-wallet-android/pull/9213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->