### PR TITLE
Sync Hide Suspicious txs option in settings

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/SpamManager.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/managers/SpamManager.kt
@@ -15,6 +15,9 @@ import io.horizontalsystems.bankwallet.modules.transactions.TransactionSource
 import io.horizontalsystems.marketkit.models.BlockchainType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicReference
 
@@ -64,12 +67,15 @@ class SpamManager(
         return trustedAddressesCache.get().contains(key)
     }
 
-    var hideSuspiciousTx = localStorage.hideSuspiciousTransactions
-        private set
+    private val _hideSuspiciousTxStateFlow = MutableStateFlow(localStorage.hideSuspiciousTransactions)
+    val hideSuspiciousTxStateFlow: StateFlow<Boolean> = _hideSuspiciousTxStateFlow.asStateFlow()
+
+    val hideSuspiciousTx: Boolean
+        get() = _hideSuspiciousTxStateFlow.value
 
     fun updateFilterHideSuspiciousTx(hide: Boolean) {
         localStorage.hideSuspiciousTransactions = hide
-        hideSuspiciousTx = hide
+        _hideSuspiciousTxStateFlow.value = hide
     }
 
     fun findSpamByAddress(address: String): ScannedTransaction? {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/passcode/SecuritySettingsViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/settings/security/passcode/SecuritySettingsViewModel.kt
@@ -57,6 +57,13 @@ class SecuritySettingsViewModel(
                 refreshDefenseSystemActions()
             }
         }
+
+        viewModelScope.launch {
+            spamManager.hideSuspiciousTxStateFlow.collect {
+                hideSuspiciousTxs = it
+                emitState()
+            }
+        }
     }
 
     private fun refreshDefenseSystemActions() {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionFilterService.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionFilterService.kt
@@ -6,9 +6,11 @@ import io.horizontalsystems.bankwallet.core.managers.TransactionAdapterManager
 import io.horizontalsystems.bankwallet.entities.Wallet
 import io.horizontalsystems.bankwallet.modules.contacts.model.Contact
 import io.horizontalsystems.marketkit.models.Blockchain
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import java.util.UUID
 
 class TransactionFilterService(
@@ -163,6 +165,17 @@ class TransactionFilterService(
         hideSuspiciousTx = checked
         spamManager.updateFilterHideSuspiciousTx(checked)
         emitState()
+    }
+
+   fun observeSpamSetting(scope: CoroutineScope) {
+        scope.launch {
+            spamManager.hideSuspiciousTxStateFlow.collect { hide ->
+                if (hideSuspiciousTx != hide) {
+                    hideSuspiciousTx = hide
+                    emitState()
+                }
+            }
+        }
     }
 
     data class State(

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/transactions/TransactionsViewModel.kt
@@ -58,6 +58,8 @@ class TransactionsViewModel(
     private var refreshViewItemsJob: Job? = null
 
     init {
+        transactionFilterService.observeSpamSetting(viewModelScope)
+
         viewModelScope.launch(Dispatchers.Default) {
             service.start()
         }


### PR DESCRIPTION
#9239

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the "Hide Suspicious Transactions" setting to update instantly across the app when modified, ensuring consistent filtering behavior throughout the wallet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->