### PR TITLE
Update translation script and localized strings

### DIFF
--- a/.github/scripts/translate_strings.py
+++ b/.github/scripts/translate_strings.py
@@ -52,8 +52,10 @@ def has_cdata(value: str) -> bool:
 
 def escape_xml_value(value: str) -> str:
     """Escape characters that must be escaped in Android strings.xml values."""
-    # & first — only when not already part of a named XML entity
-    value = re.sub(r'&(?!(amp|lt|gt|apos|quot);)', '&amp;', value)
+    # & first — convert &apos; to \' (Android rejects the XML entity), then
+    # escape any bare & that isn't part of a remaining named entity
+    value = value.replace('&apos;', "\\'")
+    value = re.sub(r'&(?!(amp|lt|gt|quot);)', '&amp;', value)
     value = value.replace('<', '&lt;').replace('>', '&gt;')
     value = re.sub(r'(?<!\\)"', r'\\"', value)
     value = re.sub(r"(?<!\\)'", r"\\'", value)
@@ -112,7 +114,7 @@ Rules:
 - Keep name attributes exactly as-is (never translate the keys)
 - Preserve all Android format placeholders: %s, %d, %1$s, %2$s, %3$s, etc.
 - Preserve literal \\n newline sequences as \\n
-- Preserve XML entities: &amp; &lt; &gt; &apos; &quot;
+- Preserve XML entities &amp; &lt; &gt; — do NOT use &apos; or &quot;, use \' and \" instead (Android requirement)
 - Return ONLY valid JSON with this exact structure:
 {{
   "de": {{"KeyName": "translated value", ...}},

--- a/.github/scripts/translate_strings.py
+++ b/.github/scripts/translate_strings.py
@@ -52,10 +52,11 @@ def has_cdata(value: str) -> bool:
 
 def escape_xml_value(value: str) -> str:
     """Escape characters that must be escaped in Android strings.xml values."""
-    # & first — convert &apos; to \' (Android rejects the XML entity), then
+    # & first — convert XML quote entities to Android escapes, then
     # escape any bare & that isn't part of a remaining named entity
     value = value.replace('&apos;', "\\'")
-    value = re.sub(r'&(?!(amp|lt|gt|quot);)', '&amp;', value)
+    value = value.replace('&quot;', '\\"')
+    value = re.sub(r'&(?!(amp|lt|gt);)', '&amp;', value)
     value = value.replace('<', '&lt;').replace('>', '&gt;')
     value = re.sub(r'(?<!\\)"', r'\\"', value)
     value = re.sub(r"(?<!\\)'", r"\\'", value)

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1760,9 +1760,9 @@
     <string name="Swap_TopTokens">Meilleurs tokens</string>
     <string name="Swap_RecentSearch">Recherche récente</string>
     <string name="SwapTerms_RiskRestrictions_Highlight">évaluations des fournisseurs</string>
-    <string name="ZcashEndpointSettings_Description">Choisissez le serveur lightwallet que l&apos;application Unstoppable doit utiliser pour synchroniser le(s) portefeuille(s) Zcash.</string>
+    <string name="ZcashEndpointSettings_Description">Choisissez le serveur lightwallet que l\'application Unstoppable doit utiliser pour synchroniser le(s) portefeuille(s) Zcash.</string>
     <string name="AddZcashEndpoint_AddEndpoint">Ajouter un point de terminaison</string>
     <string name="AddZcashEndpoint_EndpointUrl">URL du point de terminaison</string>
     <string name="AddZcashEndpoint_Warning_UrlExists">Un point de terminaison avec cette URL existe déjà</string>
-    <string name="AddZcashEndpoint_Error_InvalidUrl">L&apos;URL saisie est invalide. Une URL valide doit utiliser le schéma https</string>
+    <string name="AddZcashEndpoint_Error_InvalidUrl">L\'URL saisie est invalide. Une URL valide doit utiliser le schéma https</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1364,7 +1364,7 @@
     <string name="SwapTerms_UserResponsibility_Info">Olası riskleri gözden geçirdim ve sağlayıcı seçimim için sorumluluk kabul ediyorum.</string>
     <string name="ZcashEndpointSettings_Description">Unstoppable uygulamasının Zcash cüzdan(larını) senkronize etmek için kullanması gereken lightwallet sunucusunu seçin.</string>
     <string name="AddZcashEndpoint_AddEndpoint">Uç nokta ekle</string>
-    <string name="AddZcashEndpoint_EndpointUrl">Uç nokta URL&apos;si</string>
-    <string name="AddZcashEndpoint_Warning_UrlExists">Bu URL&apos;ye sahip bir uç nokta zaten var</string>
+    <string name="AddZcashEndpoint_EndpointUrl">Uç nokta URL\'si</string>
+    <string name="AddZcashEndpoint_Warning_UrlExists">Bu URL\'ye sahip bir uç nokta zaten var</string>
     <string name="AddZcashEndpoint_Error_InvalidUrl">Girilen URL geçersizdir. Geçerli bir URL https şeması kullanmalıdır</string>
 </resources>


### PR DESCRIPTION
- Modify `translate_strings.py` to replace `&apos;` with `\'` and update instructions for the translation model to follow Android's requirement for escaping quotes.
- Update French and Turkish `strings.xml` to use `\'` instead of `&apos;` in Zcash endpoint settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of special characters in translations: apostrophes and quotes are now correctly escaped, and only &amp;, &lt;, &gt; entities are preserved per translation rules. This reduces misrendered characters and improves fidelity of translated text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->