### PR TITLE
Fix Zcash synchronizer conflict when ZEC is not enabled

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/zcash/ZcashAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/zcash/ZcashAdapter.kt
@@ -634,12 +634,10 @@ class ZcashAdapter(
                 isExchangeRateEnabled = false
             )
 
-            val account = synchronizer.getAccounts().first()
-            val transparentAddress = synchronizer.getTransparentAddress(account)
-
-            synchronizer.close()
-
-            return transparentAddress
+            return synchronizer.use { synchronizer ->
+                val account = synchronizer.getAccounts().first()
+                synchronizer.getTransparentAddress(account)
+            }
         }
 
         suspend fun estimateBirthdayHeight(context: Context, date: Date): Long {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/SwapHelper.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/SwapHelper.kt
@@ -26,6 +26,7 @@ import io.horizontalsystems.marketkit.models.Token
 import io.horizontalsystems.marketkit.models.TokenType
 import io.horizontalsystems.monerokit.MoneroKit
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -163,7 +164,7 @@ object SwapHelper {
 
                 BlockchainType.Zcash -> {
                     zcashAddressCache[account.id] ?: zcashAddressMutex.withLock {
-                        zcashAddressCache[account.id] ?: withContext(Dispatchers.IO) {
+                        zcashAddressCache[account.id] ?: withContext(NonCancellable + Dispatchers.IO) {
                             ZcashAdapter.getTransparentAddress(account, App.zcashEndpointManager.currentLightWalletEndpoint)
                         }.also { zcashAddressCache[account.id] = it }
                     }


### PR DESCRIPTION
When fetchFinalQuote was called twice in quick succession, the first job could be cancelled while holding the mutex inside withContext(IO). The Zcash SDK's runBlocking call would still complete, but cancellation was delivered before close() was reached, leaving the synchronizer registered as active. The second job would then fail with IllegalStateException when trying to create a synchronizer with the same alias.

Use NonCancellable in withContext so the critical section (create, close, cache) always runs to completion. Add synchronizer.use{} in getTransparentAddress to guarantee close() even if an exception is thrown after creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Zcash swap reliability through enhanced transparent address resolution with better resource management and network operation optimization.
  * Strengthened address fetching stability to prevent interruptions during swap transactions, ensuring more consistent processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->