### PR TITLE
Swap support zcash shielded

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/zcash/ZcashAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/zcash/ZcashAdapter.kt
@@ -587,7 +587,21 @@ class ZcashAdapter(
             }
         }
 
-        suspend fun getTransparentAddress(account: WalletAccount, lightWalletEndpoint: LightWalletEndpoint): String {
+        suspend fun getTransparentAddress(account: WalletAccount, lightWalletEndpoint: LightWalletEndpoint): String =
+            withTemporarySynchronizer(account, lightWalletEndpoint) { synchronizer ->
+                synchronizer.getTransparentAddress(synchronizer.getAccounts().first())
+            }
+
+        suspend fun getUnifiedAddress(account: WalletAccount, lightWalletEndpoint: LightWalletEndpoint): String =
+            withTemporarySynchronizer(account, lightWalletEndpoint) { synchronizer ->
+                synchronizer.getUnifiedAddress(synchronizer.getAccounts().first())
+            }
+
+        private suspend fun <T> withTemporarySynchronizer(
+            account: WalletAccount,
+            lightWalletEndpoint: LightWalletEndpoint,
+            block: suspend (Synchronizer) -> T,
+        ): T {
             val seed = (account.type as? AccountType.Mnemonic)?.seed
                 ?: throw IllegalArgumentException("Unsupported account type for Zcash")
 
@@ -635,64 +649,8 @@ class ZcashAdapter(
             )
 
             return synchronizer.use { synchronizer ->
-                val account = synchronizer.getAccounts().first()
-                synchronizer.getTransparentAddress(account)
+                block(synchronizer)
             }
-        }
-
-        suspend fun getUnifiedAddress(account: WalletAccount, lightWalletEndpoint: LightWalletEndpoint): String {
-            val seed = (account.type as? AccountType.Mnemonic)?.seed
-                ?: throw IllegalArgumentException("Unsupported account type for Zcash")
-
-            val alias = getValidAliasFromAccountId(account.id)
-            val network = ZcashNetwork.Mainnet
-            val context = App.instance
-            val existingWallet = App.localStorage.zcashAccountIds.contains(account.id)
-            val restoreSettings = App.restoreSettingsManager.settings(account, BlockchainType.Zcash)
-
-            val walletInitMode = if (existingWallet) {
-                WalletInitMode.ExistingWallet
-            } else when (account.origin) {
-                AccountOrigin.Created -> WalletInitMode.NewWallet
-                AccountOrigin.Restored -> WalletInitMode.RestoreWallet
-            }
-
-            val birthday = when (account.origin) {
-                AccountOrigin.Created -> {
-                    BlockHeight.ofLatestCheckpoint(context, network)
-                }
-
-                AccountOrigin.Restored -> restoreSettings.birthdayHeight
-                    ?.let { height ->
-                        max(network.saplingActivationHeight.value, height)
-                    }
-                    ?.let {
-                        BlockHeight.new(it)
-                    }
-            }
-
-            val synchronizer = Synchronizer.newBlocking(
-                context = context,
-                zcashNetwork = network,
-                alias = alias,
-                lightWalletEndpoint = lightWalletEndpoint,
-                setup = AccountCreateSetup(
-                    accountName = account.name,
-                    keySource = null,
-                    seed = FirstClassByteArray(seed)
-                ),
-                birthday = birthday,
-                walletInitMode = walletInitMode,
-                isTorEnabled = false,
-                isExchangeRateEnabled = false
-            )
-
-            val account = synchronizer.getAccounts().first()
-            val unifiedAddress = synchronizer.getUnifiedAddress(account)
-
-            synchronizer.close()
-
-            return unifiedAddress
         }
 
         suspend fun estimateBirthdayHeight(context: Context, date: Date): Long {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/zcash/ZcashAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/zcash/ZcashAdapter.kt
@@ -640,6 +640,61 @@ class ZcashAdapter(
             }
         }
 
+        suspend fun getUnifiedAddress(account: WalletAccount, lightWalletEndpoint: LightWalletEndpoint): String {
+            val seed = (account.type as? AccountType.Mnemonic)?.seed
+                ?: throw IllegalArgumentException("Unsupported account type for Zcash")
+
+            val alias = getValidAliasFromAccountId(account.id)
+            val network = ZcashNetwork.Mainnet
+            val context = App.instance
+            val existingWallet = App.localStorage.zcashAccountIds.contains(account.id)
+            val restoreSettings = App.restoreSettingsManager.settings(account, BlockchainType.Zcash)
+
+            val walletInitMode = if (existingWallet) {
+                WalletInitMode.ExistingWallet
+            } else when (account.origin) {
+                AccountOrigin.Created -> WalletInitMode.NewWallet
+                AccountOrigin.Restored -> WalletInitMode.RestoreWallet
+            }
+
+            val birthday = when (account.origin) {
+                AccountOrigin.Created -> {
+                    BlockHeight.ofLatestCheckpoint(context, network)
+                }
+
+                AccountOrigin.Restored -> restoreSettings.birthdayHeight
+                    ?.let { height ->
+                        max(network.saplingActivationHeight.value, height)
+                    }
+                    ?.let {
+                        BlockHeight.new(it)
+                    }
+            }
+
+            val synchronizer = Synchronizer.newBlocking(
+                context = context,
+                zcashNetwork = network,
+                alias = alias,
+                lightWalletEndpoint = lightWalletEndpoint,
+                setup = AccountCreateSetup(
+                    accountName = account.name,
+                    keySource = null,
+                    seed = FirstClassByteArray(seed)
+                ),
+                birthday = birthday,
+                walletInitMode = walletInitMode,
+                isTorEnabled = false,
+                isExchangeRateEnabled = false
+            )
+
+            val account = synchronizer.getAccounts().first()
+            val unifiedAddress = synchronizer.getUnifiedAddress(account)
+
+            synchronizer.close()
+
+            return unifiedAddress
+        }
+
         suspend fun estimateBirthdayHeight(context: Context, date: Date): Long {
             val blockHeight = SdkSynchronizer.estimateBirthdayHeight(
                 context = context,

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/SwapQuote.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/SwapQuote.kt
@@ -4,7 +4,7 @@ import io.horizontalsystems.bankwallet.modules.multiswap.action.ISwapProviderAct
 import io.horizontalsystems.marketkit.models.Token
 import java.math.BigDecimal
 
-data class SwapQuote(
+open class SwapQuote(
     val amountOut: BigDecimal,
     val tokenIn: Token,
     val tokenOut: Token,

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/BaseThorChainProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/BaseThorChainProvider.kt
@@ -1,9 +1,9 @@
 package io.horizontalsystems.bankwallet.modules.multiswap.providers
 
 import io.horizontalsystems.bankwallet.core.App
+import io.horizontalsystems.bankwallet.core.blockTime
 import io.horizontalsystems.bankwallet.core.derivation
 import io.horizontalsystems.bankwallet.core.managers.APIClient
-import io.horizontalsystems.bankwallet.core.blockTime
 import io.horizontalsystems.bankwallet.core.nativeTokenQueries
 import io.horizontalsystems.bankwallet.modules.multiswap.SwapFinalQuote
 import io.horizontalsystems.bankwallet.modules.multiswap.SwapQuote
@@ -187,6 +187,10 @@ abstract class BaseThorChainProvider(
     protected open fun getRefundAddress(tokenIn: Token): String? = null
     protected open fun getFromAddress(tokenIn: Token): String? = null
 
+    protected open suspend fun resolveDestinationAddress(tokenOut: Token): String {
+        return SwapHelper.getReceiveAddressForToken(tokenOut)
+    }
+
     private fun estimatedTime(quoteSwap: Response.QuoteSwap, tokenOut: Token): Long {
         val inbound = quoteSwap.inbound_confirmation_seconds ?: 0L
         val swap = quoteSwap.streaming_swap_seconds ?: 6L
@@ -203,7 +207,7 @@ abstract class BaseThorChainProvider(
         recipient: io.horizontalsystems.bankwallet.entities.Address?,
         slippage: BigDecimal,
     ): SwapFinalQuote {
-        val destination = recipient?.hex ?: SwapHelper.getReceiveAddressForToken(tokenOut)
+        val destination = recipient?.hex ?: resolveDestinationAddress(tokenOut)
         val quoteSwap = quoteSwap(tokenIn, tokenOut, amountIn, slippage, destination, getRefundAddress(tokenIn), getFromAddress(tokenIn))
 
         val amountOut = quoteSwap.expected_amount_out.movePointLeft(8)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/MayaProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/MayaProvider.kt
@@ -18,6 +18,16 @@ object MayaProvider : BaseThorChainProvider(
     override val icon = R.drawable.swap_provider_maya
     override val riskLevel = RiskLevel.EXCELLENT
 
+    override suspend fun resolveDestinationAddress(tokenOut: Token): String {
+        // Maya delivers ZEC directly to unified/sapling/orchard receivers via its transparent
+        // vault, so for ZEC out we resolve the wallet's unified address. Every other tokenOut
+        // goes through the generic destination resolver.
+        if (tokenOut.blockchainType == BlockchainType.Zcash) {
+            return SwapHelper.getReceiveAddressUnifiedForZcash(tokenOut)
+        }
+        return super.resolveDestinationAddress(tokenOut)
+    }
+
     override fun getRefundAddress(tokenIn: Token): String? {
         return if (tokenIn.blockchainType == BlockchainType.Zcash) {
             App.adapterManager.getAdapterForToken<ZcashAdapter>(tokenIn)?.receiveAddressTransparent

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/SwapHelper.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/SwapHelper.kt
@@ -10,13 +10,11 @@ import io.horizontalsystems.bankwallet.core.adapters.ECashAdapter
 import io.horizontalsystems.bankwallet.core.adapters.LitecoinAdapter
 import io.horizontalsystems.bankwallet.core.adapters.Trc20Adapter
 import io.horizontalsystems.bankwallet.core.adapters.toMoneroSeed
-import io.horizontalsystems.bankwallet.entities.AccountType
-import io.horizontalsystems.zanokit.ZanoKit
-import io.horizontalsystems.zanokit.ZanoWallet
 import io.horizontalsystems.bankwallet.core.adapters.zcash.ZcashAdapter
 import io.horizontalsystems.bankwallet.core.factories.FeeRateProviderFactory
 import io.horizontalsystems.bankwallet.core.isEvm
 import io.horizontalsystems.bankwallet.core.managers.NoActiveAccount
+import io.horizontalsystems.bankwallet.entities.AccountType
 import io.horizontalsystems.bankwallet.entities.transactionrecords.tron.TronApproveTransactionRecord
 import io.horizontalsystems.bankwallet.modules.multiswap.action.ActionApprove
 import io.horizontalsystems.bankwallet.modules.multiswap.action.ActionRevoke
@@ -25,6 +23,8 @@ import io.horizontalsystems.marketkit.models.BlockchainType
 import io.horizontalsystems.marketkit.models.Token
 import io.horizontalsystems.marketkit.models.TokenType
 import io.horizontalsystems.monerokit.MoneroKit
+import io.horizontalsystems.zanokit.ZanoKit
+import io.horizontalsystems.zanokit.ZanoWallet
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.sync.Mutex
@@ -37,6 +37,9 @@ object SwapHelper {
 
     private val zcashAddressCache = ConcurrentHashMap<String, String>()
     private val zcashAddressMutex = Mutex()
+
+    private val zcashUnifiedAddressCache = ConcurrentHashMap<String, String>()
+    private val zcashUnifiedAddressMutex = Mutex()
 
     suspend fun getAllowanceTrc20(token: Token, spenderAddress: String): BigDecimal? {
         if (token.type !is TokenType.Eip20) return null
@@ -172,6 +175,24 @@ object SwapHelper {
 
                 else -> throw SwapError.NoDestinationAddress()
             }
+        }
+    }
+
+    // Resolves the wallet's unified (shielded) Zcash address. Used for other->ZEC swaps where
+    // the provider can deliver directly into the shielded pool. Falls back to deriving the
+    // unified address from the active account when no Zcash adapter is enabled, caching the
+    // result to avoid re-running the expensive derivation (each call spins up a synchronizer).
+    suspend fun getReceiveAddressUnifiedForZcash(token: Token): String {
+        App.adapterManager.getAdapterForToken<ZcashAdapter>(token)?.let {
+            return it.receiveAddress
+        }
+
+        val account = App.accountManager.activeAccount ?: throw NoActiveAccount()
+
+        return zcashUnifiedAddressCache[account.id] ?: zcashUnifiedAddressMutex.withLock {
+            zcashUnifiedAddressCache[account.id] ?: withContext(Dispatchers.IO) {
+                ZcashAdapter.getUnifiedAddress(account, App.zcashEndpointManager.currentLightWalletEndpoint)
+            }.also { zcashUnifiedAddressCache[account.id] = it }
         }
     }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/SwapHelper.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/SwapHelper.kt
@@ -165,12 +165,8 @@ object SwapHelper {
                     }
                 }
 
-                BlockchainType.Zcash -> {
-                    zcashAddressCache[account.id] ?: zcashAddressMutex.withLock {
-                        zcashAddressCache[account.id] ?: withContext(NonCancellable + Dispatchers.IO) {
-                            ZcashAdapter.getTransparentAddress(account, App.zcashEndpointManager.currentLightWalletEndpoint)
-                        }.also { zcashAddressCache[account.id] = it }
-                    }
+                BlockchainType.Zcash -> cachedZcashAddress(account.id, zcashAddressCache, zcashAddressMutex) {
+                    ZcashAdapter.getTransparentAddress(account, App.zcashEndpointManager.currentLightWalletEndpoint)
                 }
 
                 else -> throw SwapError.NoDestinationAddress()
@@ -189,10 +185,22 @@ object SwapHelper {
 
         val account = App.accountManager.activeAccount ?: throw NoActiveAccount()
 
-        return zcashUnifiedAddressCache[account.id] ?: zcashUnifiedAddressMutex.withLock {
-            zcashUnifiedAddressCache[account.id] ?: withContext(Dispatchers.IO) {
-                ZcashAdapter.getUnifiedAddress(account, App.zcashEndpointManager.currentLightWalletEndpoint)
-            }.also { zcashUnifiedAddressCache[account.id] = it }
+        return cachedZcashAddress(account.id, zcashUnifiedAddressCache, zcashUnifiedAddressMutex) {
+            ZcashAdapter.getUnifiedAddress(account, App.zcashEndpointManager.currentLightWalletEndpoint)
+        }
+    }
+
+    // Double-checked cache for a derived Zcash address. The derivation spins up a fresh
+    // synchronizer, so results are memoized per account under a mutex to serialize concurrent
+    // callers and run the work off the main thread.
+    private suspend fun cachedZcashAddress(
+        accountId: String,
+        cache: ConcurrentHashMap<String, String>,
+        mutex: Mutex,
+        derive: suspend () -> String,
+    ): String {
+        return cache[accountId] ?: mutex.withLock {
+            cache[accountId] ?: withContext(NonCancellable + Dispatchers.IO) { derive() }.also { cache[accountId] = it }
         }
     }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/USwapProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/USwapProvider.kt
@@ -272,7 +272,7 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
         // the transparent and shielded destinations so the server can return both routes;
         // pickRoute then remembers the better one for the confirmation quote.
         val (destinationAddress, destinationAddressUnified) = if (supportsAlternateRouteSelection(tokenOut)) {
-            resolveDestinations(recipient = null, tokenOut = tokenOut)
+            resolveDestinations(tokenOut)
         } else {
             null to null
         }
@@ -365,10 +365,10 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
     // Resolves the destination(s) sent to the server. `primary` is always returned (transparent
     // for ZEC, native otherwise); `unified` is filled only for ZEC out with no explicit recipient
     // so providers that can deliver into the shielded pool get to route there.
-    private suspend fun resolveDestinations(recipient: String?, tokenOut: Token): Pair<String, String?> {
-        val primary = recipient ?: SwapHelper.getReceiveAddressForToken(tokenOut)
+    private suspend fun resolveDestinations(tokenOut: Token): Pair<String, String?> {
+        val primary = SwapHelper.getReceiveAddressForToken(tokenOut)
 
-        if (recipient != null || tokenOut.blockchainType != BlockchainType.Zcash) {
+        if (tokenOut.blockchainType != BlockchainType.Zcash) {
             return primary to null
         }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/USwapProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/USwapProvider.kt
@@ -9,6 +9,7 @@ import io.horizontalsystems.bankwallet.core.managers.APIClient
 import io.horizontalsystems.bankwallet.core.nativeTokenQueries
 import io.horizontalsystems.bankwallet.modules.multiswap.SwapFinalQuote
 import io.horizontalsystems.bankwallet.modules.multiswap.SwapQuote
+import io.horizontalsystems.bankwallet.modules.multiswap.action.ISwapProviderAction
 import io.horizontalsystems.bankwallet.modules.multiswap.sendtransaction.SendTransactionData
 import io.horizontalsystems.bankwallet.modules.multiswap.sendtransaction.SendTransactionSettings
 import io.horizontalsystems.bankwallet.modules.multiswap.ui.DataFieldRecipient
@@ -80,13 +81,28 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
     private var supportedBlockchainTypes = setOf<BlockchainType>()
 
     // Some provider+tokenOut pairs fan a dry quote into multiple routes (currently: Exolix
-    // returns both transparent and shielded ZEC). The dry call picks one and remembers it here
-    // so the confirmation (non-dry) call re-quotes exactly that same route.
-    private var selectedAlternateRoute: SelectedAlternateRoute? = null
-
+    // returns both transparent and shielded ZEC). The dry call picks one and carries it on the
+    // returned quote so the confirmation (non-dry) call re-quotes exactly that same route.
     private data class SelectedAlternateRoute(
         val buyAsset: String,
         val destinationAddress: String,
+    )
+
+    // SwapQuote variant that remembers the route the dry quote settled on, so fetchFinalQuote can
+    // replay it. Kept local to USwapProvider since no other provider needs alternate routes.
+    private class USwapQuote(
+        amountOut: BigDecimal,
+        tokenIn: Token,
+        tokenOut: Token,
+        amountIn: BigDecimal,
+        actionRequired: ISwapProviderAction?,
+        estimationTime: Long?,
+        val selectedAlternateRoute: SelectedAlternateRoute?,
+    ) : SwapQuote(amountOut, tokenIn, tokenOut, amountIn, actionRequired, estimationTime)
+
+    private data class RouteSelection(
+        val route: UnstoppableAPI.Response.Quote.Route,
+        val selectedAlternateRoute: SelectedAlternateRoute?,
     )
 
     private sealed class ProviderData {
@@ -278,7 +294,7 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
             destinationAddressUnified = SwapHelper.getReceiveAddressUnifiedForZcash(tokenOut)
         }
 
-        val bestRoute = quoteSwapBestRoute(
+        val routeSelection = quoteSwapBestRoute(
             tokenIn,
             tokenOut,
             amountIn,
@@ -290,6 +306,7 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
             null,
             true
         )
+        val bestRoute = routeSelection.route
 
         val approvalAddress = bestRoute.meta?.approvalAddress?.let { router ->
             try {
@@ -304,13 +321,14 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
             EvmSwapHelper.actionApprove(allowance, amountIn, it, tokenIn)
         }
 
-        return SwapQuote(
+        return USwapQuote(
             amountOut = bestRoute.expectedBuyAmount ?: BigDecimal.ZERO,
             tokenIn = tokenIn,
             tokenOut = tokenOut,
             amountIn = amountIn,
             actionRequired = actionApprove,
             estimationTime = bestRoute.estimatedTime?.total,
+            selectedAlternateRoute = routeSelection.selectedAlternateRoute,
         )
     }
 
@@ -325,7 +343,7 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
         refundAddress: String?,
         buyAssetOverride: String?,
         dry: Boolean,
-    ): UnstoppableAPI.Response.Quote.Route {
+    ): RouteSelection {
         val usingDerivedIdentifiers = assetsMap.isEmpty()
         val assetIn = assetsMap[tokenIn] ?: deriveIdentifier(tokenIn) ?: throw IllegalStateException("No identifier for tokenIn")
         val assetOut = assetsMap[tokenOut] ?: deriveIdentifier(tokenOut) ?: throw IllegalStateException("No identifier for tokenOut")
@@ -370,9 +388,9 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
         fallbackBuyAsset: String,
         destinationAddress: String?,
         destinationAddressUnified: String?,
-    ): UnstoppableAPI.Response.Quote.Route {
+    ): RouteSelection {
         if (!dry || !supportsAlternateRouteSelection(tokenOut)) {
-            return routes.maxBy { it.expectedBuyAmount ?: BigDecimal.ZERO }
+            return RouteSelection(routes.maxBy { it.expectedBuyAmount ?: BigDecimal.ZERO }, null)
         }
 
         // Exolix's ZEC dry quote can carry both the transparent and shielded routes. Pick the
@@ -389,14 +407,14 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
             destinationAddress
         }
 
-        selectedDestination?.let {
-            selectedAlternateRoute = SelectedAlternateRoute(
+        val selectedAlternateRoute = selectedDestination?.let {
+            SelectedAlternateRoute(
                 buyAsset = best.buyAsset ?: fallbackBuyAsset,
                 destinationAddress = it,
             )
         }
 
-        return best
+        return RouteSelection(best, selectedAlternateRoute)
     }
 
     override suspend fun checkAmlAddresses(addresses: List<String>): Boolean? {
@@ -418,7 +436,7 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
         // When a dry quote previously fanned out into multiple routes, the confirmation quote must
         // re-request the exact (buyAsset, destination) the dry call settled on. An explicit
         // recipient overrides any selection.
-        val selection = selectedAlternateRoute?.takeIf {
+        val selection = (swapQuote as? USwapQuote)?.selectedAlternateRoute?.takeIf {
             recipient == null && supportsAlternateRouteSelection(tokenOut)
         }
         val destination = selection?.destinationAddress
@@ -436,7 +454,7 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
             refundAddress,
             selection?.buyAsset,
             false,
-        )
+        ).route
 
         val amountOut = bestRoute.expectedBuyAmount ?: BigDecimal.ZERO
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/USwapProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/USwapProvider.kt
@@ -271,10 +271,11 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
         // For providers that fan a dry quote into multiple routes (Exolix ZEC-out), resolve both
         // the transparent and shielded destinations so the server can return both routes;
         // pickRoute then remembers the better one for the confirmation quote.
-        val (destinationAddress, destinationAddressUnified) = if (supportsAlternateRouteSelection(tokenOut)) {
-            resolveDestinations(tokenOut)
-        } else {
-            null to null
+        var destinationAddress: String? = null
+        var destinationAddressUnified: String? = null
+        if (supportsAlternateRouteSelection(tokenOut)) {
+            destinationAddress = SwapHelper.getReceiveAddressForToken(tokenOut)
+            destinationAddressUnified = SwapHelper.getReceiveAddressUnifiedForZcash(tokenOut)
         }
 
         val bestRoute = quoteSwapBestRoute(
@@ -360,19 +361,6 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
     // Exolix's ZEC pair does (transparent + shielded); extend here if another provider splits.
     private fun supportsAlternateRouteSelection(tokenOut: Token): Boolean {
         return provider == UProvider.Exolix && tokenOut.blockchainType == BlockchainType.Zcash
-    }
-
-    // Resolves the destination(s) sent to the server. `primary` is always returned (transparent
-    // for ZEC, native otherwise); `unified` is filled only for ZEC out with no explicit recipient
-    // so providers that can deliver into the shielded pool get to route there.
-    private suspend fun resolveDestinations(tokenOut: Token): Pair<String, String?> {
-        val primary = SwapHelper.getReceiveAddressForToken(tokenOut)
-
-        if (tokenOut.blockchainType != BlockchainType.Zcash) {
-            return primary to null
-        }
-
-        return primary to SwapHelper.getReceiveAddressUnifiedForZcash(tokenOut)
     }
 
     private fun pickRoute(

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/USwapProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/USwapProvider.kt
@@ -79,6 +79,16 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
     private var assetsMap = mapOf<Token, String>()
     private var supportedBlockchainTypes = setOf<BlockchainType>()
 
+    // Some provider+tokenOut pairs fan a dry quote into multiple routes (currently: Exolix
+    // returns both transparent and shielded ZEC). The dry call picks one and remembers it here
+    // so the confirmation (non-dry) call re-quotes exactly that same route.
+    private var selectedAlternateRoute: SelectedAlternateRoute? = null
+
+    private data class SelectedAlternateRoute(
+        val buyAsset: String,
+        val destinationAddress: String,
+    )
+
     private sealed class ProviderData {
         data class TokenMap(val map: Map<Token, String>) : ProviderData()
         data class ChainIds(val ids: List<String>) : ProviderData()
@@ -117,6 +127,11 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
 
         val assetsMap = mutableMapOf<Token, String>()
         for (token in tokens) {
+            // ZEC.ZECSHIELDED is an internal Exolix routing variant. The app always quotes
+            // ZEC.ZEC and lets the server expand it into the shielded route, so skip it here
+            // to keep the Zcash native token mapping deterministic.
+            if (token.identifier == ZCASH_SHIELDED_ASSET) continue
+
             val blockchainType = blockchainTypes[token.chainId] ?: continue
 
             when (blockchainType) {
@@ -253,11 +268,22 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
         tokenOut: Token,
         amountIn: BigDecimal,
     ): SwapQuote {
+        // For providers that fan a dry quote into multiple routes (Exolix ZEC-out), resolve both
+        // the transparent and shielded destinations so the server can return both routes;
+        // pickRoute then remembers the better one for the confirmation quote.
+        val (destinationAddress, destinationAddressUnified) = if (supportsAlternateRouteSelection(tokenOut)) {
+            resolveDestinations(recipient = null, tokenOut = tokenOut)
+        } else {
+            null to null
+        }
+
         val bestRoute = quoteSwapBestRoute(
             tokenIn,
             tokenOut,
             amountIn,
             BigDecimal("1"),
+            destinationAddress,
+            destinationAddressUnified,
             null,
             null,
             null,
@@ -293,8 +319,10 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
         amountIn: BigDecimal,
         slippage: BigDecimal,
         destinationAddress: String?,
+        destinationAddressUnified: String?,
         sourceAddress: String?,
         refundAddress: String?,
+        buyAssetOverride: String?,
         dry: Boolean,
     ): UnstoppableAPI.Response.Quote.Route {
         val usingDerivedIdentifiers = assetsMap.isEmpty()
@@ -305,11 +333,12 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
         val quote = unstoppableAPI.quote(
             UnstoppableAPI.Request.Quote(
                 sellAsset = assetIn,
-                buyAsset = assetOut,
+                buyAsset = buyAssetOverride ?: assetOut,
                 sellAmount = amountIn.toPlainString(),
                 providers = setOf(provider.id),
                 slippage = slippage,
                 destinationAddress = destinationAddress,
+                destinationAddressUnified = destinationAddressUnified,
                 sourceAddress = sourceAddress,
                 refundAddress = refundAddress,
                 dry = dry,
@@ -317,7 +346,69 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
             )
         )
 
-        return quote.routes.maxBy { it.expectedBuyAmount ?: BigDecimal.ZERO }
+        return pickRoute(
+            routes = quote.routes,
+            dry = dry,
+            tokenOut = tokenOut,
+            fallbackBuyAsset = assetOut,
+            destinationAddress = destinationAddress,
+            destinationAddressUnified = destinationAddressUnified,
+        )
+    }
+
+    // True for provider+tokenOut pairs whose dry quote fans into multiple routes. Today only
+    // Exolix's ZEC pair does (transparent + shielded); extend here if another provider splits.
+    private fun supportsAlternateRouteSelection(tokenOut: Token): Boolean {
+        return provider == UProvider.Exolix && tokenOut.blockchainType == BlockchainType.Zcash
+    }
+
+    // Resolves the destination(s) sent to the server. `primary` is always returned (transparent
+    // for ZEC, native otherwise); `unified` is filled only for ZEC out with no explicit recipient
+    // so providers that can deliver into the shielded pool get to route there.
+    private suspend fun resolveDestinations(recipient: String?, tokenOut: Token): Pair<String, String?> {
+        val primary = recipient ?: SwapHelper.getReceiveAddressForToken(tokenOut)
+
+        if (recipient != null || tokenOut.blockchainType != BlockchainType.Zcash) {
+            return primary to null
+        }
+
+        return primary to SwapHelper.getReceiveAddressUnifiedForZcash(tokenOut)
+    }
+
+    private fun pickRoute(
+        routes: List<UnstoppableAPI.Response.Quote.Route>,
+        dry: Boolean,
+        tokenOut: Token,
+        fallbackBuyAsset: String,
+        destinationAddress: String?,
+        destinationAddressUnified: String?,
+    ): UnstoppableAPI.Response.Quote.Route {
+        if (!dry || !supportsAlternateRouteSelection(tokenOut)) {
+            return routes.maxBy { it.expectedBuyAmount ?: BigDecimal.ZERO }
+        }
+
+        // Exolix's ZEC dry quote can carry both the transparent and shielded routes. Pick the
+        // better-priced one — preferring shielded on a tie, for privacy — and remember it so
+        // the confirmation quote replays the same route.
+        val best = routes.maxWithOrNull(
+            compareBy<UnstoppableAPI.Response.Quote.Route> { it.expectedBuyAmount ?: BigDecimal.ZERO }
+                .thenBy { if (it.buyAsset == ZCASH_SHIELDED_ASSET) 1 else 0 }
+        ) ?: throw IllegalStateException("No routes")
+
+        val selectedDestination = if (best.buyAsset == ZCASH_SHIELDED_ASSET) {
+            destinationAddressUnified ?: destinationAddress
+        } else {
+            destinationAddress
+        }
+
+        selectedDestination?.let {
+            selectedAlternateRoute = SelectedAlternateRoute(
+                buyAsset = best.buyAsset ?: fallbackBuyAsset,
+                destinationAddress = it,
+            )
+        }
+
+        return best
     }
 
     override suspend fun checkAmlAddresses(addresses: List<String>): Boolean? {
@@ -333,9 +424,18 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
         recipient: io.horizontalsystems.bankwallet.entities.Address?,
         slippage: BigDecimal,
     ): SwapFinalQuote {
-        val destination = recipient?.hex ?: SwapHelper.getReceiveAddressForToken(tokenOut)
         val sourceAddress = SwapHelper.getSendingAddressForToken(tokenIn)
         val refundAddress = SwapHelper.getReceiveAddressForToken(tokenIn)
+
+        // When a dry quote previously fanned out into multiple routes, the confirmation quote must
+        // re-request the exact (buyAsset, destination) the dry call settled on. An explicit
+        // recipient overrides any selection.
+        val selection = selectedAlternateRoute?.takeIf {
+            recipient == null && supportsAlternateRouteSelection(tokenOut)
+        }
+        val destination = selection?.destinationAddress
+            ?: recipient?.hex
+            ?: SwapHelper.getReceiveAddressForToken(tokenOut)
 
         val bestRoute = quoteSwapBestRoute(
             tokenIn,
@@ -343,8 +443,10 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
             amountIn,
             slippage,
             destination,
+            null,
             sourceAddress,
             refundAddress,
+            selection?.buyAsset,
             false,
         )
 
@@ -561,6 +663,12 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
 
         throw IllegalArgumentException("Not supported blockchainType: $blockchainType")
     }
+
+    companion object {
+        // Exolix's shielded Zcash route. Internal routing detail — the app always quotes ZEC.ZEC
+        // and lets the server expand it into this shielded variant.
+        private const val ZCASH_SHIELDED_ASSET = "ZEC.ZECSHIELDED"
+    }
 }
 
 interface UnstoppableAPI {
@@ -600,6 +708,7 @@ interface UnstoppableAPI {
             val providers: Set<String>,
             val slippage: BigDecimal,
             val destinationAddress: String?,
+            val destinationAddressUnified: String? = null,
             val sourceAddress: String?,
             val refundAddress: String?,
             val dry: Boolean,
@@ -655,6 +764,7 @@ interface UnstoppableAPI {
         ) {
             data class Route(
                 val expectedBuyAmount: BigDecimal?,
+                val buyAsset: String?,
                 val tx: JsonElement?,
                 val inboundAddress: String,
                 val memo: String?,


### PR DESCRIPTION
#9266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified (shielded) Zcash address support for swaps to improve privacy.
  * Deterministic alternate-route selection for Zcash swaps with persistent route replay for confirmations.
  * Swap quote requests now include unified destination where applicable.

* **Refactor**
  * Centralized and memoized address resolution and caching to optimize swap/address lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->