### PR TITLE
Add Zec in default token list for new wallet

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/createaccount/CreateAccountViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/createaccount/CreateAccountViewModel.kt
@@ -142,6 +142,7 @@ class CreateAccountViewModel(
             TokenQuery(BlockchainType.Bitcoin, TokenType.Derived(TokenType.Derivation.Bip84)),
             TokenQuery(BlockchainType.Ethereum, TokenType.Native),
             TokenQuery(BlockchainType.Monero, TokenType.Native),
+            TokenQuery(BlockchainType.Zcash, TokenType.Native),
             TokenQuery(BlockchainType.Tron, TokenType.Native),
             TokenQuery(BlockchainType.BinanceSmartChain, TokenType.Native),
             TokenQuery(BlockchainType.Tron, TokenType.Eip20("TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t")),//USDT(TRC20)


### PR DESCRIPTION
#9278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Zcash is now automatically enabled as a default token for newly created accounts, providing immediate access to this blockchain without additional configuration steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->