### PR TITLE
Add Pegasus to USwap simple transaction providers

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/UProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/UProvider.kt
@@ -10,6 +10,10 @@ enum class UProvider(
     val riskLevel: RiskLevel,
     val isEvm: Boolean,
     val isSingleTransactionSwap: Boolean,
+    // Provider accepts plain sends to its deposit address (any output type) on UTXO
+    // chains (Bitcoin-family, Zcash, Monero, Zano). Providers with special tx
+    // requirements (e.g. thorchain memos) must be false and handled separately if ever needed.
+    val supportsSimpleUtxoTransactions: Boolean,
 ) {
     Near(
         "NEAR",
@@ -20,7 +24,8 @@ enum class UProvider(
         true,
         RiskLevel.FAIR,
         isEvm = false,
-        isSingleTransactionSwap = false
+        isSingleTransactionSwap = false,
+        supportsSimpleUtxoTransactions = true
     ),
     QuickEx(
         "QUICKEX",
@@ -31,7 +36,8 @@ enum class UProvider(
         true,
         RiskLevel.GOOD,
         isEvm = false,
-        isSingleTransactionSwap = false
+        isSingleTransactionSwap = false,
+        supportsSimpleUtxoTransactions = true
     ),
     LetsExchange(
         "LETSEXCHANGE",
@@ -42,7 +48,8 @@ enum class UProvider(
         true,
         RiskLevel.GOOD,
         isEvm = false,
-        isSingleTransactionSwap = false
+        isSingleTransactionSwap = false,
+        supportsSimpleUtxoTransactions = true
     ),
     StealthEx(
         "STEALTHEX",
@@ -53,7 +60,8 @@ enum class UProvider(
         true,
         RiskLevel.FAIR,
         isEvm = false,
-        isSingleTransactionSwap = false
+        isSingleTransactionSwap = false,
+        supportsSimpleUtxoTransactions = true
     ),
     Exolix(
         "EXOLIX",
@@ -64,7 +72,8 @@ enum class UProvider(
         true,
         RiskLevel.GOOD,
         isEvm = false,
-        isSingleTransactionSwap = false
+        isSingleTransactionSwap = false,
+        supportsSimpleUtxoTransactions = true
     ),
     Cce(
         "CCE",
@@ -75,7 +84,8 @@ enum class UProvider(
         true,
         RiskLevel.GOOD,
         isEvm = false,
-        isSingleTransactionSwap = false
+        isSingleTransactionSwap = false,
+        supportsSimpleUtxoTransactions = true
     ),
     Swapuz(
         "SWAPUZ",
@@ -86,7 +96,8 @@ enum class UProvider(
         true,
         RiskLevel.GOOD,
         isEvm = false,
-        isSingleTransactionSwap = false
+        isSingleTransactionSwap = false,
+        supportsSimpleUtxoTransactions = true
     ),
     Barter(
         "BARTER",
@@ -97,7 +108,8 @@ enum class UProvider(
         true,
         RiskLevel.FAIR,
         isEvm = true,
-        isSingleTransactionSwap = true
+        isSingleTransactionSwap = true,
+        supportsSimpleUtxoTransactions = false
     ),
     Circle(
         "CIRCLE",
@@ -108,7 +120,8 @@ enum class UProvider(
         true,
         RiskLevel.EXCELLENT,
         isEvm = true,
-        isSingleTransactionSwap = false
+        isSingleTransactionSwap = false,
+        supportsSimpleUtxoTransactions = false
     ),
     Pegasus(
         id = "PEGASUS",
@@ -119,6 +132,7 @@ enum class UProvider(
         requireTerms = true,
         riskLevel = RiskLevel.GOOD,
         isEvm = false,
-        isSingleTransactionSwap = false
+        isSingleTransactionSwap = false,
+        supportsSimpleUtxoTransactions = true
     );
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/USwapProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/USwapProvider.kt
@@ -471,21 +471,7 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
             BlockchainType.Dash,
             BlockchainType.ECash,
                 -> {
-                // supported only providers that accepts any type of outputs
-                // providers with specific requirements like thorchain is not supported
-                // if thorchain support needed then it should be handled separately
-                val simpleBtcTransactionProviders = listOf(
-                    UProvider.Near,
-                    UProvider.QuickEx,
-                    UProvider.LetsExchange,
-                    UProvider.StealthEx,
-                    UProvider.Exolix,
-                    UProvider.Cce,
-                    UProvider.Swapuz,
-                    UProvider.Pegasus
-                )
-
-                if (!simpleBtcTransactionProviders.contains(provider)) {
+                if (!provider.supportsSimpleUtxoTransactions) {
                     throw IllegalStateException("Only simple BTC tx providers are supported")
                 }
 
@@ -546,17 +532,7 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
             }
 
             BlockchainType.Zcash -> {
-                val simpleZcashTransactionProviders = listOf(
-                    UProvider.Near,
-                    UProvider.QuickEx,
-                    UProvider.LetsExchange,
-                    UProvider.StealthEx,
-                    UProvider.Exolix,
-                    UProvider.Cce,
-                    UProvider.Swapuz
-                )
-
-                if (!simpleZcashTransactionProviders.contains(provider)) {
+                if (!provider.supportsSimpleUtxoTransactions) {
                     throw IllegalStateException("Only simple ZEC tx providers are supported")
                 }
 
@@ -568,18 +544,7 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
             }
 
             BlockchainType.Monero -> {
-                val simpleMoneroTransactionProviders = listOf(
-                    UProvider.Near,
-                    UProvider.QuickEx,
-                    UProvider.LetsExchange,
-                    UProvider.StealthEx,
-                    UProvider.Exolix,
-                    UProvider.Cce,
-                    UProvider.Swapuz,
-                    UProvider.Pegasus,
-                )
-
-                if (!simpleMoneroTransactionProviders.contains(provider)) {
+                if (!provider.supportsSimpleUtxoTransactions) {
                     throw IllegalStateException("Only simple XMR tx providers are supported")
                 }
 
@@ -591,17 +556,7 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
             }
 
             BlockchainType.Zano -> {
-                val simpleZanoTransactionProviders = listOf(
-                    UProvider.Near,
-                    UProvider.QuickEx,
-                    UProvider.LetsExchange,
-                    UProvider.StealthEx,
-                    UProvider.Exolix,
-                    UProvider.Cce,
-                    UProvider.Swapuz
-                )
-
-                if (!simpleZanoTransactionProviders.contains(provider)) {
+                if (!provider.supportsSimpleUtxoTransactions) {
                     throw IllegalStateException("Only simple ZANO tx providers are supported")
                 }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/USwapProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/providers/USwapProvider.kt
@@ -481,7 +481,8 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
                     UProvider.StealthEx,
                     UProvider.Exolix,
                     UProvider.Cce,
-                    UProvider.Swapuz
+                    UProvider.Swapuz,
+                    UProvider.Pegasus
                 )
 
                 if (!simpleBtcTransactionProviders.contains(provider)) {
@@ -574,7 +575,8 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
                     UProvider.StealthEx,
                     UProvider.Exolix,
                     UProvider.Cce,
-                    UProvider.Swapuz
+                    UProvider.Swapuz,
+                    UProvider.Pegasus,
                 )
 
                 if (!simpleMoneroTransactionProviders.contains(provider)) {


### PR DESCRIPTION
#9262 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Providers now declare whether they support simple UTXO send transactions, enabling eligible providers (including Pegasus, Near, QuickEx, LetsExchange, StealthEx, Exolix, Cce, Swapuz) to be used in simple-send flows.
* **Bug Fixes**
  * Removed hard-coded per-blockchain allowlists; provider support is now determined consistently and unsupported providers show a clear message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->