### PR TITLE
Fix selected swap tokenOut by default for BCH

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/SwapDefaultTokenService.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/SwapDefaultTokenService.kt
@@ -1,12 +1,11 @@
 package io.horizontalsystems.bankwallet.modules.multiswap
 
 import io.horizontalsystems.bankwallet.core.ServiceState
+import io.horizontalsystems.bankwallet.core.defaultTokenQuery
 import io.horizontalsystems.bankwallet.core.managers.MarketKitWrapper
 import io.horizontalsystems.bankwallet.core.managers.WalletManager
 import io.horizontalsystems.marketkit.models.BlockchainType
 import io.horizontalsystems.marketkit.models.Token
-import io.horizontalsystems.marketkit.models.TokenQuery
-import io.horizontalsystems.marketkit.models.TokenType
 
 class SwapDefaultTokenService(
     private val marketKit: MarketKitWrapper,
@@ -25,30 +24,16 @@ class SwapDefaultTokenService(
     }
 
     private fun determineTokenOut(token: Token) {
-        val blockchainType = token.blockchainType
-
-        if (token.type == TokenType.Native) {
-            // Use the same context-aware Popular Tokens list as the token selector, so the
-            // auto-picked counterpart matches the top of that list (e.g. USDT on Polygon)
-            // instead of a hardcoded "tether" lookup that misses chain-specific stablecoins.
-            tokenOut = SwapPopularTokens.build(marketKit, token).firstOrNull()
-                ?: walletManager.activeWallets
-                    .firstOrNull { it.token.blockchainType == BlockchainType.Bitcoin }
-                    ?.token
-                ?: marketKit.token(TokenQuery(BlockchainType.Bitcoin, TokenType.Derived(TokenType.Derivation.Bip84)))
-        } else if (token.type is TokenType.Derived) {
-            val targetBlockchainType = if (blockchainType == BlockchainType.Bitcoin) BlockchainType.Monero else BlockchainType.Bitcoin
-            tokenOut = walletManager.activeWallets
-                .firstOrNull { it.token.blockchainType == targetBlockchainType }
+        // The default counterpart is the first entry of the context-aware Popular Tokens list,
+        // built with the just-selected token as context — so the auto-pick always matches the
+        // top bubble the user would see in the token picker for that token. This holds for every
+        // token type: native context → its USDT (fallback USDT-ETH), non-native context → the
+        // chain's native coin. See token_picker spec (Popular Tokens, Cases А/Б).
+        tokenOut = SwapPopularTokens.build(marketKit, token).firstOrNull()
+            ?: walletManager.activeWallets
+                .firstOrNull { it.token.blockchainType == BlockchainType.Bitcoin }
                 ?.token
-                ?: if (targetBlockchainType == BlockchainType.Bitcoin) {
-                    marketKit.token(TokenQuery(BlockchainType.Bitcoin, TokenType.Derived(TokenType.Derivation.Bip84)))
-                } else {
-                    marketKit.token(TokenQuery(BlockchainType.Monero, TokenType.Native))
-                }
-        } else {
-            tokenOut = marketKit.token(TokenQuery(blockchainType, TokenType.Native))
-        }
+            ?: marketKit.token(BlockchainType.Bitcoin.defaultTokenQuery)
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic selection of the swap output token to behave consistently across different token types.
  * When choosing the default counterpart, the app now prefers the context-appropriate “popular tokens” match, then falls back to the active wallet’s Bitcoin token (if available), and finally to Bitcoin’s default token—resulting in more predictable swap outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->