### PR TITLE
Don't autofocus amount when navigating to swap in tabs

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/main/MainFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/main/MainFragment.kt
@@ -200,7 +200,8 @@ private fun MainScreen(
                         fragmentNavController,
                         onClickClose = null,
                         bottomPadding = navigationBarHeight,
-                        closeAfterSwap = false
+                        closeAfterSwap = false,
+                        autofocus = false
                     )
 
 //                    MainNavigation.Transactions -> TransactionsScreen(

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/SwapFragment.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/multiswap/SwapFragment.kt
@@ -138,7 +138,8 @@ fun SwapScreen(
     tokenOut: Token? = null,
     onClickClose: (() -> Unit)? = null,
     bottomPadding: Dp = 0.dp,
-    closeAfterSwap: Boolean = true
+    closeAfterSwap: Boolean = true,
+    autofocus: Boolean = true
 ) {
     val currentBackStackEntry = remember { navController.currentBackStackEntry }
     val viewModel = viewModel<SwapViewModel>(
@@ -279,6 +280,7 @@ fun SwapScreen(
         onResume = viewModel::onResume,
         onPause = viewModel::onPause,
         bottomPadding = bottomPadding,
+        autofocus = autofocus
     )
 }
 
@@ -300,6 +302,7 @@ private fun SwapScreenInner(
     onResume: () -> Unit,
     onPause: () -> Unit,
     bottomPadding: Dp = 0.dp,
+    autofocus: Boolean,
 ) {
     LifecycleResumeEffect(Unit) {
         onResume.invoke()
@@ -349,7 +352,7 @@ private fun SwapScreenInner(
         // the lock screen).
         var keyboardRequested by rememberSaveable { mutableStateOf(false) }
         LaunchedEffect(Unit) {
-            if (!keyboardRequested && !App.pinComponent.isLocked) {
+            if (autofocus && !keyboardRequested && !App.pinComponent.isLocked) {
                 keyboardRequested = true
                 amountInputFocusRequester.requestFocus()
             }


### PR DESCRIPTION
#9308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed automatic keyboard focus in the swap screen when navigating from the main interface, providing a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->