### PR TITLE
Implement WalletConnect UX fixes

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/main/MainActivityViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/main/MainActivityViewModel.kt
@@ -57,7 +57,7 @@ class MainActivityViewModel(
         }
         viewModelScope.launch {
             WCDelegate.walletEvents.collect {
-                wcEvent.postValue(it)
+                wcEvent.value = it
             }
         }
         viewModelScope.launch {
@@ -73,12 +73,18 @@ class MainActivityViewModel(
     }
 
     fun onWcEventHandled() {
-        wcEvent.postValue(null)
+        wcEvent.value = null
     }
 
-    fun reEmitPendingWcProposalIfNeeded() {
-        if (wcEvent.value == null && WCDelegate.sessionProposalEvent != null) {
-            wcEvent.postValue(HSDAppEvent.SessionProposal(WCDelegate.sessionProposalEvent!!))
+    fun reEmitPendingWcEventIfNeeded() {
+        if (wcEvent.value != null) return
+
+        WCDelegate.sessionRequestEvent?.let {
+            wcEvent.value = HSDAppEvent.SessionRequest(it)
+            return
+        }
+        WCDelegate.sessionProposalEvent?.let {
+            wcEvent.value = HSDAppEvent.SessionProposal(it)
         }
     }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/main/MainPage.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/main/MainPage.kt
@@ -243,7 +243,7 @@ private fun MainScreen(
 
     LifecycleEventEffect(event = Lifecycle.Event.ON_RESUME) {
         viewModel.onResume()
-        mainActivityViewModel.reEmitPendingWcProposalIfNeeded()
+        mainActivityViewModel.reEmitPendingWcEventIfNeeded()
     }
 }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/main/MainViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/main/MainViewModel.kt
@@ -319,7 +319,21 @@ class MainViewModel(
         var deeplinkPage: DeeplinkPage? = null
         val deeplinkString = deepLink.toString()
         val deeplinkScheme: String = Translator.getString(R.string.DeeplinkScheme)
+
+        // Cold-start fallback: while DAppManager isn't yet available, WC deeplinks are routed here
+        // (via MainActivity) and shown through the WC list. Once available, MainActivity pairs
+        // directly so the proposal dialog works from any screen (see Nav3.handleWalletConnectDeepLink).
+        val wcUri: String? = wcManager.getWalletConnectUri(deepLink)
+
         when {
+            wcUri != null -> {
+                wcSupportState = wcManager.getWalletConnectSupportState()
+                if (wcSupportState == WCManager.SupportState.Supported) {
+                    deeplinkPage = DeeplinkPage(WCListPage(WCListPage.Input(wcUri)))
+                    tab = MainNavigation.Settings
+                }
+            }
+
             deeplinkString.startsWith("$deeplinkScheme:") -> {
                 val uid = deepLink.getQueryParameter("uid")
                 when {
@@ -346,14 +360,6 @@ class MainViewModel(
                 }
 
                 tab = MainNavigation.Market
-            }
-
-            deeplinkString.startsWith("wc:") -> {
-                wcSupportState = wcManager.getWalletConnectSupportState()
-                if (wcSupportState == WCManager.SupportState.Supported) {
-                    deeplinkPage = DeeplinkPage(WCListPage(WCListPage.Input(deeplinkString)))
-                    tab = MainNavigation.Settings
-                }
             }
 
             deeplinkString.startsWith("https://unstoppable.money/referral") -> {
@@ -438,7 +444,16 @@ class MainViewModel(
 
     fun handleDeepLink(uri: Uri) {
         val deeplinkString = uri.toString()
-        if (deeplinkString.startsWith("unstoppable.money:") || deeplinkString.startsWith("tc:")) {
+
+        // A wrapped WalletConnect link (e.g. `unstoppable.money://wc?uri=wc:...`) shares the
+        // app's `unstoppable.money` scheme with TonConnect, so it would be swallowed by the
+        // TonConnect branch below and the WC pairing would never start. Exclude it here and
+        // let getNavigationDataForDeeplink() detect it (by `wc:` prefix or host == "wc").
+        val isWalletConnectDeeplink = deeplinkString.startsWith("wc:") || uri.host == "wc"
+
+        if (!isWalletConnectDeeplink &&
+            (deeplinkString.startsWith("unstoppable.money:") || deeplinkString.startsWith("tc:"))
+        ) {
             val returnParam = uri.getQueryParameter("ret")
             // when app is opened from camera app, it returns "none" as ret param
             // so we don't need closing app in this case

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/nav3/Nav3.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/nav3/Nav3.kt
@@ -38,10 +38,14 @@ import io.horizontalsystems.bankwallet.modules.main.MainActivityViewModel
 import io.horizontalsystems.bankwallet.modules.main.MainActivityViewModel.Factory
 import io.horizontalsystems.bankwallet.modules.main.MainScreenValidationError
 import io.horizontalsystems.bankwallet.modules.pin.ui.PinUnlock
+import io.horizontalsystems.bankwallet.modules.walletconnect.WCAccountTypeNotSupportedSheet
+import io.horizontalsystems.bankwallet.modules.walletconnect.WCErrorNoAccountSheet
+import io.horizontalsystems.bankwallet.modules.walletconnect.WCManager
 import io.horizontalsystems.bankwallet.modules.walletconnect.request.WCRequestSheet
 import io.horizontalsystems.bankwallet.modules.walletconnect.session.WCSessionSheet
 import io.horizontalsystems.core.helpers.HudHelper
 import io.horizontalsystems.core.hideKeyboard
+import io.horizontalsystems.dapp.core.DAppManager
 import io.horizontalsystems.dapp.core.HSDAppEvent
 
 @Composable
@@ -58,10 +62,17 @@ fun Nav3() {
     val hsNavigation = remember { HSNavigation(backStack) }
 
     HandleNavigateToMain(mainActivityViewModel, hsNavigation)
-    IntentEffect(mainActivityViewModel)
+    IntentEffect(mainActivityViewModel, hsNavigation)
     Validate(mainActivityViewModel)
     HandleWcEvent(mainActivityViewModel, hsNavigation)
     ToggleScreenshot(hsNavigation)
+
+    LaunchedEffect(isLocked) {
+        if (!isLocked) {
+            // Re-show any WC request/proposal that arrived while locked
+            mainActivityViewModel.reEmitPendingWcEventIfNeeded()
+        }
+    }
 
     val activity = LocalActivity.current
 
@@ -118,18 +129,60 @@ private fun HandleNavigateToMain(
 }
 
 @Composable
-private fun IntentEffect(viewModel: MainActivityViewModel) {
+private fun IntentEffect(viewModel: MainActivityViewModel, navController: HSNavigation) {
     val activity = LocalActivity.current
     LaunchedEffect(Unit) {
-        activity?.intent?.let { viewModel.setIntent(it) }
+        activity?.intent?.let {
+            if (!handleWalletConnectDeepLink(it, navController)) {
+                viewModel.setIntent(it)
+            }
+        }
     }
     DisposableEffect(activity) {
-        val consumer = Consumer<Intent> { viewModel.setIntent(it) }
+        val consumer = Consumer<Intent> {
+            if (!handleWalletConnectDeepLink(it, navController)) {
+                viewModel.setIntent(it)
+            }
+        }
         (activity as? ComponentActivity)?.addOnNewIntentListener(consumer)
         onDispose {
             (activity as? ComponentActivity)?.removeOnNewIntentListener(consumer)
         }
     }
+}
+
+// WalletConnect deeplinks are handled here, at the navigation root, so they work no matter which
+// inner screen is shown (the deeplink -> handleDeepLink flow in MainScreen only runs while
+// MainScreen is composed, so a `wc:` link received on e.g. the WC list page would otherwise be
+// ignored). Pairing here is enough — the connect proposal dialog is opened by HandleWcEvent
+// regardless of the current destination.
+//
+// Returns true if the intent was a WalletConnect deeplink and was handled here. When DAppManager
+// isn't available yet (e.g. cold start before the relay connects) it returns false so the intent
+// falls back to MainScreen's deeplink flow, which waits and routes through the WC list.
+private fun handleWalletConnectDeepLink(intent: Intent, navController: HSNavigation): Boolean {
+    val uri = intent.data ?: return false
+    val wcUri = App.wcManager.getWalletConnectUri(uri) ?: return false
+    if (!DAppManager.isAvailable) return false
+
+    when (val supportState = App.wcManager.getWalletConnectSupportState()) {
+        WCManager.SupportState.Supported -> {
+            DAppManager.pair(wcUri.trim())
+        }
+
+        WCManager.SupportState.NotSupportedDueToNoActiveAccount -> {
+            navController.slideFromBottom(WCErrorNoAccountSheet)
+        }
+
+        is WCManager.SupportState.NotSupported -> {
+            navController.slideFromBottom(
+                WCAccountTypeNotSupportedSheet(
+                    WCAccountTypeNotSupportedSheet.Input(supportState.accountTypeDescription)
+                )
+            )
+        }
+    }
+    return true
 }
 
 @Composable
@@ -162,9 +215,33 @@ private fun HandleWcEvent(
     val wcEvent by viewModel.wcEvent.observeAsState()
     LaunchedEffect(wcEvent) {
         val event = wcEvent ?: return@LaunchedEffect
+
+        // Don't open WC bottom sheets while the app is locked. The event is retained in
+        // WCDelegate and re-emitted via reEmitPendingWcEventIfNeeded() once the user unlocks,
+        // so the request/proposal isn't lost behind the pin screen.
+        val deferWhileLocked = App.pinComponent.isLocked &&
+                (event is HSDAppEvent.SessionRequest || event is HSDAppEvent.SessionProposal)
+        if (deferWhileLocked) {
+            viewModel.onWcEventHandled()
+            return@LaunchedEffect
+        }
+
         when (event) {
-            is HSDAppEvent.SessionRequest -> navController.slideFromBottom(WCRequestSheet)
-            is HSDAppEvent.SessionProposal -> navController.slideFromBottom(WCSessionSheet(null))
+            is HSDAppEvent.SessionRequest -> {
+                // reEmitPendingWcEventIfNeeded() can fire more than once per foreground
+                // transition (from both the unlock effect and MainScreen's ON_RESUME), so skip
+                // if the request sheet is already shown to avoid stacking duplicates.
+                if (navController.lastOrNull() !is WCRequestSheet) {
+                    navController.slideFromBottom(WCRequestSheet)
+                }
+            }
+
+            is HSDAppEvent.SessionProposal -> {
+                if (navController.lastOrNull() !is WCSessionSheet) {
+                    navController.slideFromBottom(WCSessionSheet(null))
+                }
+            }
+
             is HSDAppEvent.Error -> HudHelper.showErrorMessage(view, event.throwable.message ?: "Error")
             is HSDAppEvent.SessionSettled -> HudHelper.showSuccessMessage(view, hudTextConnected)
             else -> {}

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/WCDelegate.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/WCDelegate.kt
@@ -142,6 +142,14 @@ object WCDelegate : DAppServiceCallback {
         )
     }
 
+    // The user dismissed the request UI (tapped outside / back) without responding. The request
+    // stays in DAppManager's pending list (still reachable from the WC list), but clear the
+    // "active request" pointer so reEmitPendingWcEventIfNeeded() doesn't auto-reopen it on the
+    // next resume (removing the bottom sheet overlay re-resumes the screen underneath).
+    fun discardActiveSessionRequest() {
+        sessionRequestEvent = null
+    }
+
     fun rejectRequest(
         topic: String,
         requestId: Long,

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/WCManager.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/WCManager.kt
@@ -1,5 +1,6 @@
 package io.horizontalsystems.bankwallet.modules.walletconnect
 
+import android.net.Uri
 import io.horizontalsystems.bankwallet.core.App
 import io.horizontalsystems.bankwallet.core.IAccountManager
 import io.horizontalsystems.bankwallet.entities.Account
@@ -50,6 +51,30 @@ class WCManager(
         val handler = handlersMap[chainNamespace] ?: return null
 
         return handler.getAction(request, chainInternalId)
+    }
+
+    // WalletConnect can arrive either as a raw `wc:` URI (QR scan / clipboard) or wrapped in the
+    // app's own scheme by the dApp / Web3Modal, e.g. `unstoppable.money://wc?uri=<URL-encoded wc:>`.
+    // Returns the embedded `wc:` pairing URI, or null if the deeplink isn't a WalletConnect one.
+    fun getWalletConnectUri(deepLink: Uri): String? {
+        val deeplinkString = deepLink.toString()
+        return when {
+            deeplinkString.startsWith("wc:") -> deeplinkString
+            deepLink.host == "wc" -> {
+                val encodedQuery = deepLink.encodedQuery
+                val marker = "uri="
+                val start = encodedQuery?.indexOf(marker) ?: -1
+                if (start >= 0) {
+                    Uri.decode(encodedQuery!!.substring(start + marker.length))
+                        .trim()
+                        .removePrefix("@")
+                } else {
+                    null
+                }
+            }
+
+            else -> null
+        }
     }
 
     fun getWalletConnectSupportState(): SupportState {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/WCManager.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/WCManager.kt
@@ -61,16 +61,11 @@ class WCManager(
         return when {
             deeplinkString.startsWith("wc:") -> deeplinkString
             deepLink.host == "wc" -> {
-                val encodedQuery = deepLink.encodedQuery
-                val marker = "uri="
-                val start = encodedQuery?.indexOf(marker) ?: -1
-                if (start >= 0) {
-                    Uri.decode(encodedQuery!!.substring(start + marker.length))
-                        .trim()
-                        .removePrefix("@")
-                } else {
-                    null
-                }
+                // getQueryParameter isolates and percent-decodes just the `uri` value, so any
+                // additional params (e.g. ?uri=<...>&foo=bar) don't leak into the pairing URI.
+                deepLink.getQueryParameter("uri")
+                    ?.trim()
+                    ?.removePrefix("@")
             }
 
             else -> null

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/list/WalletConnectListViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/list/WalletConnectListViewModel.kt
@@ -39,7 +39,11 @@ class WalletConnectListViewModel(
     private var _refreshFlow: MutableSharedFlow<Unit> =
         MutableSharedFlow(replay = 0, extraBufferCapacity = 1, BufferOverflow.DROP_OLDEST)
     private var refreshFlow: SharedFlow<Unit> = _refreshFlow.asSharedFlow()
-    private val uiStateFlow = merge(WCDelegate.walletEvents, refreshFlow).map {
+    private val uiStateFlow = merge(
+        WCDelegate.walletEvents,
+        refreshFlow,
+        wcSessionManager.sessionsFlow
+    ).map {
         getUiState()
     }
 
@@ -122,7 +126,7 @@ class WalletConnectListViewModel(
 
     private fun getUiState(): WalletConnectListUiState {
         return WalletConnectListUiState(
-            sessionViewItems = getSessions(wcSessionManager.sessions),
+            sessionViewItems = getSessions(wcSessionManager.sessionsFlow.value),
             pairingsNumber = pairingsNumber,
         )
     }
@@ -150,7 +154,7 @@ class WalletConnectListViewModel(
 
     private fun syncPendingRequestsCountMap() {
         viewModelScope.launch {
-            wcSessionManager.sessions.forEach { session ->
+            wcSessionManager.sessionsFlow.value.forEach { session ->
                 val requests = DAppManager.getPendingRequests(session.topic)
                 pendingRequestCountMap[session.topic] = requests.size
                 pendingRequests = getPendingRequestViewItems(session.topic)

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/request/WCRequestEvmViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/request/WCRequestEvmViewModel.kt
@@ -149,6 +149,7 @@ class WCRequestEvmViewModel(
                     else -> throw Exception("Unsupported Chain")
                 }
 
+                WCDelegate.discardActiveSessionRequest()
                 WCDelegate.respondPendingRequest(
                     sessionRequest.requestId,
                     sessionRequest.topic,
@@ -168,6 +169,7 @@ class WCRequestEvmViewModel(
 
     fun reject() {
         val sessionRequest = sessionRequestUi as? SessionRequestUI.Content ?: return
+        WCDelegate.discardActiveSessionRequest()
         WCDelegate.rejectRequest(sessionRequest.topic, sessionRequest.requestId)
         clearSessionRequest()
     }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/request/WCRequestEvmViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/request/WCRequestEvmViewModel.kt
@@ -166,24 +166,10 @@ class WCRequestEvmViewModel(
         }
     }
 
-    suspend fun reject() {
-        return suspendCoroutine { continuation ->
-            val sessionRequest = sessionRequestUi as? SessionRequestUI.Content
-            if (sessionRequest != null) {
-                WCDelegate.rejectRequest(
-                    sessionRequest.topic,
-                    sessionRequest.requestId,
-                    onSuccessResult = {
-                        clearSessionRequest()
-                        continuation.resume(Unit)
-                    },
-                    onErrorResult = {
-                        clearSessionRequest()
-                        continuation.resumeWithException(it)
-                    }
-                )
-            }
-        }
+    fun reject() {
+        val sessionRequest = sessionRequestUi as? SessionRequestUI.Content ?: return
+        WCDelegate.rejectRequest(sessionRequest.topic, sessionRequest.requestId)
+        clearSessionRequest()
     }
 
     class Factory : ViewModelProvider.Factory {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/request/WCRequestSheet.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/request/WCRequestSheet.kt
@@ -62,7 +62,9 @@ import io.horizontalsystems.bankwallet.uiv3.components.controls.HSButton
 import io.horizontalsystems.bankwallet.uiv3.components.info.TextBlock
 import io.horizontalsystems.core.helpers.HudHelper
 import io.horizontalsystems.marketkit.models.BlockchainType
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 
 private val logger = AppLogger("wallet-connect request")
@@ -163,9 +165,15 @@ fun WcRequestError(
     onDismiss: () -> Unit
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val scope = rememberCoroutineScope()
     val dismiss = {
+        // Discard synchronously, then animate the sheet out before popping (see WCNewSignRequestScreen).
         WCDelegate.discardActiveSessionRequest()
-        onDismiss()
+        scope.launch {
+            sheetState.hide()
+            onDismiss()
+        }
+        Unit
     }
     BottomSheetContent(
         onDismissRequest = dismiss,
@@ -243,8 +251,10 @@ fun WCNewSignRequestScreen(
 
     BottomSheetContent(
         onDismissRequest = {
+            // Discard synchronously (avoids the reEmit race), then animate out before popping —
+            // same reason as hideAndPop above; popping outright can leave the sheet card on screen.
             WCDelegate.discardActiveSessionRequest()
-            navController.removeLastOrNull()
+            hideAndPop()
         },
         sheetState = sheetState
     ) { snackbarActions ->
@@ -332,7 +342,9 @@ fun WCNewSignRequestScreen(
                         logger.info("allow request")
                         scope.launch {
                             try {
-                                onAllow()
+                                // Offload the signing (CPU-bound crypto) off the Main thread, but
+                                // keep hide()/removeLastOrNull() on Main — they mutate UI state.
+                                withContext(Dispatchers.Default) { onAllow() }
                                 sheetState.hide()
                                 navController.removeLastOrNull()
                             } catch (e: Throwable) {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/request/WCRequestSheet.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/request/WCRequestSheet.kt
@@ -37,6 +37,7 @@ import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.core.AppLogger
 import io.horizontalsystems.bankwallet.core.isEvm
 import io.horizontalsystems.bankwallet.modules.nav3.HSNavigation
+import io.horizontalsystems.bankwallet.modules.walletconnect.WCDelegate
 import io.horizontalsystems.bankwallet.modules.walletconnect.request.sendtransaction.WCEthereumTransaction
 import io.horizontalsystems.bankwallet.modules.walletconnect.request.sendtransaction.WCSendEthRequestScreen
 import io.horizontalsystems.bankwallet.modules.walletconnect.request.signtransaction.WCSignEthereumTransactionRequestScreen
@@ -93,8 +94,6 @@ data object WCRequestSheet : HSBottomSheet() {
 fun WcRequestEvm(navController: HSNavigation) {
     val wcRequestEvmViewModel =
         viewModel<WCRequestEvmViewModel>(factory = WCRequestEvmViewModel.Factory())
-    val composableScope = rememberCoroutineScope()
-    val view = LocalView.current
 
     when (val sessionRequestUI = wcRequestEvmViewModel.sessionRequestUi) {
         is SessionRequestUI.Content -> {
@@ -142,28 +141,8 @@ fun WcRequestEvm(navController: HSNavigation) {
                 WCNewSignRequestScreen(
                     sessionRequestUI,
                     navController,
-                    onAllow = {
-                        composableScope.launch {
-                            try {
-                                wcRequestEvmViewModel.allow()
-                                navController.removeLastOrNull()
-                            } catch (e: Throwable) {
-                                showError(view, e)
-                            }
-                        }
-                        logger.info("allow request")
-                    },
-                    onDecline = {
-                        composableScope.launch {
-                            try {
-                                wcRequestEvmViewModel.reject()
-                                navController.removeLastOrNull()
-                            } catch (e: Throwable) {
-                                showError(view, e)
-                            }
-                        }
-                        logger.info("decline request")
-                    }
+                    onAllow = { wcRequestEvmViewModel.allow() },
+                    onDecline = { wcRequestEvmViewModel.reject() }
                 )
             }
         }
@@ -184,8 +163,12 @@ fun WcRequestError(
     onDismiss: () -> Unit
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val dismiss = {
+        WCDelegate.discardActiveSessionRequest()
+        onDismiss()
+    }
     BottomSheetContent(
-        onDismissRequest = onDismiss,
+        onDismissRequest = dismiss,
         sheetState = sheetState,
         buttons = {
             HSButton(
@@ -193,7 +176,7 @@ fun WcRequestError(
                 variant = ButtonVariant.Secondary,
                 size = ButtonSize.Medium,
                 modifier = Modifier.fillMaxWidth(),
-                onClick = onDismiss
+                onClick = dismiss
             )
         },
     ) {
@@ -238,16 +221,31 @@ fun WcRequestError(
 fun WCNewSignRequestScreen(
     sessionRequestUI: SessionRequestUI.Content,
     navController: HSNavigation,
-    onAllow: () -> Unit,
+    onAllow: suspend () -> Unit,
     onDecline: () -> Unit
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val scope = rememberCoroutineScope()
+    val view = LocalView.current
     val messageBottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var messageBottomSheet by remember { mutableStateOf<String?>(null) }
 
+    // Animate the bottom sheet out before popping. Removing the entry directly disposes the
+    // ModalBottomSheet's window abruptly, which intermittently leaves the sheet content on screen
+    // (the dim is removed but the sheet card stays).
+    val hideAndPop = {
+        scope.launch {
+            sheetState.hide()
+            navController.removeLastOrNull()
+        }
+        Unit
+    }
+
     BottomSheetContent(
-        onDismissRequest = navController::removeLastOrNull,
+        onDismissRequest = {
+            WCDelegate.discardActiveSessionRequest()
+            navController.removeLastOrNull()
+        },
         sheetState = sheetState
     ) { snackbarActions ->
         Column(
@@ -320,13 +318,28 @@ fun WCNewSignRequestScreen(
                     variant = ButtonVariant.Secondary,
                     size = ButtonSize.Medium,
                     modifier = Modifier.weight(1f),
-                    onClick = onDecline
+                    onClick = {
+                        logger.info("decline request")
+                        onDecline()
+                        hideAndPop()
+                    }
                 )
                 HSButton(
                     title = stringResource(R.string.Button_Confirm),
                     variant = ButtonVariant.Primary,
                     modifier = Modifier.weight(1f),
-                    onClick = onAllow
+                    onClick = {
+                        logger.info("allow request")
+                        scope.launch {
+                            try {
+                                onAllow()
+                                sheetState.hide()
+                                navController.removeLastOrNull()
+                            } catch (e: Throwable) {
+                                showError(view, e)
+                            }
+                        }
+                    }
                 )
             }
         }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/request/WcRequestScreen.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/request/WcRequestScreen.kt
@@ -27,6 +27,7 @@ import coil.compose.rememberAsyncImagePainter
 import io.horizontalsystems.bankwallet.R
 import io.horizontalsystems.bankwallet.modules.evmfee.FeeSettingsInfoSheet
 import io.horizontalsystems.bankwallet.modules.nav3.HSNavigation
+import io.horizontalsystems.bankwallet.modules.walletconnect.WCDelegate
 import io.horizontalsystems.bankwallet.modules.walletconnect.request.sendtransaction.DataBlock
 import io.horizontalsystems.bankwallet.ui.compose.ComposeAppTheme
 import io.horizontalsystems.bankwallet.ui.compose.components.VSpacer
@@ -64,7 +65,10 @@ fun WcRequestScreen(
     val feeInfoText = stringResource(id = R.string.FeeSettings_NetworkFee_Info)
 
     BottomSheetContent(
-        onDismissRequest = navController::removeLastOrNull,
+        onDismissRequest = {
+            WCDelegate.discardActiveSessionRequest()
+            navController.removeLastOrNull()
+        },
         sheetState = sheetState
     ) { snackbarActions ->
         Column(

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/request/sendtransaction/WCSendEthScreen.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/request/sendtransaction/WCSendEthScreen.kt
@@ -33,6 +33,7 @@ import io.horizontalsystems.bankwallet.modules.evmfee.FeeSettingsInfoSheet
 import io.horizontalsystems.bankwallet.modules.nav3.HSNavigation
 import io.horizontalsystems.bankwallet.modules.sendevmtransaction.SectionViewItem
 import io.horizontalsystems.bankwallet.modules.sendevmtransaction.ViewItem
+import io.horizontalsystems.bankwallet.modules.walletconnect.WCDelegate
 import io.horizontalsystems.bankwallet.modules.walletconnect.request.SessionRequestUI
 import io.horizontalsystems.bankwallet.modules.walletconnect.session.TitleValueCell
 import io.horizontalsystems.bankwallet.ui.compose.ComposeAppTheme
@@ -81,7 +82,10 @@ fun WCSendEthRequestScreen(
     val feeInfoText = stringResource(id = R.string.FeeSettings_NetworkFee_Info)
 
     BottomSheetContent(
-        onDismissRequest = navController::removeLastOrNull,
+        onDismissRequest = {
+            WCDelegate.discardActiveSessionRequest()
+            navController.removeLastOrNull()
+        },
         sheetState = sheetState,
     ) { snackbarActions ->
         Column(

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/request/signtransaction/WCSignEthereumTransactionRequestScreen.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/request/signtransaction/WCSignEthereumTransactionRequestScreen.kt
@@ -33,6 +33,7 @@ import io.horizontalsystems.bankwallet.modules.confirm.ConfirmTransactionScreen
 import io.horizontalsystems.bankwallet.modules.evmfee.FeeSettingsInfoSheet
 import io.horizontalsystems.bankwallet.modules.nav3.HSNavigation
 import io.horizontalsystems.bankwallet.modules.sendevmtransaction.SendEvmTransactionView
+import io.horizontalsystems.bankwallet.modules.walletconnect.WCDelegate
 import io.horizontalsystems.bankwallet.modules.walletconnect.request.SessionRequestUI
 import io.horizontalsystems.bankwallet.modules.walletconnect.request.sendtransaction.DataBlock
 import io.horizontalsystems.bankwallet.modules.walletconnect.request.sendtransaction.FeeCell
@@ -82,7 +83,10 @@ fun WCSignEthereumTransactionRequestScreen(
     val doneMessage = stringResource(R.string.Hud_Text_Done)
 
     BottomSheetContent(
-        onDismissRequest = navController::removeLastOrNull,
+        onDismissRequest = {
+            WCDelegate.discardActiveSessionRequest()
+            navController.removeLastOrNull()
+        },
         sheetState = sheetState,
     ) { snackbarActions ->
         Column(

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/session/WCSessionSheet.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/session/WCSessionSheet.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -64,6 +65,7 @@ import io.horizontalsystems.bankwallet.uiv3.components.controls.HSButton
 import io.horizontalsystems.bankwallet.uiv3.components.info.TextBlock
 import io.horizontalsystems.bankwallet.uiv3.components.section.SectionHeader
 import io.horizontalsystems.marketkit.models.BlockchainType
+import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -85,8 +87,18 @@ fun WCSessionScreen(
     viewModel: WCSessionViewModel,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val scope = rememberCoroutineScope()
     val uiState = viewModel.uiState
     val buttonsStates = uiState.buttonStates
+
+    // Animate the sheet out before popping; removing the entry outright can leave the card on screen.
+    val hideAndPop = {
+        scope.launch {
+            sheetState.hide()
+            navController.removeLastOrNull()
+        }
+        Unit
+    }
 
     val connectionTitleRes =
         if (uiState.connected) R.string.WalletConnect_ConnectedTo else R.string.WalletConnect_ConnectTo
@@ -99,7 +111,11 @@ fun WCSessionScreen(
     }
 
     BottomSheetContent(
-        onDismissRequest = navController::removeLastOrNull,
+        onDismissRequest = {
+            // Reject the proposal on dismiss so the dApp isn't left waiting, then animate out.
+            viewModel.rejectProposal()
+            hideAndPop()
+        },
         sheetState = sheetState,
     ) { snackbarActions ->
         uiState.showError?.let {

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/session/WCSessionViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/walletconnect/session/WCSessionViewModel.kt
@@ -331,6 +331,13 @@ class WCSessionViewModel(
     fun rejectProposal() {
         val proposal = proposal ?: return
 
+        // Clear the pending proposal pointer synchronously so reEmitPendingWcEventIfNeeded() can't
+        // re-open this proposal when the sheet's removal re-resumes the screen underneath. reject()
+        // below only nulls it inside its async network callback, which races the sheet closing.
+        // Done after the guard above so session-only screens (no local proposal) don't clobber an
+        // unrelated pending proposal event.
+        WCDelegate.sessionProposalEvent = null
+
         if (!connectivityManager.isConnected) {
             showError = Translator.getString(R.string.Hud_Text_NoInternet)
             emitState()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a way to discard the currently active WalletConnect session request when dismissing request UI.

* **Bug Fixes**
  * Improved WalletConnect deep link routing during cold start and reduced conflicts with other deep link schemes.
  * Re-emit pending WalletConnect requests/proposals on resume/unlock, with lock-aware handling.
  * Prevent duplicate WalletConnect request/proposal bottom sheets by checking current navigation state.
  * Enhanced WalletConnect cleanup: active requests are discarded and proposals are rejected correctly when sheets are dismissed (with safer timing).
  * Updated WalletConnect list UI to reflect live sessions and pending counts from the sessions stream.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->