### PR TITLE
Show warning for public Memos during send

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/zcash/ZcashAdapter.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/adapters/zcash/ZcashAdapter.kt
@@ -261,7 +261,7 @@ class ZcashAdapter(
             is AddressType.Invalid -> throw ZcashError.InvalidAddress
             is AddressType.Transparent -> ZCashAddressType.Transparent
             is AddressType.Shielded -> ZCashAddressType.Shielded
-            is AddressType.Tex -> ZCashAddressType.Shielded
+            is AddressType.Tex -> ZCashAddressType.Transparent
             AddressType.Unified -> ZCashAddressType.Unified
         }
     }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/memo/HSMemoInput.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/memo/HSMemoInput.kt
@@ -1,31 +1,65 @@
 package io.horizontalsystems.bankwallet.modules.memo
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import io.horizontalsystems.bankwallet.R
+import io.horizontalsystems.bankwallet.entities.DataState
 import io.horizontalsystems.bankwallet.ui.compose.ComposeAppTheme
 import io.horizontalsystems.bankwallet.ui.compose.components.FormsInput
+import io.horizontalsystems.bankwallet.ui.compose.components.FormsInputStateWarning
+import io.horizontalsystems.bankwallet.ui.compose.components.caption_grey
+
+/**
+ * Describes where a memo ends up once the transaction is sent, so the UI can
+ * communicate the privacy implications consistently across blockchains.
+ *
+ * - [Public]: written on-chain in clear text (e.g. Bitcoin OP_RETURN, Stellar, TON) — anyone can read it.
+ * - [Encrypted]: written on-chain but encrypted, readable only by sender and recipient (e.g. Zcash shielded, Monero, Zano).
+ */
+enum class MemoVisibility {
+    Public,
+    Encrypted
+}
 
 @Composable
 fun HSMemoInput(
     maxLength: Int,
     memo: String? = null,
+    visibility: MemoVisibility = MemoVisibility.Public,
     onValueChange: (String) -> Unit
 ) {
-    FormsInput(
-        modifier = Modifier.padding(horizontal = 16.dp),
-        hint = stringResource(R.string.Send_DialogMemoHint),
-        initial = memo,
-        hintColor = ComposeAppTheme.colors.andy,
-        hintStyle = ComposeAppTheme.typography.bodyItalic,
-        textColor = ComposeAppTheme.colors.leah,
-        textStyle = ComposeAppTheme.typography.bodyItalic,
-        pasteEnabled = false,
-        singleLine = true,
-        maxLength = maxLength,
-        onValueChange = onValueChange
-    )
+    val state = when (visibility) {
+        MemoVisibility.Public -> DataState.Error(
+            FormsInputStateWarning(stringResource(R.string.Send_Memo_PublicWarning))
+        )
+
+        MemoVisibility.Encrypted -> null
+    }
+
+    Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+        FormsInput(
+            hint = stringResource(R.string.Send_DialogMemoHint),
+            initial = memo,
+            hintColor = ComposeAppTheme.colors.andy,
+            hintStyle = ComposeAppTheme.typography.bodyItalic,
+            textColor = ComposeAppTheme.colors.leah,
+            textStyle = ComposeAppTheme.typography.bodyItalic,
+            pasteEnabled = false,
+            singleLine = true,
+            maxLength = maxLength,
+            state = state,
+            onValueChange = onValueChange
+        )
+
+        if (visibility == MemoVisibility.Encrypted) {
+            caption_grey(
+                modifier = Modifier.padding(start = 16.dp, top = 8.dp, end = 16.dp),
+                text = stringResource(R.string.Send_Memo_EncryptedInfo)
+            )
+        }
+    }
 }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/memo/HSMemoInput.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/memo/HSMemoInput.kt
@@ -18,11 +18,14 @@ import io.horizontalsystems.bankwallet.ui.compose.components.caption_grey
  * communicate the privacy implications consistently across blockchains.
  *
  * - [Public]: written on-chain in clear text (e.g. Bitcoin OP_RETURN, Stellar, TON) — anyone can read it.
- * - [Encrypted]: written on-chain but encrypted, readable only by sender and recipient (e.g. Zcash shielded, Monero, Zano).
+ * - [Encrypted]: written on-chain but encrypted, readable only by sender and recipient (e.g. Zcash shielded).
+ * - [Offchain]: kept only on this device, never broadcast to the blockchain, and not recovered on wallet
+ *   restore (e.g. Monero, Zano).
  */
 enum class MemoVisibility {
     Public,
-    Encrypted
+    Encrypted,
+    Offchain
 }
 
 @Composable
@@ -37,7 +40,14 @@ fun HSMemoInput(
             FormsInputStateWarning(stringResource(R.string.Send_Memo_PublicWarning))
         )
 
-        MemoVisibility.Encrypted -> null
+        MemoVisibility.Encrypted,
+        MemoVisibility.Offchain -> null
+    }
+
+    val infoText = when (visibility) {
+        MemoVisibility.Public -> null
+        MemoVisibility.Encrypted -> stringResource(R.string.Send_Memo_EncryptedInfo)
+        MemoVisibility.Offchain -> stringResource(R.string.Send_Memo_OffchainInfo)
     }
 
     Column(modifier = Modifier.padding(horizontal = 16.dp)) {
@@ -55,10 +65,10 @@ fun HSMemoInput(
             onValueChange = onValueChange
         )
 
-        if (visibility == MemoVisibility.Encrypted) {
+        infoText?.let {
             caption_grey(
                 modifier = Modifier.padding(start = 16.dp, top = 8.dp, end = 16.dp),
-                text = stringResource(R.string.Send_Memo_EncryptedInfo)
+                text = it
             )
         }
     }

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/bitcoin/SendBitcoinScreen.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/bitcoin/SendBitcoinScreen.kt
@@ -34,6 +34,7 @@ import io.horizontalsystems.bankwallet.modules.amount.HSAmountInput
 import io.horizontalsystems.bankwallet.modules.availablebalance.AvailableBalance
 import io.horizontalsystems.bankwallet.modules.fee.HSFeeRaw
 import io.horizontalsystems.bankwallet.modules.memo.HSMemoInput
+import io.horizontalsystems.bankwallet.modules.memo.MemoVisibility
 import io.horizontalsystems.bankwallet.modules.nav3.HSNavigation
 import io.horizontalsystems.bankwallet.modules.nav3.HSPage
 import io.horizontalsystems.bankwallet.modules.send.AddressRiskySheet
@@ -190,7 +191,7 @@ fun SendBitcoinScreen(
                 )
 
                 VSpacer(16.dp)
-                HSMemoInput(maxLength = 120) {
+                HSMemoInput(maxLength = 120, visibility = MemoVisibility.Public) {
                     viewModel.onEnterMemo(it)
                 }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/monero/SendMoneroScreen.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/monero/SendMoneroScreen.kt
@@ -21,6 +21,7 @@ import io.horizontalsystems.bankwallet.modules.amount.HSAmountInput
 import io.horizontalsystems.bankwallet.modules.availablebalance.AvailableBalance
 import io.horizontalsystems.bankwallet.modules.fee.HSFee
 import io.horizontalsystems.bankwallet.modules.memo.HSMemoInput
+import io.horizontalsystems.bankwallet.modules.memo.MemoVisibility
 import io.horizontalsystems.bankwallet.modules.nav3.HSNavigation
 import io.horizontalsystems.bankwallet.modules.nav3.HSPage
 import io.horizontalsystems.bankwallet.modules.send.AddressRiskySheet
@@ -113,7 +114,7 @@ fun SendMoneroScreen(
             )
 
             VSpacer(16.dp)
-            HSMemoInput(maxLength = 120, memo) {
+            HSMemoInput(maxLength = 120, memo = memo, visibility = MemoVisibility.Encrypted) {
                 viewModel.onEnterMemo(it)
             }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/monero/SendMoneroScreen.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/monero/SendMoneroScreen.kt
@@ -114,7 +114,7 @@ fun SendMoneroScreen(
             )
 
             VSpacer(16.dp)
-            HSMemoInput(maxLength = 120, memo = memo, visibility = MemoVisibility.Encrypted) {
+            HSMemoInput(maxLength = 120, memo = memo, visibility = MemoVisibility.Offchain) {
                 viewModel.onEnterMemo(it)
             }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/stellar/SendStellarScreen.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/stellar/SendStellarScreen.kt
@@ -21,6 +21,7 @@ import io.horizontalsystems.bankwallet.modules.amount.HSAmountInput
 import io.horizontalsystems.bankwallet.modules.availablebalance.AvailableBalance
 import io.horizontalsystems.bankwallet.modules.fee.HSFee
 import io.horizontalsystems.bankwallet.modules.memo.HSMemoInput
+import io.horizontalsystems.bankwallet.modules.memo.MemoVisibility
 import io.horizontalsystems.bankwallet.modules.nav3.HSNavigation
 import io.horizontalsystems.bankwallet.modules.nav3.HSPage
 import io.horizontalsystems.bankwallet.modules.send.AddressRiskySheet
@@ -111,7 +112,7 @@ fun SendStellarScreen(
             )
 
             VSpacer(16.dp)
-            HSMemoInput(maxLength = 120) {
+            HSMemoInput(maxLength = 120, visibility = MemoVisibility.Public) {
                 viewModel.onEnterMemo(it)
             }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/ton/SendTonScreen.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/ton/SendTonScreen.kt
@@ -21,6 +21,7 @@ import io.horizontalsystems.bankwallet.modules.amount.HSAmountInput
 import io.horizontalsystems.bankwallet.modules.availablebalance.AvailableBalance
 import io.horizontalsystems.bankwallet.modules.fee.HSFee
 import io.horizontalsystems.bankwallet.modules.memo.HSMemoInput
+import io.horizontalsystems.bankwallet.modules.memo.MemoVisibility
 import io.horizontalsystems.bankwallet.modules.nav3.HSNavigation
 import io.horizontalsystems.bankwallet.modules.nav3.HSPage
 import io.horizontalsystems.bankwallet.modules.send.AddressRiskySheet
@@ -112,7 +113,7 @@ fun SendTonScreen(
             )
 
             VSpacer(16.dp)
-            HSMemoInput(maxLength = 120) {
+            HSMemoInput(maxLength = 120, visibility = MemoVisibility.Public) {
                 viewModel.onEnterMemo(it)
             }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/zano/SendZanoScreen.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/zano/SendZanoScreen.kt
@@ -21,6 +21,7 @@ import io.horizontalsystems.bankwallet.modules.amount.HSAmountInput
 import io.horizontalsystems.bankwallet.modules.availablebalance.AvailableBalance
 import io.horizontalsystems.bankwallet.modules.fee.HSFee
 import io.horizontalsystems.bankwallet.modules.memo.HSMemoInput
+import io.horizontalsystems.bankwallet.modules.memo.MemoVisibility
 import io.horizontalsystems.bankwallet.modules.nav3.HSNavigation
 import io.horizontalsystems.bankwallet.modules.nav3.HSPage
 import io.horizontalsystems.bankwallet.modules.send.AddressRiskySheet
@@ -112,7 +113,7 @@ fun SendZanoScreen(
             )
 
             VSpacer(16.dp)
-            HSMemoInput(maxLength = 120, memo) {
+            HSMemoInput(maxLength = 120, memo = memo, visibility = MemoVisibility.Encrypted) {
                 viewModel.onEnterMemo(it)
             }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/zano/SendZanoScreen.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/zano/SendZanoScreen.kt
@@ -113,7 +113,7 @@ fun SendZanoScreen(
             )
 
             VSpacer(16.dp)
-            HSMemoInput(maxLength = 120, memo = memo, visibility = MemoVisibility.Encrypted) {
+            HSMemoInput(maxLength = 120, memo = memo, visibility = MemoVisibility.Offchain) {
                 viewModel.onEnterMemo(it)
             }
 

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/zcash/SendZCashMemoService.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/zcash/SendZCashMemoService.kt
@@ -44,7 +44,11 @@ class SendZCashMemoService {
     }
 
     private fun refreshMemoIsAllowed() {
-        memoIsAllowed = addressType == ZcashAdapter.ZCashAddressType.Shielded
+        // Encrypted memos are supported by any destination that has a shielded receiver:
+        // legacy Sapling addresses and modern unified (u1...) addresses. Transparent
+        // (including Tex) destinations have no memo field.
+        memoIsAllowed = addressType == ZcashAdapter.ZCashAddressType.Shielded ||
+                addressType == ZcashAdapter.ZCashAddressType.Unified
     }
 
     data class State(

--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/zcash/SendZCashScreen.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/zcash/SendZCashScreen.kt
@@ -20,6 +20,7 @@ import io.horizontalsystems.bankwallet.modules.amount.AmountInputModeViewModel
 import io.horizontalsystems.bankwallet.modules.amount.HSAmountInput
 import io.horizontalsystems.bankwallet.modules.availablebalance.AvailableBalance
 import io.horizontalsystems.bankwallet.modules.memo.HSMemoInput
+import io.horizontalsystems.bankwallet.modules.memo.MemoVisibility
 import io.horizontalsystems.bankwallet.modules.nav3.HSNavigation
 import io.horizontalsystems.bankwallet.modules.nav3.HSPage
 import io.horizontalsystems.bankwallet.modules.send.AddressRiskySheet
@@ -111,7 +112,8 @@ fun SendZCashScreen(
             if (memoIsAllowed) {
                 VSpacer(16.dp)
                 HSMemoInput(
-                    maxLength = viewModel.memoMaxLength
+                    maxLength = viewModel.memoMaxLength,
+                    visibility = MemoVisibility.Encrypted
                 ) {
                     viewModel.onEnterMemo(it)
                 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1789,4 +1789,5 @@
     <string name="MoneroNodeSettings_Latency">%d ms</string>
     <string name="Send_Memo_PublicWarning">Diese Notiz wird öffentlich auf der Blockchain gespeichert.</string>
     <string name="Send_Memo_EncryptedInfo">Diese Notiz ist verschlüsselt und nur für Sie und den Empfänger sichtbar.</string>
+    <string name="Send_Memo_OffchainInfo">Nur auf diesem Gerät gespeichert — nicht in der Blockchain.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1787,4 +1787,6 @@
     <string name="MoneroNodeSettings_AutoSelectDescription">Verwendet automatisch den schnellsten Node</string>
     <string name="MoneroNodeSettings_Unreachable">Nicht erreichbar</string>
     <string name="MoneroNodeSettings_Latency">%d ms</string>
+    <string name="Send_Memo_PublicWarning">Diese Notiz wird öffentlich auf der Blockchain gespeichert.</string>
+    <string name="Send_Memo_EncryptedInfo">Diese Notiz ist verschlüsselt und nur für Sie und den Empfänger sichtbar.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1778,4 +1778,6 @@
     <string name="MoneroNodeSettings_AutoSelectDescription">Utilizar automáticamente el nodo más rápido</string>
     <string name="MoneroNodeSettings_Unreachable">Inaccesible</string>
     <string name="MoneroNodeSettings_Latency">%d ms</string>
+    <string name="Send_Memo_PublicWarning">Este memo será público en la blockchain.</string>
+    <string name="Send_Memo_EncryptedInfo">Este memo está cifrado y solo es visible para usted y el destinatario.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1780,4 +1780,5 @@
     <string name="MoneroNodeSettings_Latency">%d ms</string>
     <string name="Send_Memo_PublicWarning">Este memo será público en la blockchain.</string>
     <string name="Send_Memo_EncryptedInfo">Este memo está cifrado y solo es visible para usted y el destinatario.</string>
+    <string name="Send_Memo_OffchainInfo">Almacenado solo en este dispositivo — no en la cadena de bloques.</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -710,4 +710,6 @@
     <string name="MoneroNodeSettings_AutoSelectDescription">استفاده خودکار از سریع‌ترین گره</string>
     <string name="MoneroNodeSettings_Unreachable">غیرقابل دسترس</string>
     <string name="MoneroNodeSettings_Latency">%d ms</string>
+    <string name="Send_Memo_PublicWarning">این یادداشت در بلاک چین عمومی خواهد بود.</string>
+    <string name="Send_Memo_EncryptedInfo">این یادداشت رمزگذاری شده است و تنها برای شما و گیرنده قابل مشاهده است.</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -712,4 +712,5 @@
     <string name="MoneroNodeSettings_Latency">%d ms</string>
     <string name="Send_Memo_PublicWarning">این یادداشت در بلاک چین عمومی خواهد بود.</string>
     <string name="Send_Memo_EncryptedInfo">این یادداشت رمزگذاری شده است و تنها برای شما و گیرنده قابل مشاهده است.</string>
+    <string name="Send_Memo_OffchainInfo">فقط در این دستگاه ذخیره شده است — در بلاک‌چین نیست.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1780,4 +1780,6 @@
     <string name="MoneroNodeSettings_AutoSelectDescription">Utiliser automatiquement le nœud le plus rapide</string>
     <string name="MoneroNodeSettings_Unreachable">Inaccessible</string>
     <string name="MoneroNodeSettings_Latency">%d ms</string>
+    <string name="Send_Memo_PublicWarning">Ce mémo sera public sur la blockchain.</string>
+    <string name="Send_Memo_EncryptedInfo">Ce mémo est chiffré et visible uniquement pour vous et le destinataire.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1782,4 +1782,5 @@
     <string name="MoneroNodeSettings_Latency">%d ms</string>
     <string name="Send_Memo_PublicWarning">Ce mémo sera public sur la blockchain.</string>
     <string name="Send_Memo_EncryptedInfo">Ce mémo est chiffré et visible uniquement pour vous et le destinataire.</string>
+    <string name="Send_Memo_OffchainInfo">Stocké sur cet appareil uniquement — pas sur la blockchain.</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1779,4 +1779,6 @@
     <string name="MoneroNodeSettings_AutoSelectDescription">가장 빠른 노드를 자동으로 사용</string>
     <string name="MoneroNodeSettings_Unreachable">연결할 수 없음</string>
     <string name="MoneroNodeSettings_Latency">%d ms</string>
+    <string name="Send_Memo_PublicWarning">이 메모는 블록체인에 공개됩니다.</string>
+    <string name="Send_Memo_EncryptedInfo">이 메모는 암호화되어 있으며 귀하와 수신자에게만 표시됩니다.</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1781,4 +1781,5 @@
     <string name="MoneroNodeSettings_Latency">%d ms</string>
     <string name="Send_Memo_PublicWarning">이 메모는 블록체인에 공개됩니다.</string>
     <string name="Send_Memo_EncryptedInfo">이 메모는 암호화되어 있으며 귀하와 수신자에게만 표시됩니다.</string>
+    <string name="Send_Memo_OffchainInfo">이 기기에만 저장됨 — 블록체인에 기록되지 않음.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1785,4 +1785,5 @@
     <string name="MoneroNodeSettings_Latency">%d ms</string>
     <string name="Send_Memo_PublicWarning">Este memorando será público na blockchain.</string>
     <string name="Send_Memo_EncryptedInfo">Este memorando está criptografado e é visível apenas para você e o destinatário.</string>
+    <string name="Send_Memo_OffchainInfo">Armazenado apenas neste dispositivo — não na blockchain.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1783,4 +1783,6 @@
     <string name="MoneroNodeSettings_AutoSelectDescription">Usar automaticamente o nó mais rápido</string>
     <string name="MoneroNodeSettings_Unreachable">Inacessível</string>
     <string name="MoneroNodeSettings_Latency">%d ms</string>
+    <string name="Send_Memo_PublicWarning">Este memorando será público na blockchain.</string>
+    <string name="Send_Memo_EncryptedInfo">Este memorando está criptografado e é visível apenas para você e o destinatário.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1787,4 +1787,5 @@
     <string name="MoneroNodeSettings_Latency">%d ms</string>
     <string name="Send_Memo_PublicWarning">Этот меморандум будет открыт в блокчейне.</string>
     <string name="Send_Memo_EncryptedInfo">Этот меморандум зашифрован и видим только вам и получателю.</string>
+    <string name="Send_Memo_OffchainInfo">Сохранено только на этом устройстве — не в блокчейне.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1785,4 +1785,6 @@
     <string name="MoneroNodeSettings_AutoSelectDescription">Автоматически использовать самый быстрый узел</string>
     <string name="MoneroNodeSettings_Unreachable">Недоступно</string>
     <string name="MoneroNodeSettings_Latency">%d ms</string>
+    <string name="Send_Memo_PublicWarning">Этот меморандум будет открыт в блокчейне.</string>
+    <string name="Send_Memo_EncryptedInfo">Этот меморандум зашифрован и видим только вам и получателю.</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1779,4 +1779,6 @@
     <string name="MoneroNodeSettings_AutoSelectDescription">En hızlı düğümü otomatik olarak kullan</string>
     <string name="MoneroNodeSettings_Unreachable">Ulaşılamaz</string>
     <string name="MoneroNodeSettings_Latency">%d ms</string>
+    <string name="Send_Memo_PublicWarning">Bu not blockchain üzerinde herkese açık olacaktır.</string>
+    <string name="Send_Memo_EncryptedInfo">Bu not şifrelenir ve yalnızca sizin ve alıcının tarafından görülür.</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1781,4 +1781,5 @@
     <string name="MoneroNodeSettings_Latency">%d ms</string>
     <string name="Send_Memo_PublicWarning">Bu not blockchain üzerinde herkese açık olacaktır.</string>
     <string name="Send_Memo_EncryptedInfo">Bu not şifrelenir ve yalnızca sizin ve alıcının tarafından görülür.</string>
+    <string name="Send_Memo_OffchainInfo">Yalnızca bu cihazda depolanır — zincir üzerinde değildir.</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1780,4 +1780,5 @@
     <string name="MoneroNodeSettings_Latency">%d ms</string>
     <string name="Send_Memo_PublicWarning">此备忘录将在区块链上公开。</string>
     <string name="Send_Memo_EncryptedInfo">此备忘录已加密，只有您和收款人可以看到。</string>
+    <string name="Send_Memo_OffchainInfo">仅存储在此设备上 — 不在区块链上。</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1778,4 +1778,6 @@
     <string name="MoneroNodeSettings_AutoSelectDescription">自动使用最快的节点</string>
     <string name="MoneroNodeSettings_Unreachable">无法访问</string>
     <string name="MoneroNodeSettings_Latency">%d ms</string>
+    <string name="Send_Memo_PublicWarning">此备忘录将在区块链上公开。</string>
+    <string name="Send_Memo_EncryptedInfo">此备忘录已加密，只有您和收款人可以看到。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -550,6 +550,7 @@
     <string name="Send_DialogMemoHint" translatable="false">Memo</string>
     <string name="Send_Memo_PublicWarning">This memo will be public on the blockchain.</string>
     <string name="Send_Memo_EncryptedInfo">This memo is encrypted and visible only to you and the recipient.</string>
+    <string name="Send_Memo_OffchainInfo">Stored on this device only — not on-chain.</string>
     <string name="Send_DialogLockTime" translatable="false">TimeLock</string>
     <string name="Send_LockTime_Off">Off</string>
     <string name="Send_LockTime_Hour">1 hour</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -548,6 +548,8 @@
     <string name="Send_DialogAvailableBalance">Available Balance</string>
     <string name="Send_DialogSpeed">Transaction Speed</string>
     <string name="Send_DialogMemoHint" translatable="false">Memo</string>
+    <string name="Send_Memo_PublicWarning">This memo will be public on the blockchain.</string>
+    <string name="Send_Memo_EncryptedInfo">This memo is encrypted and visible only to you and the recipient.</string>
     <string name="Send_DialogLockTime" translatable="false">TimeLock</string>
     <string name="Send_LockTime_Off">Off</string>
     <string name="Send_LockTime_Hour">1 hour</string>

--- a/translation_snapshot.json
+++ b/translation_snapshot.json
@@ -1079,6 +1079,7 @@
     "Send_LockTime_Off": "Off",
     "Send_LockTime_Year": "1 year",
     "Send_Memo_EncryptedInfo": "This memo is encrypted and visible only to you and the recipient.",
+    "Send_Memo_OffchainInfo": "Stored on this device only — not on-chain.",
     "Send_Memo_PublicWarning": "This memo will be public on the blockchain.",
     "Send_Rbf": "Replace by Fee",
     "Send_RbfDisabled": "Disabled",

--- a/translation_snapshot.json
+++ b/translation_snapshot.json
@@ -1078,6 +1078,8 @@
     "Send_LockTime_Month": "1 month",
     "Send_LockTime_Off": "Off",
     "Send_LockTime_Year": "1 year",
+    "Send_Memo_EncryptedInfo": "This memo is encrypted and visible only to you and the recipient.",
+    "Send_Memo_PublicWarning": "This memo will be public on the blockchain.",
     "Send_Rbf": "Replace by Fee",
     "Send_RbfDisabled": "Disabled",
     "Send_RbfEnabled": "Enabled",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memo fields now support selectable visibility (Public, Encrypted, Offchain) with on-screen guidance for each mode.
  * Send flows are updated to configure the appropriate memo visibility per asset, and Zcash memo support now also includes unified addresses.
* **Bug Fixes**
  * Improved memo handling/validation for Zcash address types.
* **Documentation**
  * Added new user-facing memo warnings and info text (including localization updates) explaining public on-chain vs private/participant-only vs device-only memos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->