### PR TITLE
Publishing updates

### DIFF
--- a/.github/workflows/publish_play.yml
+++ b/.github/workflows/publish_play.yml
@@ -1,9 +1,7 @@
 name: Publish to Google Play
 
 on:
-  push:
-    tags:
-      - '*'
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/publish_play.yml
+++ b/.github/workflows/publish_play.yml
@@ -43,7 +43,7 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: io.horizontalsystems.bankwallet
           releaseFiles: app/build/outputs/bundle/baseRelease/app-base-release.aab
-          track: internal
+          track: production
           status: draft
 
       - name: Notify Telegram on success


### PR DESCRIPTION
#9343

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now manually trigger the Google Play publishing workflow.
* **Changes**
  * Google Play releases are now published to the production track instead of the internal track.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->