### PR TITLE
Handle deeplink in inner pages

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/nav3/Nav3.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/nav3/Nav3.kt
@@ -142,6 +142,11 @@ private fun IntentEffect(viewModel: MainActivityViewModel, navigation: HSNavigat
         val consumer = Consumer<Intent> {
             if (!handleWalletConnectDeepLink(it, navigation)) {
                 viewModel.setIntent(it)
+                // The intent is consumed by MainScreen's observer, which only runs while
+                // MainScreen (EntryPage) is composed. If an inner screen (e.g. Receive) is on
+                // top, pop back to the root so the deeplink is processed immediately instead of
+                // waiting until the user manually returns to the main screen.
+                navigation.removeLastUntil(EntryPage::class, false)
             }
         }
         (activity as? ComponentActivity)?.addOnNewIntentListener(consumer)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deep links and incoming intents now return to the app’s main entry screen before being handled, reducing delays when another screen is open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->