### PR TITLE
Allow showing swap provider name in debug builds

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/Interfaces.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/Interfaces.kt
@@ -115,6 +115,7 @@ interface ILocalStorage {
     var termsAccepted: Boolean
     var swapTermsAccepted: Boolean
     var simulateFailSwap: SimulateFailSwapMode
+    var showSwapProviderName: Boolean
     var passkeyTermsAccepted: Boolean
     var checkedTerms: List<String>
     val mainShowedOnceFlow: StateFlow<Boolean>

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/managers/LocalStorageManager.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/managers/LocalStorageManager.kt
@@ -430,6 +430,12 @@ class LocalStorageManager(
             preferences.edit().putString("simulate-failed-swap", value.name).apply()
         }
 
+    override var showSwapProviderName: Boolean
+        get() = preferences.getBoolean("show-swap-provider-name", false)
+        set(value) {
+            preferences.edit { putBoolean("show-swap-provider-name", value) }
+        }
+
     override var passkeyTermsAccepted: Boolean
         get() = preferences.getBoolean(PASSKEY_TERMS_ACCEPTED, false)
         set(value) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapPage.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.horizontalsystems.walletkit.R
+import io.horizontalsystems.walletkit.BuildConfig
 import io.horizontalsystems.walletkit.core.App
 import io.horizontalsystems.walletkit.core.badge
 import io.horizontalsystems.walletkit.core.stats.StatEvent
@@ -605,6 +606,16 @@ private fun ProviderCellInfo(
                 )
             }
         )
+        if (BuildConfig.DEBUG && App.localStorage.showSwapProviderName) {
+            CellSecondary(
+                middle = {
+                    CellMiddleInfo(eyebrow = "Provider".hs)
+                },
+                right = {
+                    CellRightInfo(titleSubheadSb = quote.provider.title.hs)
+                }
+            )
+        }
         CellSecondary(
             middle = {
                 CellMiddleInfoTextIcon(

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapSelectProviderPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapSelectProviderPage.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import io.horizontalsystems.walletkit.BuildConfig
 import io.horizontalsystems.walletkit.R
 import io.horizontalsystems.walletkit.core.App
 import io.horizontalsystems.walletkit.core.stats.StatEvent
@@ -181,6 +182,13 @@ private fun SwapSelectProviderScreenInner(
                                                     color = it.color ?: ComposeAppTheme.colors.grey,
                                                 )
                                             }
+                                        }
+                                        if (BuildConfig.DEBUG && App.localStorage.showSwapProviderName) {
+                                            Text(
+                                                text = provider.title,
+                                                style = ComposeAppTheme.typography.subhead,
+                                                color = ComposeAppTheme.colors.grey,
+                                            )
                                         }
                                     }
                                     Column(

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/settings/main/MainSettingsScreen.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/settings/main/MainSettingsScreen.kt
@@ -444,9 +444,10 @@ private fun SettingSections(
 @Composable
 private fun DebugSettingsSection() {
     var simulateFailSwap by remember { mutableStateOf(App.localStorage.simulateFailSwap) }
+    var showSwapProviderName by remember { mutableStateOf(App.localStorage.showSwapProviderName) }
 
     CellUniversalLawrenceSection(
-        listOf {
+        listOf({
             RowUniversal(
                 modifier = Modifier.padding(horizontal = 16.dp),
                 onClick = {
@@ -468,7 +469,26 @@ private fun DebugSettingsSection() {
                     modifier = Modifier.padding(start = 8.dp)
                 )
             }
-        }
+        }, {
+            RowUniversal(
+                modifier = Modifier.padding(horizontal = 16.dp),
+                onClick = {
+                    showSwapProviderName = !showSwapProviderName
+                    App.localStorage.showSwapProviderName = showSwapProviderName
+                }
+            ) {
+                body_leah(
+                    text = "Show swap provider name",
+                    maxLines = 1,
+                    modifier = Modifier.weight(1f)
+                )
+                subhead1_grey(
+                    text = showSwapProviderName.toString(),
+                    maxLines = 1,
+                    modifier = Modifier.padding(start = 8.dp)
+                )
+            }
+        })
     )
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new debug setting to show swap provider names.
  * When enabled, swap screens can display the provider name alongside provider details in debug builds.
  * The setting is saved locally, so it remains available after restarting the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->