### PR TITLE
Fix deeplink amount parsing for tokens

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/utils/AddressUriParser.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/utils/AddressUriParser.kt
@@ -74,13 +74,14 @@ class AddressUriParser(private val blockchainType: BlockchainType?, private val 
                 val chainEnd = rest.indexOf('/').let { if (it == -1) rest.length else it }
                 val chainPart = rest.substring(1, chainEnd)
                 rest = rest.substring(chainEnd)
-                chainPart.toLongOrNull()?.let { chainId ->
-                    // Reject URIs targeting EVM chains we don't support: a silent fall-through
-                    // would mis-render as a chain-agnostic native EVM URI in the UI
-                    val uid = chainId.blockchainTypeFromChainId?.uid
-                        ?: return AddressUriResult.InvalidBlockchainType
-                    parsedUri.parameters[AddressUri.Field.BlockchainUid] = uid
-                }
+                // EIP-681 requires a numeric chain id; ignoring a malformed one would
+                // mis-render the URI as chain-agnostic and cause chain confusion
+                val chainId = chainPart.toLongOrNull() ?: return AddressUriResult.WrongUri
+                // Reject URIs targeting EVM chains we don't support: a silent fall-through
+                // would mis-render as a chain-agnostic native EVM URI in the UI
+                val uid = chainId.blockchainTypeFromChainId?.uid
+                    ?: return AddressUriResult.InvalidBlockchainType
+                parsedUri.parameters[AddressUri.Field.BlockchainUid] = uid
             }
 
             if (rest.startsWith("/")) {
@@ -113,10 +114,11 @@ class AddressUriParser(private val blockchainType: BlockchainType?, private val 
             val recipient = parameters["address"] ?: return AddressUriResult.WrongUri
             val rawAmount = parameters["uint256"] ?: return AddressUriResult.WrongUri
             if (!isEvmAddress(contract) || !isEvmAddress(recipient)) return AddressUriResult.WrongUri
-            if (rawAmount.toBigIntegerOrNull() == null) return AddressUriResult.WrongUri
+            val amount = rawAmount.toBigIntegerOrNull() ?: return AddressUriResult.WrongUri
+            if (amount.signum() <= 0 || amount.bitLength() > 256) return AddressUriResult.WrongUri
 
             parsedUri.parameters[AddressUri.Field.TokenUid] = "eip20:${contract.lowercase()}"
-            parsedUri.parameters[AddressUri.Field.Value] = rawAmount
+            parsedUri.parameters[AddressUri.Field.Value] = amount.toString()
             rawPath = recipient
         }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/utils/AddressUriParser.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/utils/AddressUriParser.kt
@@ -9,7 +9,6 @@ import io.horizontalsystems.walletkit.core.supported
 import io.horizontalsystems.walletkit.entities.AddressUri
 import io.horizontalsystems.marketkit.models.BlockchainType
 import io.horizontalsystems.marketkit.models.TokenType
-import java.math.BigDecimal
 import java.net.URI
 
 
@@ -61,17 +60,31 @@ class AddressUriParser(private val blockchainType: BlockchainType?, private val 
 
         val parsedUri = AddressUri(scheme = scheme)
 
-        // EIP-681 fix: Ethereum addresses sometimes come as address@chainId
+        // EIP-681 path: [pay-]<address>[@<chainId>][/<function>]
         var rawPath = path
+        var function: String? = null
 
-        if (scheme == "ethereum" && rawPath.contains("@")) {
-            val parts = rawPath.split("@")
-            if (parts.size == 2) {
-                rawPath = parts[0]
-                val chainIdFromPath = parts[1]
-                chainIdFromPath.toLongOrNull()?.blockchainTypeFromChainId?.uid?.let  {
-                    parsedUri.parameters[AddressUri.Field.BlockchainUid] = it
+        if (scheme == "ethereum") {
+            val stripped = path.removePrefix("pay-")
+            val addressEnd = stripped.indexOfFirst { it == '@' || it == '/' }.let { if (it == -1) stripped.length else it }
+            rawPath = stripped.take(addressEnd)
+            var rest = stripped.substring(addressEnd)
+
+            if (rest.startsWith("@")) {
+                val chainEnd = rest.indexOf('/').let { if (it == -1) rest.length else it }
+                val chainPart = rest.substring(1, chainEnd)
+                rest = rest.substring(chainEnd)
+                chainPart.toLongOrNull()?.let { chainId ->
+                    // Reject URIs targeting EVM chains we don't support: a silent fall-through
+                    // would mis-render as a chain-agnostic native EVM URI in the UI
+                    val uid = chainId.blockchainTypeFromChainId?.uid
+                        ?: return AddressUriResult.InvalidBlockchainType
+                    parsedUri.parameters[AddressUri.Field.BlockchainUid] = uid
                 }
+            }
+
+            if (rest.startsWith("/")) {
+                function = rest.substring(1).ifEmpty { null }
             }
         }
 
@@ -79,24 +92,32 @@ class AddressUriParser(private val blockchainType: BlockchainType?, private val 
         val query = schemeSpecificPart.substring(queryStartIndex)
 
         val parameters = parseQueryParameters(query)
-        if (parameters.isEmpty()) {
-            parsedUri.address = fullAddress(scheme, rawPath, parsedUri.value(AddressUri.Field.BlockchainUid))
 
-            return AddressUriResult.Uri(parsedUri)
-        }
-
+        // amounts stay in the units the uri declared them in (`value` = base units);
+        // conversion to a readable amount happens where the token is known
         for (parameter in parameters) {
             val (key, value) = parameter
             AddressUri.Field.entries.firstOrNull { it.value == key }?.let { field ->
-                if (field == AddressUri.Field.Value && scheme == "ethereum") {
-                    //convert from wei to amount
-                    value.toBigDecimalOrNull()?.divide(BigDecimal.TEN.pow(18))?.let {
-                        parsedUri.parameters[field] = it.toPlainString()
-                    }
-                } else {
-                    parsedUri.parameters[field] = value
-                }
+                parsedUri.parameters[field] = value
             }
+        }
+
+        if (function != null) {
+            // Only ERC-20 transfer(address,uint256) is supported. Anything else is rejected —
+            // a silent fallback into a "native send to contract address" interpretation would
+            // let a crafted URI phish a token transfer disguised as a plain coin transfer
+            if (function != "transfer") return AddressUriResult.WrongUri
+            if (parameters.containsKey(AddressUri.Field.Value.value)) return AddressUriResult.WrongUri
+
+            val contract = rawPath
+            val recipient = parameters["address"] ?: return AddressUriResult.WrongUri
+            val rawAmount = parameters["uint256"] ?: return AddressUriResult.WrongUri
+            if (!isEvmAddress(contract) || !isEvmAddress(recipient)) return AddressUriResult.WrongUri
+            if (rawAmount.toBigIntegerOrNull() == null) return AddressUriResult.WrongUri
+
+            parsedUri.parameters[AddressUri.Field.TokenUid] = "eip20:${contract.lowercase()}"
+            parsedUri.parameters[AddressUri.Field.Value] = rawAmount
+            rawPath = recipient
         }
 
         parsedUri.value<String>(AddressUri.Field.BlockchainUid)?.let { uid ->
@@ -113,6 +134,10 @@ class AddressUriParser(private val blockchainType: BlockchainType?, private val 
 
         parsedUri.address = fullAddress(scheme, rawPath, parsedUri.value(AddressUri.Field.BlockchainUid))
         return AddressUriResult.Uri(parsedUri)
+    }
+
+    private fun isEvmAddress(address: String): Boolean {
+        return evmAddressRegex.matches(address)
     }
 
     private fun parseQueryParameters(query: String?): Map<String, String> {
@@ -153,6 +178,8 @@ class AddressUriParser(private val blockchainType: BlockchainType?, private val 
     }
 
     companion object {
+        private val evmAddressRegex = Regex("^0x[0-9a-fA-F]{40}$")
+
         fun hasUriPrefix(text: String): Boolean {
             return text.split(":").size > 1
         }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/entities/AddressUri.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/entities/AddressUri.kt
@@ -3,7 +3,9 @@ package io.horizontalsystems.walletkit.entities
 import io.horizontalsystems.walletkit.core.factories.uriScheme
 import io.horizontalsystems.walletkit.core.managers.EvmBlockchainManager
 import io.horizontalsystems.walletkit.core.supported
+import io.horizontalsystems.walletkit.serializers.BigDecimalSerializer
 import io.horizontalsystems.marketkit.models.BlockchainType
+import kotlinx.serialization.Serializable
 import java.math.BigDecimal
 
 class AddressUri(
@@ -26,11 +28,29 @@ class AddressUri(
         return value as? T
     }
 
-    val amount: BigDecimal?
-        get() = value<BigDecimal>(Field.Amount) ?: value(Field.Value) ?: value(Field.TxAmount)
+    val amount: Amount?
+        get() = value<BigDecimal>(Field.Value)?.let { Amount.Points(it) }
+            ?: (value<BigDecimal>(Field.Amount) ?: value<BigDecimal>(Field.TxAmount))?.let { Amount.Decimals(it) }
 
     val memo: String?
         get() = value(Field.TxDescription)
+
+    // The `value` field carries base units (wei, satoshi, lamports) — the token must be known
+    // before it can be rendered, so conversion is deferred to where decimals are available.
+    @Serializable
+    sealed class Amount {
+        abstract fun humanReadable(decimals: Int): BigDecimal
+
+        @Serializable
+        data class Points(@Serializable(with = BigDecimalSerializer::class) val value: BigDecimal) : Amount() {
+            override fun humanReadable(decimals: Int): BigDecimal = value.movePointLeft(decimals).stripTrailingZeros()
+        }
+
+        @Serializable
+        data class Decimals(@Serializable(with = BigDecimalSerializer::class) val value: BigDecimal) : Amount() {
+            override fun humanReadable(decimals: Int): BigDecimal = value
+        }
+    }
 
     enum class Field(val value: String) {
         Amount("amount"),

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/address/AddressParserModule.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/address/AddressParserModule.kt
@@ -10,7 +10,7 @@ object AddressParserModule {
     class Factory(private val token: Token, private val prefilledAmount: BigDecimal?) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return AddressParserViewModel(AddressUriParser(token.blockchainType, token.type), prefilledAmount) as T
+            return AddressParserViewModel(AddressUriParser(token.blockchainType, token.type), token.decimals, prefilledAmount) as T
         }
     }
 }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/address/AddressParserViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/address/AddressParserViewModel.kt
@@ -10,7 +10,11 @@ import io.horizontalsystems.walletkit.ui.compose.components.TextPreprocessor
 import java.math.BigDecimal
 import java.util.UUID
 
-class AddressParserViewModel(private val parser: IAddressParser, prefilledAmount: BigDecimal?) : ViewModel(), TextPreprocessor {
+class AddressParserViewModel(
+    private val parser: IAddressParser,
+    private val tokenDecimals: Int,
+    prefilledAmount: BigDecimal?
+) : ViewModel(), TextPreprocessor {
     private var lastEnteredText: String? = null
 
     var amountUnique by mutableStateOf<AmountUnique?>(prefilledAmount?.let { AmountUnique(it) })
@@ -23,7 +27,7 @@ class AddressParserViewModel(private val parser: IAddressParser, prefilledAmount
             val addressData = parser.parse(text)
             val amount = (addressData as? AddressUriResult.Uri)?.addressUri?.amount
             if (amount != null) {
-                amountUnique = AmountUnique(amount)
+                amountUnique = AmountUnique(amount.humanReadable(tokenDecimals))
                 processed = addressData.addressUri.address
             }
         }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/BalanceViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/BalanceViewModel.kt
@@ -439,7 +439,7 @@ data class OpenSendTokenSelect(
     val blockchainTypes: List<BlockchainType>?,
     val tokenTypes: List<TokenType>?,
     val address: String,
-    val amount: BigDecimal? = null,
+    val amount: AddressUri.Amount? = null,
     val memo: String? = null
 )
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/sendtokenselect/SendTokenSelectPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/sendtokenselect/SendTokenSelectPage.kt
@@ -5,16 +5,15 @@ import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.horizontalsystems.walletkit.R
 import io.horizontalsystems.walletkit.core.providers.Translator
+import io.horizontalsystems.walletkit.entities.AddressUri
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.nav3.HSPage
 import io.horizontalsystems.walletkit.modules.send.address.EnterAddressPage
 import io.horizontalsystems.walletkit.modules.tokenselect.TokenSelectScreen
 import io.horizontalsystems.walletkit.modules.tokenselect.TokenSelectViewModel
-import io.horizontalsystems.walletkit.serializers.BigDecimalSerializer
 import io.horizontalsystems.marketkit.models.BlockchainType
 import io.horizontalsystems.marketkit.models.TokenType
 import kotlinx.serialization.Serializable
-import java.math.BigDecimal
 
 @Serializable
 data class SendTokenSelectPage(val input: Input? = null) : HSPage() {
@@ -27,6 +26,9 @@ data class SendTokenSelectPage(val input: Input? = null) : HSPage() {
             navigation = navigation,
             title = stringResource(R.string.Balance_Send),
             onClickItem = {
+                // base-unit amounts (eip-681 `value`/`uint256`) can only be converted to a
+                // readable amount here, where the selected token's decimals are known
+                val amount = input?.amount?.humanReadable(it.wallet.token.decimals)
                 val sendTitle = Translator.getString(R.string.Send_Title, it.wallet.token.fullCoin.coin.code)
                 navigation.slideFromRight(
                     EnterAddressPage(EnterAddressPage.Input(
@@ -34,7 +36,7 @@ data class SendTokenSelectPage(val input: Input? = null) : HSPage() {
                         title = sendTitle,
                         sendEntryPointDestId = SendTokenSelectPage::class,
                         address = input?.address,
-                        amount = input?.amount,
+                        amount = amount,
                         memo = input?.memo,
                     ))
                 )
@@ -48,7 +50,7 @@ data class SendTokenSelectPage(val input: Input? = null) : HSPage() {
         val blockchainTypes: List<BlockchainType>?,
         val tokenTypes: List<TokenType>?,
         val address: String,
-        @Serializable(with = BigDecimalSerializer::class) val amount: BigDecimal?,
+        val amount: AddressUri.Amount?,
         val memo: String?
     )
 }


### PR DESCRIPTION
#9365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced support for Ethereum-style payment links using a more complete EIP-681-style path/query parser, including optional function suffixes and chain ID extraction.
  * Transfer links now validate contract, recipient, and amount formatting, and extract/store amounts in a token-decimals-aware way.
* **Bug Fixes**
  * Fixed incorrect handling of Ethereum `value` in link queries and removed inconsistent early-exit behavior when query params were absent.
  * Rejected unsupported or malformed transfer links (including invalid function names and invalid addresses).
* **Refactor**
  * Improved amount typing through the send flow for more consistent parsing and display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->