### PR TITLE
Add manual workflow for Maestro UI tests

### DIFF
--- a/.github/workflows/maestro_tests.yml
+++ b/.github/workflows/maestro_tests.yml
@@ -1,0 +1,55 @@
+name: Maestro UI Tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build CI Debug
+        run: ./gradlew assembleCiDebug --stacktrace --no-daemon
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Install Maestro CLI
+        run: |
+          curl -Ls https://get.maestro.mobile.dev | bash
+          echo "$HOME/.maestro/bin" >> $GITHUB_PATH
+
+      - name: Run Maestro tests on emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          disable-animations: true
+          script: |
+            adb install app/build/outputs/apk/ci/debug/app-ci-debug.apk
+            maestro test -e APP_ID=io.horizontalsystems.bankwallet.appcenter.dev --format junit --output maestro-report.xml maestro/
+
+      - name: Upload test output
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-output
+          path: |
+            ~/.maestro/tests/**
+            maestro-report.xml


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a manual Android UI testing workflow for running Maestro-based end-to-end checks.
  * Builds the debug app, runs it in an emulator, and generates a test report.
  * Collects test artifacts automatically when a run fails for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->