### PR TITLE
Swap provider lifi

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,7 +74,7 @@ bitcoinKit = "7a552c4"
 ethereumKit = "8c70f5e021"
 feeRateKit = "393cc14"
 marketKit = "3be4e8a"
-solanaKit = "900e80e"
+solanaKit = "b487161"
 tronKit = "2f07e86"
 zcashSdk = "2.5.2"
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/adapters/SolanaTransactionConverter.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/adapters/SolanaTransactionConverter.kt
@@ -78,15 +78,15 @@ class SolanaTransactionConverter(
             }
         }
 
-        // A recognized DEX interaction (via SolanaKit KnownPrograms) renders as a swap when it has
-        // legs on both sides, or no legs yet (pending — the kit stores no balance changes until
-        // confirmation, but the program id is known at send time). A side can carry a spurious SOL
-        // leg next to the real SPL one (token-account rent when the swap created the output ATA),
-        // so each side prefers its non-SOL leg over a bare `size == 1` match.
+        // A recognized DEX interaction (via SolanaKit KnownPrograms) renders as a swap — we key purely
+        // on the invoked program. Same-chain swaps (Jupiter) carry legs on both sides; a CROSS-CHAIN
+        // LI.FI swap FROM Solana carries only the OUTGOING side (the bought asset lands on another
+        // chain); a pending swap carries no legs yet (the kit stores no balance changes until
+        // confirmation) — all are swaps. A side can carry a spurious SOL leg next to the real SPL one
+        // (tx fee / token-account rent), so each side prefers its non-SOL leg via `primaryTransfer`
+        // (`valueIn`/`valueOut` are null when that side has no leg).
         val exchangeName = swapExchangeName(transaction)
-        if (exchangeName != null &&
-            ((incomingTransfers.isNotEmpty() && outgoingTransfers.isNotEmpty()) || (incomingTransfers.isEmpty() && outgoingTransfers.isEmpty()))
-        ) {
+        if (exchangeName != null) {
             return SolanaSwapTransactionRecord(
                 transaction = transaction,
                 baseToken = baseToken,
@@ -139,6 +139,7 @@ class SolanaTransactionConverter(
         // Mirrors the EVM flow, where the exchange contract address maps to a label ("1inch v5").
         private val swapProgramLabels = mapOf(
             KnownPrograms.jupiterV6 to "Jupiter",
+            KnownPrograms.lifi to "LI.FI",
         )
     }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapConfirmViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapConfirmViewModel.kt
@@ -319,10 +319,15 @@ class SwapConfirmViewModel(
     }
 
     private suspend fun saveSwapRecord(result: SendTransactionResult) {
+        // The broadcast hash becomes the record's inboundTxHash — required for tracking DEX
+        // swaps (Jupiter, LI.FI), where the server polls the provider's status by the source
+        // chain transaction.
         val transactionHash = when (result) {
             is SendTransactionResult.Evm -> result.fullTransaction.transaction.hash.toHexString()
             is SendTransactionResult.Btc -> result.transactionRecord?.transactionHash
             is SendTransactionResult.Zcash -> result.transactionHash
+            is SendTransactionResult.Solana -> result.txHash
+            is SendTransactionResult.Tron -> result.txHash
             else -> null
         }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/MultiSwapProviderRegistry.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/MultiSwapProviderRegistry.kt
@@ -24,6 +24,7 @@ object MultiSwapProviderRegistry {
         USwapProvider(UProvider.Circle),
         USwapProvider(UProvider.Pegasus),
         USwapProvider(UProvider.Jupiter),
+        USwapProvider(UProvider.Lifi),
     )
 
     private val providersById: Map<String, IMultiSwapProvider> by lazy {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/UProvider.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/UProvider.kt
@@ -146,5 +146,19 @@ enum class UProvider(
         isEvm = false,
         isSingleTransactionSwap = true,
         supportsSimpleUtxoTransactions = false
+    ),
+    Lifi(
+        id = "LIFI",
+        title = "LI.FI",
+        type = SwapProviderType.DEX,
+        aml = false,
+        amlPrecheck = false,
+        requireTerms = true,
+        riskLevel = RiskLevel.EXCELLENT,
+        isEvm = false,
+        // Cross-chain default; a same-chain LI.FI pair IS a single tx —
+        // USwapProvider.isSingleTransactionSwap resolves that per pair.
+        isSingleTransactionSwap = false,
+        supportsSimpleUtxoTransactions = false
     );
 }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
@@ -3,13 +3,11 @@ package io.horizontalsystems.walletkit.modules.multiswap.providers
 import android.util.Base64
 import com.google.gson.JsonElement
 import io.horizontalsystems.bitcoincore.storage.UtxoFilters
-import io.horizontalsystems.walletkit.BuildConfig
 import io.horizontalsystems.walletkit.core.App
 import io.horizontalsystems.walletkit.core.derivation
 import io.horizontalsystems.walletkit.core.isEvm
 import io.horizontalsystems.walletkit.core.managers.APIClient
 import io.horizontalsystems.walletkit.core.nativeTokenQueries
-import io.horizontalsystems.walletkit.entities.SimulateFailSwapMode
 import io.horizontalsystems.walletkit.modules.multiswap.SwapFinalQuote
 import io.horizontalsystems.walletkit.modules.multiswap.SwapQuote
 import io.horizontalsystems.walletkit.modules.multiswap.sendtransaction.SendTransactionData
@@ -26,6 +24,7 @@ import io.horizontalsystems.marketkit.models.TokenQuery
 import io.horizontalsystems.marketkit.models.TokenType
 import io.horizontalsystems.tronkit.hexStringToByteArray
 import io.horizontalsystems.tronkit.network.CreatedTransaction
+import io.horizontalsystems.walletkit.modules.multiswap.action.ISwapProviderAction
 import kotlinx.coroutines.CancellationException
 import org.json.JSONObject
 import retrofit2.http.Body
@@ -316,17 +315,21 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
     ): SwapQuote {
         val bestRoute = rateBestRoute(tokenIn, tokenOut, amountIn, BigDecimal("1"))
 
-        val approvalAddress = bestRoute.approvalSpenderOrExecution?.let { router ->
-            try {
-                Address(router)
-            } catch (_: Throwable) {
-                null
-            }
-        }
+        val approvalAddress = bestRoute.approvalSpenderOrExecution
+        val actionRequired = approvalAddress?.let { approvalAddress ->
+            when {
+                tokenIn.blockchainType.isEvm -> {
+                    val allowance = EvmSwapHelper.getAllowance(tokenIn, approvalAddress)
+                    EvmSwapHelper.actionApprove(allowance, amountIn, approvalAddress, tokenIn)
+                }
 
-        val allowance = approvalAddress?.let { EvmSwapHelper.getAllowance(tokenIn, it) }
-        val actionApprove = approvalAddress?.let {
-            EvmSwapHelper.actionApprove(allowance, amountIn, it, tokenIn)
+                tokenIn.blockchainType == BlockchainType.Tron -> {
+                    val allowance = SwapHelper.getAllowanceTrc20(tokenIn, approvalAddress)
+                    SwapHelper.actionApproveTrc20(allowance, amountIn, approvalAddress, tokenIn)
+                }
+
+                else -> null
+            }
         }
 
         return SwapQuote(
@@ -334,7 +337,7 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
             tokenIn = tokenIn,
             tokenOut = tokenOut,
             amountIn = amountIn,
-            actionRequired = actionApprove,
+            actionRequired = actionRequired,
             estimationTime = bestRoute.estimatedTime?.total,
             extraData = SwapQuoteExtraData(bestRoute)
         )

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
@@ -44,7 +44,12 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
     override val requireTerms = provider.requireTerms
     override val riskLevel = provider.riskLevel
 
-    override fun isSingleTransactionSwap(tokenInBlockchainTypeUid: String, tokenOutBlockchainTypeUid: String) = provider.isSingleTransactionSwap
+    override fun isSingleTransactionSwap(tokenInBlockchainTypeUid: String, tokenOutBlockchainTypeUid: String) = when (provider) {
+        // LI.FI spans both: a same-chain pair is a plain single-tx DEX swap, a cross-chain
+        // pair is deposit → bridge → delivery, so the flag depends on the pair, not the provider.
+        UProvider.Lifi -> tokenInBlockchainTypeUid == tokenOutBlockchainTypeUid
+        else -> provider.isSingleTransactionSwap
+    }
 
     private val unstoppableAPI = APIClient.build(
         App.appConfigProvider.uswapApiBaseUrl,
@@ -267,6 +272,34 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
             // X→wSOL would deliver native SOL while the user watches the wSOL token balance.
             is TokenType.Spl -> type.address.takeIf { it != WSOL_MINT }
             else -> null
+        }
+        // No token list (BARTER-style), but LI.FI is CROSS-CHAIN, so each side must be
+        // self-describing — the chain travels with the asset so the server resolves a
+        // cross-chain pair without a shared `chainId` hint. EVM token → `<CHAIN>.<contract>`,
+        // EVM native → `<CHAIN>.<0xeee…>` sentinel, Solana → `SOL.<mint>` (wSOL = native SOL),
+        // Tron → `TRON.TRX` (native) / `TRON.<contract>` (TRC20).
+        UProvider.Lifi -> when (token.blockchainType) {
+            BlockchainType.Solana -> when (val type = token.type) {
+                TokenType.Native -> "SOL.$WSOL_MINT"
+                // The wSOL TOKEN is excluded for the same reason as on the JUPITER path above.
+                is TokenType.Spl -> type.address.takeIf { it != WSOL_MINT }?.let { "SOL.$it" }
+                else -> null
+            }
+            // Tron is TVM (base58 addresses, not `0x`): the server resolves `TRON.TRX` as native
+            // and `TRON.<contract>` as a TRC20 — the EVM `0xeee…` native sentinel does not apply.
+            // TRC20 contracts ride the `Eip20` type with a base58 address.
+            BlockchainType.Tron -> when (val type = token.type) {
+                TokenType.Native -> "TRON.TRX"
+                is TokenType.Eip20 -> "TRON.${type.address}"
+                else -> null
+            }
+            else -> lifiChainCodes[token.blockchainType]?.let { code ->
+                when (val type = token.type) {
+                    is TokenType.Eip20 -> "$code.${type.address}"
+                    TokenType.Native -> "$code.0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+                    else -> null
+                }
+            }
         }
         // Raw EVM address encoding (BARTER's server adapter expects addresses, not identifiers).
         else -> when (val type = token.type) {
@@ -630,6 +663,21 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
 
         // Wrapped-SOL mint — the JUPITER server adapter reads it as native SOL.
         private const val WSOL_MINT = "So11111111111111111111111111111111111111112"
+
+        // LI.FI has no token list, so assets are encoded self-describingly as `<CHAIN>.<address>`
+        // (see `deriveIdentifier`). This maps each supported EVM chain to the server's chain
+        // code — the prefix the server's LI.FI resolver expects. Solana and Tron are handled
+        // inline (`SOL.` / `TRON.` prefixes) since their address formats aren't the EVM
+        // `0xeee…`/contract shape.
+        private val lifiChainCodes = mapOf(
+            BlockchainType.Ethereum to "ETH",
+            BlockchainType.Polygon to "POL",
+            BlockchainType.ArbitrumOne to "ARB",
+            BlockchainType.Optimism to "OP",
+            BlockchainType.Base to "BASE",
+            BlockchainType.Avalanche to "AVAX",
+            BlockchainType.BinanceSmartChain to "BSC",
+        )
     }
 
     data class SwapQuoteExtraData(val route: UnstoppableAPI.Response.Route) : SwapQuote.ExtraData


### PR DESCRIPTION
#9375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LI.FI as a supported swap provider, with support for Solana, Tron, and EVM routes.
  * Introduced chain-aware LI.FI asset identifiers and route handling.
* **Bug Fixes**
  * Improved swap detection to recognize more DEX-program swap scenarios.
  * Enhanced swap tracking by deriving and storing broadcast hashes for Solana and Tron.
  * Corrected LI.FI labeling and improved approval/action handling per chain.
* **Chores**
  * Updated the underlying Solana library version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->