### PR TITLE
Compare Monero node endpoints when checking duplicates

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/managers/MoneroNodeManager.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/managers/MoneroNodeManager.kt
@@ -147,7 +147,9 @@ class MoneroNodeManager(
     }
 
     private fun serializeNode(uri: Uri, username: String?, password: String?): String {
-        return "$username:$password@${uri.host}:${uri.port}/mainnet/${uri.host ?: ""}"
+        // nodes saved before port validation was added may have no port; url scheme is always https
+        val port = if (uri.port == -1) 443 else uri.port
+        return "$username:$password@${uri.host}:$port/mainnet/${uri.host ?: ""}"
     }
 
     fun addMoneroNode(url: String, username: String?, password: String?, trusted: Boolean) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/managers/MoneroNodeManager.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/managers/MoneroNodeManager.kt
@@ -147,9 +147,21 @@ class MoneroNodeManager(
     }
 
     private fun serializeNode(uri: Uri, username: String?, password: String?): String {
-        // nodes saved before port validation was added may have no port; url scheme is always https
-        val port = if (uri.port == -1) 443 else uri.port
-        return "$username:$password@${uri.host}:$port/mainnet/${uri.host ?: ""}"
+        return "$username:$password@${uri.host}:${effectivePort(uri)}/mainnet/${uri.host ?: ""}"
+    }
+
+    // nodes saved before port validation was added may have no port; url scheme is always https
+    private fun effectivePort(uri: Uri) = if (uri.port == -1) 443 else uri.port
+
+    // canonical "host:port"; default nodes store host that way already, custom nodes store a full url
+    private fun endpoint(hostOrUrl: String): String {
+        val uri = hostOrUrl.toUri()
+        return uri.host?.let { "$it:${effectivePort(uri)}" } ?: hostOrUrl
+    }
+
+    fun hasNode(url: String): Boolean {
+        val endpoint = endpoint(url)
+        return allNodes.any { endpoint(it.host) == endpoint }
     }
 
     fun addMoneroNode(url: String, username: String?, password: String?, trusted: Boolean) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/moneronetwork/addnode/AddMoneroNodeScreen.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/moneronetwork/addnode/AddMoneroNodeScreen.kt
@@ -62,7 +62,7 @@ fun AddMoneroNodeScreen(
                     modifier = Modifier.padding(horizontal = 16.dp),
                     qrScannerEnabled = true,
                     onValueChange = viewModel::onEnterRpcUrl,
-                    hint = "",
+                    hint = "https://node.com:port",
                     state = getState(viewModel.uiState.urlCaution)
                 )
                 Spacer(modifier = Modifier.height(24.dp))

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/moneronetwork/addnode/AddMoneroNodeViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/moneronetwork/addnode/AddMoneroNodeViewModel.kt
@@ -58,6 +58,12 @@ class AddMoneroNodeViewModel(
             return
         }
 
+        if (sourceUri.port == -1) {
+            urlCaution = Caution(Translator.getString(R.string.AddMoneroNode_Error_PortRequired), Caution.Type.Error)
+            emitState()
+            return
+        }
+
         if (nodeManager.allNodes.any { it.host == url }) {
             urlCaution = Caution(Translator.getString(R.string.AddMoneroNode_Warning_UrlExists), Caution.Type.Warning)
             emitState()

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/moneronetwork/addnode/AddMoneroNodeViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/moneronetwork/addnode/AddMoneroNodeViewModel.kt
@@ -64,7 +64,7 @@ class AddMoneroNodeViewModel(
             return
         }
 
-        if (nodeManager.allNodes.any { it.host == url }) {
+        if (nodeManager.hasNode(url)) {
             urlCaution = Caution(Translator.getString(R.string.AddMoneroNode_Warning_UrlExists), Caution.Type.Warning)
             emitState()
             return

--- a/walletkit/src/main/res/values-fa/strings.xml
+++ b/walletkit/src/main/res/values-fa/strings.xml
@@ -721,6 +721,6 @@
     <string name="Send_Memo_PublicWarning">این یادداشت در بلاک چین عمومی خواهد بود.</string>
     <string name="Send_Memo_EncryptedInfo">این یادداشت رمزگذاری شده است و تنها برای شما و گیرنده قابل مشاهده است.</string>
     <string name="Send_Memo_OffchainInfo">فقط در این دستگاه ذخیره شده است — در بلاک‌چین نیست.</string>
-    <string name="AddMoneroNode_Error_PortRequired">آدرس گره باید شامل یک پورت باشد، به عنوان مثال https://node.com:18081</string>
+    <string name="AddMoneroNode_Error_PortRequired">آدرس URL گره باید شامل یک پورت باشد، به عنوان مثال https://node.com:18081</string>
     <string name="ManageAccounts_ManageWallet">مدیریت کیف پول</string>
 </resources>

--- a/walletkit/src/main/res/values-fa/strings.xml
+++ b/walletkit/src/main/res/values-fa/strings.xml
@@ -721,4 +721,6 @@
     <string name="Send_Memo_PublicWarning">این یادداشت در بلاک چین عمومی خواهد بود.</string>
     <string name="Send_Memo_EncryptedInfo">این یادداشت رمزگذاری شده است و تنها برای شما و گیرنده قابل مشاهده است.</string>
     <string name="Send_Memo_OffchainInfo">فقط در این دستگاه ذخیره شده است — در بلاک‌چین نیست.</string>
+    <string name="AddMoneroNode_Error_PortRequired">آدرس گره باید شامل یک پورت باشد، به عنوان مثال https://node.com:18081</string>
+    <string name="ManageAccounts_ManageWallet">مدیریت کیف پول</string>
 </resources>

--- a/walletkit/src/main/res/values/strings.xml
+++ b/walletkit/src/main/res/values/strings.xml
@@ -1271,6 +1271,7 @@
     <string name="AddMoneroNode_Pasword">Password (optional)</string>
     <string name="AddMoneroNode_Warning_UrlExists">Node with this url already exists</string>
     <string name="AddMoneroNode_Error_InvalidUrl">Entered url is invalid. Valid url must have one of the following schemes: https</string>
+    <string name="AddMoneroNode_Error_PortRequired">Node url must include a port, e.g. https://node.com:18081</string>
     <string name="AddZanoNode_Warning_UrlExists">Node with this url already exists</string>
     <string name="AddZanoNode_Error_InvalidUrl">Entered url is invalid. Valid url must have one of the following schemes: http, https</string>
     <string name="MoneroNodeSettings_TrustedTitle">Node Preferences</string>


### PR DESCRIPTION
#8358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer guidance when entering a Monero node URL, including an example format.
  * Added validation requiring node URLs to include an explicit port.

* **Bug Fixes**
  * Improved detection of existing Monero nodes across equivalent URL formats.
  * Standardized secure node endpoints without an explicitly specified port.
  * Added a clear error message explaining that a port is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->