### PR TITLE
Update Zano kit, show friendly error when node unreachable

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/zano/SendZanoViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/modules/send/zano/SendZanoViewModel.kt
@@ -21,6 +21,7 @@ import io.horizontalsystems.bankwallet.modules.send.SendResult
 import io.horizontalsystems.bankwallet.modules.xrate.XRateService
 import io.horizontalsystems.bankwallet.ui.compose.TranslatableString
 import io.horizontalsystems.marketkit.models.Token
+import io.horizontalsystems.zanokit.NodeUnreachableException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -177,6 +178,7 @@ class SendZanoViewModel(
 
     private fun createCaution(error: Throwable) = when (error) {
         is UnknownHostException -> HSCaution(TranslatableString.ResString(R.string.Hud_Text_NoInternet))
+        is NodeUnreachableException -> HSCaution(TranslatableString.ResString(R.string.Send_Error_NodeUnreachable))
         is LocalizedException -> HSCaution(TranslatableString.ResString(error.errorTextRes))
         else -> HSCaution(TranslatableString.PlainString(error.message ?: ""))
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1805,4 +1805,5 @@
     <string name="PasskeyTerms_DeviceDependency_Description">Der Zugriff erfordert Ihr Gerät. Der Verlust des Zugriffs kann zum Verlust Ihrer Gelder führen.</string>
     <string name="PasskeyTerms_LimitedAccess_Description">Funktioniert möglicherweise nicht auf allen Geräten oder Plattformen.</string>
     <string name="PasskeyTerms_Responsibility_Description">Sie sind für den Zugriff auf Ihr Gerät verantwortlich. Unstoppable kann dieses Wallet nicht wiederherstellen, wenn der Zugriff verloren geht.</string>
+    <string name="Send_Error_NodeUnreachable">Knoten konnte nicht erreicht werden. Bitte überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1796,4 +1796,5 @@
     <string name="PasskeyTerms_DeviceDependency_Description">El acceso requiere tu dispositivo. Perder el acceso puede provocar la pérdida de fondos.</string>
     <string name="PasskeyTerms_LimitedAccess_Description">Puede que no funcione en todos los dispositivos o plataformas.</string>
     <string name="PasskeyTerms_Responsibility_Description">Eres responsable del acceso a tu dispositivo. Unstoppable no puede recuperar esta wallet si se pierde el acceso.</string>
+    <string name="Send_Error_NodeUnreachable">No se pudo alcanzar el nodo. Verifique su conexión e intente de nuevo.</string>
 </resources>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -704,4 +704,5 @@
     <string name="PasskeyTerms_DeviceDependency_Description">دسترسی به دستگاه شما نیاز دارد. از دست دادن دسترسی ممکن است به از دست رفتن دارایی‌ها منجر شود.</string>
     <string name="PasskeyTerms_LimitedAccess_Description">ممکن است روی همه دستگاه‌ها یا پلتفرم‌ها کار نکند.</string>
     <string name="PasskeyTerms_Responsibility_Description">مسئولیت دسترسی به دستگاهتان بر عهده شماست. در صورت از دست رفتن دسترسی، Unstoppable نمی‌تواند این کیف‌پول را بازیابی کند.</string>
+    <string name="Send_Error_NodeUnreachable">نتوانستیم به گره دسترسی پیدا کنیم. لطفاً اتصال خود را بررسی کنید و دوباره تلاش کنید.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1798,4 +1798,5 @@
     <string name="PasskeyTerms_DeviceDependency_Description">L\'accès nécessite votre appareil. La perte d\'accès peut entraîner la perte de vos fonds.</string>
     <string name="PasskeyTerms_LimitedAccess_Description">Peut ne pas fonctionner sur tous les appareils ou plateformes.</string>
     <string name="PasskeyTerms_Responsibility_Description">Vous êtes responsable de l\'accès à votre appareil. Unstoppable ne peut pas récupérer ce portefeuille si l\'accès est perdu.</string>
+    <string name="Send_Error_NodeUnreachable">Impossible de joindre le nœud. Veuillez vérifier votre connexion et réessayer.</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1797,4 +1797,5 @@
     <string name="WalletConnect_DisconnectWarning">이 연결을 삭제하시겠습니까?</string>
     <string name="WalletConnect_RequestFailedDescription">문제가 발생하여 요청을 완료할 수 없습니다</string>
     <string name="Watch_Monero_Warning">Monero 워치 지갑은 입금 거래만 표시합니다. 표시된 잔액이 정확하지 않을 수 있습니다.</string>
+    <string name="Send_Error_NodeUnreachable">노드에 도달할 수 없습니다. 연결을 확인하고 다시 시도하세요.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1801,4 +1801,5 @@
     <string name="PasskeyTerms_DeviceDependency_Description">O acesso requer seu dispositivo. Perder o acesso pode resultar na perda de fundos.</string>
     <string name="PasskeyTerms_LimitedAccess_Description">Pode não funcionar em todos os dispositivos ou plataformas.</string>
     <string name="PasskeyTerms_Responsibility_Description">Você é responsável pelo acesso ao seu dispositivo. A Unstoppable não pode recuperar esta carteira se o acesso for perdido.</string>
+    <string name="Send_Error_NodeUnreachable">Não foi possível alcançar o nó. Verifique sua conexão e tente novamente.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1803,4 +1803,5 @@
     <string name="PasskeyTerms_DeviceDependency_Description">Для доступа требуется ваше устройство. Потеря доступа может привести к потере средств.</string>
     <string name="PasskeyTerms_LimitedAccess_Description">Может работать не на всех устройствах или платформах.</string>
     <string name="PasskeyTerms_Responsibility_Description">Вы несёте ответственность за доступ к вашему устройству. Unstoppable не сможет восстановить этот кошелёк, если доступ будет утерян.</string>
+    <string name="Send_Error_NodeUnreachable">Не удалось подключиться к узлу. Проверьте подключение и попробуйте снова.</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1797,4 +1797,5 @@
     <string name="WalletConnect_Safe">Güvenli</string>
     <string name="WalletConnect_TokenAllowance">Token İzni</string>
     <string name="Watch_Monero_Warning">Monero izleme cüzdanı yalnızca gelen işlemleri gösterir. Görüntülenen bakiye yanlış olabilir.</string>
+    <string name="Send_Error_NodeUnreachable">Düğüme ulaşılamadı. Lütfen bağlantınızı kontrol edin ve tekrar deneyin.</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -1796,4 +1796,5 @@
     <string name="PasskeyTerms_LimitedAccess_Description">可能无法在所有设备或平台上运行。</string>
     <string name="PasskeyTerms_Responsibility_Description">您需要对设备的访问权限负责。如果访问权限丢失，Unstoppable 无法恢复此钱包。</string>
     <string name="Restore_SelectNetwork_EvmPrivateKey_Subtitle">Ethereum、Arbitrum、Optimism…</string>
+    <string name="Send_Error_NodeUnreachable">无法连接到节点。请检查您的连接并重试。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -560,6 +560,8 @@
     <string name="Send_UnexpectedError">Unexpected error</string>
     <string name="Send_UnexpectedError_Description">Something went wrong while sending your transaction. Please try again or copy the error code and contact support.</string>
 
+    <string name="Send_Error_NodeUnreachable">Could not reach the node. Please check your connection and try again.</string>
+
     <string name="Send_Warning_LowFee">Warning! Risk of getting stuck</string>
     <string name="Send_Error_LowFee">Fee Error</string>
     <string name="Send_Error_LowFee_Description">Fee Rate is too low.</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,7 +70,7 @@ unstoppableDomains = "v7.1.0"
 
 # Wallet Kits
 moneroKit = "eff5f66"
-zanoKit = "4bf2274"
+zanoKit = "c08505d"
 stellarKit = "09a8a96"
 tonKit = "947c48a"
 bitcoinKit = "7a552c4"

--- a/translation_snapshot.json
+++ b/translation_snapshot.json
@@ -1073,6 +1073,7 @@
     "Send_Error_LowFee_Description": "Fee Rate is too low.",
     "Send_Error_MaximumAmount": "Max. amount %s",
     "Send_Error_MinimumAmount": "Min. amount %s",
+    "Send_Error_NodeUnreachable": "Could not reach the node. Please check your connection and try again.",
     "Send_Error_SendToSelf": "Sending %s to your own address is not allowed. Please enter a different recipient address.",
     "Send_Error_UnsupportedAddress": "Time locking works only when sending to payment addresses starting with 1... (aka BIP44 addresses)",
     "Send_Fee": "Fee",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sending now shows a specific error when the network node cannot be reached.
  - Error guidance prompts you to check your connection and try again.

- **Localization**
  - Added the node connection error message in English, German, Spanish, Persian, French, Korean, Brazilian Portuguese, Russian, Turkish, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->