### PR TITLE
Add coin control for Monero

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,7 +66,7 @@ web3j = "5.0.2"
 unstoppableDomains = "v7.1.0"
 
 # Wallet Kits
-moneroKit = "0bab15a"
+moneroKit = "fd1d2d1"
 zanoKit = "4bf2274"
 stellarKit = "09a8a96"
 tonKit = "947c48a"

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/Interfaces.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/Interfaces.kt
@@ -503,7 +503,7 @@ interface ISendStellarAdapter {
 
 interface ISendMoneroAdapter {
     val balanceData: BalanceData
-    val unspentOutputs: List<MoneroUnspentOutput>
+    suspend fun getUnspentOutputs(): List<MoneroUnspentOutput>
     suspend fun send(amount: BigDecimal, address: String, memo: String?, selectedOutputs: List<String>? = null): String
     suspend fun estimateFee(amount: BigDecimal, address: String, memo: String?) : BigDecimal
 }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/Interfaces.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/Interfaces.kt
@@ -503,9 +503,18 @@ interface ISendStellarAdapter {
 
 interface ISendMoneroAdapter {
     val balanceData: BalanceData
-    suspend fun send(amount: BigDecimal, address: String, memo: String?): String
+    val unspentOutputs: List<MoneroUnspentOutput>
+    suspend fun send(amount: BigDecimal, address: String, memo: String?, selectedOutputs: List<String>? = null): String
     suspend fun estimateFee(amount: BigDecimal, address: String, memo: String?) : BigDecimal
 }
+
+data class MoneroUnspentOutput(
+    val keyImage: String,
+    val amount: BigDecimal,
+    val txHash: String,
+    val address: String,
+    val timestamp: Long?,
+)
 
 interface ISendZanoAdapter {
     val balanceData: BalanceData

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/adapters/MoneroAdapter.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/adapters/MoneroAdapter.kt
@@ -54,10 +54,10 @@ class MoneroAdapter(
     override val balanceData: BalanceData
         get() = balance.toBalanceData()
 
-    override val balanceStateUpdatedFlowable: Flowable<Unit>
+    override val balanceUpdatedFlowable: Flowable<Unit>
         get() = balanceUpdatedSubject.toFlowable(BackpressureStrategy.BUFFER)
 
-    override val balanceUpdatedFlowable: Flowable<Unit>
+    override val balanceStateUpdatedFlowable: Flowable<Unit>
         get() = balanceStateUpdatedSubject.toFlowable(BackpressureStrategy.BUFFER)
 
     override val receiveAddress: String

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/adapters/MoneroAdapter.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/adapters/MoneroAdapter.kt
@@ -12,6 +12,7 @@ import io.horizontalsystems.walletkit.core.IBalanceAdapter
 import io.horizontalsystems.walletkit.core.IReceiveAdapter
 import io.horizontalsystems.walletkit.core.ISendMoneroAdapter
 import io.horizontalsystems.walletkit.core.ITransactionsAdapter
+import io.horizontalsystems.walletkit.core.MoneroUnspentOutput
 import io.horizontalsystems.walletkit.core.managers.MoneroNodeManager.MoneroNode
 import io.horizontalsystems.walletkit.core.managers.RestoreSettings
 import io.horizontalsystems.walletkit.entities.AccountOrigin
@@ -107,9 +108,30 @@ class MoneroAdapter(
     override val debugInfo: String
         get() = ""
 
-    override suspend fun send(amount: BigDecimal, address: String, memo: String?): String {
+    override val unspentOutputs: List<MoneroUnspentOutput>
+        get() {
+            val timestamps = kit.allTransactionsFlow.value.associate { it.hash to it.timestamp }
+            return kit.getUnspentOutputs()
+                .filter { it.unlocked && !it.frozen }
+                .map { output ->
+                    MoneroUnspentOutput(
+                        keyImage = output.keyImage,
+                        amount = output.amount.scaledDown(DECIMALS),
+                        txHash = output.txHash,
+                        address = kit.getSubaddress(0, output.subaddressIndex)?.address ?: "",
+                        timestamp = timestamps[output.txHash]
+                    )
+                }
+        }
+
+    override suspend fun send(
+        amount: BigDecimal,
+        address: String,
+        memo: String?,
+        selectedOutputs: List<String>?
+    ): String {
         val amountInPiconero = amount.movePointRight(DECIMALS).toLong()
-        return kit.send(amountInPiconero, address, memo)
+        return kit.send(amountInPiconero, address, memo, selectedOutputs)
     }
 
     override suspend fun estimateFee(

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/adapters/MoneroAdapter.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/adapters/MoneroAdapter.kt
@@ -28,6 +28,7 @@ import io.reactivex.Flowable
 import io.reactivex.subjects.PublishSubject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import java.math.BigDecimal
@@ -108,21 +109,22 @@ class MoneroAdapter(
     override val debugInfo: String
         get() = ""
 
-    override val unspentOutputs: List<MoneroUnspentOutput>
-        get() {
-            val timestamps = kit.allTransactionsFlow.value.associate { it.hash to it.timestamp }
-            return kit.getUnspentOutputs()
-                .filter { it.unlocked && !it.frozen }
-                .map { output ->
-                    MoneroUnspentOutput(
-                        keyImage = output.keyImage,
-                        amount = output.amount.scaledDown(DECIMALS),
-                        txHash = output.txHash,
-                        address = kit.getSubaddress(0, output.subaddressIndex)?.address ?: "",
-                        timestamp = timestamps[output.txHash]
-                    )
-                }
-        }
+    // JNI: refreshes the coins list under the wallet2 mutex, which the background
+    // refresh can hold for seconds - never call on the main thread
+    override suspend fun getUnspentOutputs(): List<MoneroUnspentOutput> = withContext(Dispatchers.IO) {
+        val timestamps = kit.allTransactionsFlow.value.associate { it.hash to it.timestamp }
+        kit.getUnspentOutputs()
+            .filter { it.unlocked && !it.frozen }
+            .map { output ->
+                MoneroUnspentOutput(
+                    keyImage = output.keyImage,
+                    amount = output.amount.scaledDown(DECIMALS),
+                    txHash = output.txHash,
+                    address = kit.getSubaddress(0, output.subaddressIndex)?.address ?: "",
+                    timestamp = timestamps[output.txHash]
+                )
+            }
+    }
 
     override suspend fun send(
         amount: BigDecimal,

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/managers/LocalStorageManager.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/managers/LocalStorageManager.kt
@@ -103,7 +103,7 @@ class LocalStorageManager(
     private val ENABLED_PAID_ACTIONS = "enabled_paid_actions"
 
     private val coroutineScope = CoroutineScope(Dispatchers.Default)
-    private val _utxoExpertModeEnabledFlow = MutableStateFlow(false)
+    private val _utxoExpertModeEnabledFlow = MutableStateFlow(preferences.getBoolean(UTXO_EXPERT_MODE, false))
     override val utxoExpertModeEnabledFlow = _utxoExpertModeEnabledFlow
 
     private val _marketSignalsStateChangedFlow =  MutableSharedFlow<Boolean>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/amount/SendAmountService.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/amount/SendAmountService.kt
@@ -54,6 +54,9 @@ class SendAmountService(
         )
     }
 
+    // mutated from the UI thread and background collectors (e.g. Monero account
+    // switches); all mutators are serialized to keep validation consistent
+    @Synchronized
     fun setAmount(amount: BigDecimal?) {
         this.amount = amount
 
@@ -62,6 +65,7 @@ class SendAmountService(
         emitState()
     }
 
+    @Synchronized
     fun setMinimumSendAmount(minimumSendAmount: BigDecimal?) {
         this.minimumSendAmount = minimumSendAmount
 
@@ -70,6 +74,7 @@ class SendAmountService(
         emitState()
     }
 
+    @Synchronized
     fun setAvailableBalance(availableBalance: BigDecimal) {
         this.availableBalance = availableBalance
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/amount/SendAmountService.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/amount/SendAmountService.kt
@@ -9,7 +9,7 @@ import java.math.BigDecimal
 class SendAmountService(
     private val amountValidator: AmountValidator,
     private val coinCode: String,
-    private val availableBalance: BigDecimal,
+    private var availableBalance: BigDecimal,
     private val leaveSomeBalanceForFee: Boolean = false
 ) {
     private var amount: BigDecimal? = null
@@ -64,6 +64,14 @@ class SendAmountService(
 
     fun setMinimumSendAmount(minimumSendAmount: BigDecimal?) {
         this.minimumSendAmount = minimumSendAmount
+
+        validateAmount()
+
+        emitState()
+    }
+
+    fun setAvailableBalance(availableBalance: BigDecimal) {
+        this.availableBalance = availableBalance
 
         validateAmount()
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/bitcoin/SendBitcoinScreen.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/bitcoin/SendBitcoinScreen.kt
@@ -48,6 +48,7 @@ import io.horizontalsystems.walletkit.ui.compose.ComposeAppTheme
 import io.horizontalsystems.walletkit.ui.compose.TranslatableString
 import io.horizontalsystems.walletkit.ui.compose.components.ButtonPrimaryYellow
 import io.horizontalsystems.walletkit.ui.compose.components.HSpacer
+import io.horizontalsystems.walletkit.ui.compose.components.HsDivider
 import io.horizontalsystems.walletkit.ui.compose.components.MenuItem
 import io.horizontalsystems.walletkit.ui.compose.components.RowUniversal
 import io.horizontalsystems.walletkit.ui.compose.components.VSpacer
@@ -209,6 +210,7 @@ fun SendBitcoinScreen(
                             navigation.add(UtxoExpertModePage)
                         }
                     )
+                    HsDivider(modifier = Modifier.fillMaxWidth())
                 }
                 HSFeeRaw(
                     coinCode = wallet.coin.code,

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/bitcoin/utxoexpert/UtxoExpertModeScreen.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/bitcoin/utxoexpert/UtxoExpertModeScreen.kt
@@ -164,9 +164,9 @@ private fun UtxoInfoCell(
 ) {
     RowUniversal(
         modifier = Modifier
-            .height(64.dp)
             .fillMaxWidth()
             .padding(horizontal = 16.dp),
+        verticalPadding = 12.dp,
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/bitcoin/utxoexpert/UtxoExpertModeScreen.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/bitcoin/utxoexpert/UtxoExpertModeScreen.kt
@@ -124,7 +124,7 @@ fun UtxoExpertModeScreen(
 }
 
 @Composable
-private fun UtxoList(
+fun UtxoList(
     utxos: List<UtxoExpertModeModule.UnspentOutputViewItem>,
     onItemClicked: (String) -> Unit,
 ) {
@@ -157,7 +157,7 @@ private fun UtxoList(
 }
 
 @Composable
-private fun UtxoInfoCell(
+fun UtxoInfoCell(
     title: String,
     value: String?,
     subValue: String?
@@ -188,7 +188,7 @@ private fun UtxoInfoCell(
 }
 
 @Composable
-private fun UtxoCell(
+fun UtxoCell(
     id: String,
     selected: Boolean,
     showTopBorder: Boolean,

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroAdvancedSettingsScreen.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroAdvancedSettingsScreen.kt
@@ -1,0 +1,79 @@
+package io.horizontalsystems.walletkit.modules.send.monero
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.compose.viewModel
+import io.horizontalsystems.walletkit.R
+import io.horizontalsystems.walletkit.core.App
+import io.horizontalsystems.walletkit.core.ILocalStorage
+import io.horizontalsystems.walletkit.core.ViewModelUiState
+import io.horizontalsystems.walletkit.modules.send.bitcoin.advanced.UtxoSwitch
+import io.horizontalsystems.walletkit.ui.compose.components.CellUniversalLawrenceSection
+import io.horizontalsystems.walletkit.ui.compose.components.InfoText
+import io.horizontalsystems.walletkit.ui.compose.components.VSpacer
+import io.horizontalsystems.walletkit.uiv3.components.HSScaffold
+
+class SendMoneroAdvancedSettingsViewModel(
+    private val localStorage: ILocalStorage,
+) : ViewModelUiState<SendMoneroAdvancedSettingsViewModel.UiState>() {
+
+    private var utxoExpertModeEnabled = localStorage.utxoExpertModeEnabled
+
+    override fun createState() = UiState(
+        utxoExpertModeEnabled = utxoExpertModeEnabled,
+    )
+
+    fun setUtxoExpertMode(enabled: Boolean) {
+        utxoExpertModeEnabled = enabled
+        localStorage.utxoExpertModeEnabled = enabled
+        emitState()
+    }
+
+    data class UiState(
+        val utxoExpertModeEnabled: Boolean,
+    )
+
+    class Factory : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return SendMoneroAdvancedSettingsViewModel(App.localStorage) as T
+        }
+    }
+}
+
+@Composable
+fun SendMoneroAdvancedSettingsScreen(onBack: () -> Unit) {
+    val viewModel: SendMoneroAdvancedSettingsViewModel = viewModel(
+        factory = SendMoneroAdvancedSettingsViewModel.Factory()
+    )
+    val uiState = viewModel.uiState
+
+    HSScaffold(
+        title = stringResource(R.string.Send_Advanced),
+        onBack = onBack,
+    ) {
+        Column(
+            modifier = Modifier.verticalScroll(rememberScrollState())
+        ) {
+            VSpacer(12.dp)
+            CellUniversalLawrenceSection(
+                listOf {
+                    UtxoSwitch(
+                        enabled = uiState.utxoExpertModeEnabled,
+                        onChange = { viewModel.setUtxoExpertMode(it) }
+                    )
+                }
+            )
+            InfoText(
+                text = stringResource(R.string.Send_Utxo_Description),
+            )
+        }
+    }
+}

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroFeeService.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroFeeService.kt
@@ -1,7 +1,9 @@
 package io.horizontalsystems.walletkit.modules.send.monero
 
+import android.util.Log
 import io.horizontalsystems.walletkit.core.ISendMoneroAdapter
 import io.horizontalsystems.walletkit.core.ServiceState
+import io.horizontalsystems.walletkit.core.managers.ConnectivityManager
 import io.horizontalsystems.walletkit.entities.Address
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -14,8 +16,12 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.math.BigDecimal
+import java.net.UnknownHostException
 
-class SendMoneroFeeService(private val adapter: ISendMoneroAdapter) : ServiceState<SendMoneroFeeService.State>(), AutoCloseable {
+class SendMoneroFeeService(
+    private val adapter: ISendMoneroAdapter,
+    private val connectivityManager: ConnectivityManager,
+) : ServiceState<SendMoneroFeeService.State>(), AutoCloseable {
     private var memo: String? = null
     private var address: Address? = null
     private var amount: BigDecimal? = null
@@ -26,6 +32,14 @@ class SendMoneroFeeService(private val adapter: ISendMoneroAdapter) : ServiceSta
     private val mutex = Mutex()
     private val coroutineScope = CoroutineScope(Dispatchers.Default)
     private var estimateFeeJob: Job? = null
+
+    init {
+        coroutineScope.launch {
+            connectivityManager.networkAvailabilityFlow.collect {
+                refreshFeeAndEmitState()
+            }
+        }
+    }
 
     override fun createState() = State(
         fee = fee,
@@ -41,6 +55,18 @@ class SendMoneroFeeService(private val adapter: ISendMoneroAdapter) : ServiceSta
         estimateFeeJob?.cancel()
         estimateFeeJob = coroutineScope.launch {
             if (amount != null && address != null) {
+                // the native fee estimator blocks on daemon RPC and cannot be
+                // cancelled, so fail fast while there is no network at all
+                if (!connectivityManager.isConnected) {
+                    mutex.withLock {
+                        fee = null
+                        error = UnknownHostException()
+                        inProgress = false
+                        emitState()
+                    }
+                    return@launch
+                }
+
                 mutex.withLock {
                     inProgress = true
                     error = null
@@ -60,6 +86,7 @@ class SendMoneroFeeService(private val adapter: ISendMoneroAdapter) : ServiceSta
                     } catch (e: CancellationException) {
                         throw e
                     } catch (e: Throwable) {
+                        Log.e("SendMoneroFeeService", "estimateFee attempt ${attempts + 1} failed", e)
                         lastError = e
                         attempts++
                         if (attempts < MAX_FEE_ATTEMPTS) delay(500)

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroFeeService.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroFeeService.kt
@@ -47,6 +47,10 @@ class SendMoneroFeeService(
         error = error,
     )
 
+    // triggered concurrently from the view model's collectors and the
+    // connectivity collector; the monitor makes each cancel+launch pair atomic
+    // so exactly one estimate job survives - the latest
+    @Synchronized
     private fun refreshFeeAndEmitState() {
         val amount = amount
         val address = address
@@ -110,18 +114,21 @@ class SendMoneroFeeService(
         }
     }
 
+    @Synchronized
     fun setAmount(amount: BigDecimal?) {
         this.amount = amount
 
         refreshFeeAndEmitState()
     }
 
+    @Synchronized
     fun setAddress(address: Address?) {
         this.address = address
 
         refreshFeeAndEmitState()
     }
 
+    @Synchronized
     fun setMemo(memo: String?) {
         this.memo = memo
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroModule.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroModule.kt
@@ -20,6 +20,7 @@ object SendMoneroModule {
         private val hideAddress: Boolean,
     ) : ViewModelProvider.Factory {
         val adapter = App.adapterManager.getAdapterForWallet<ISendMoneroAdapter>(wallet) ?: throw IllegalStateException("ISendMoneroAdapter is null")
+        val balanceAdapter = App.adapterManager.getBalanceAdapterForWallet(wallet) ?: throw IllegalStateException("IBalanceAdapter is null")
 
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -32,7 +33,7 @@ object SendMoneroModule {
                 availableBalance = adapter.balanceData.available
             )
             val addressService = SendMoneroAddressService()
-            val feeService = SendMoneroFeeService(adapter)
+            val feeService = SendMoneroFeeService(adapter, App.connectivityManager)
             val xRateService = XRateService(App.marketKit, App.currencyManager.baseCurrency)
             val feeToken = App.coinManager.getToken(TokenQuery(BlockchainType.Monero, TokenType.Native)) ?: throw IllegalArgumentException()
 
@@ -49,7 +50,9 @@ object SendMoneroModule {
                 addressService,
                 feeService,
                 App.contactsRepository,
-                App.recentAddressManager
+                App.recentAddressManager,
+                balanceAdapter,
+                App.localStorage
             ) as T
         }
     }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroScreen.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroScreen.kt
@@ -1,17 +1,25 @@
 package io.horizontalsystems.walletkit.modules.send.monero
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.horizontalsystems.walletkit.R
+import io.horizontalsystems.walletkit.core.AdapterState
 import io.horizontalsystems.walletkit.core.providers.Translator
 import io.horizontalsystems.walletkit.modules.address.AddressParserModule
 import io.horizontalsystems.walletkit.modules.address.AddressParserViewModel
@@ -19,18 +27,53 @@ import io.horizontalsystems.walletkit.modules.address.HSAddressCell
 import io.horizontalsystems.walletkit.modules.amount.AmountInputModeViewModel
 import io.horizontalsystems.walletkit.modules.amount.HSAmountInput
 import io.horizontalsystems.walletkit.modules.availablebalance.AvailableBalance
-import io.horizontalsystems.walletkit.modules.fee.HSFee
+import io.horizontalsystems.walletkit.modules.fee.HSFeeRaw
 import io.horizontalsystems.walletkit.modules.memo.HSMemoInput
 import io.horizontalsystems.walletkit.modules.memo.MemoVisibility
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.nav3.HSPage
 import io.horizontalsystems.walletkit.modules.send.AddressRiskySheet
 import io.horizontalsystems.walletkit.modules.send.SendConfirmationPage
-import io.horizontalsystems.walletkit.modules.send.SendScreen
+import io.horizontalsystems.walletkit.modules.send.SendPage
+import io.horizontalsystems.walletkit.modules.send.bitcoin.UtxoCell
+import io.horizontalsystems.walletkit.modules.send.bitcoin.advanced.FeeRateCaution
+import io.horizontalsystems.walletkit.modules.send.monero.utxoexpert.MoneroUtxoExpertModeScreen
+import io.horizontalsystems.walletkit.ui.compose.ComposeAppTheme
+import io.horizontalsystems.walletkit.ui.compose.TranslatableString
 import io.horizontalsystems.walletkit.ui.compose.components.ButtonPrimaryYellow
+import io.horizontalsystems.walletkit.ui.compose.components.HsDivider
+import io.horizontalsystems.walletkit.ui.compose.components.MenuItem
 import io.horizontalsystems.walletkit.ui.compose.components.VSpacer
+import io.horizontalsystems.walletkit.uiv3.components.HSScaffold
 import java.math.BigDecimal
 import kotlin.reflect.KClass
+
+data object SendMoneroAdvancedSettingsPage : HSPage() {
+    @Composable
+    override fun GetContent(navigation: HSNavigation) {
+        SendMoneroAdvancedSettingsScreen(
+            onBack = { navigation.removeLastOrNull() }
+        )
+    }
+}
+
+data object MoneroUtxoExpertModePage : HSPage() {
+    @Composable
+    override fun GetContent(navigation: HSNavigation) {
+        val viewModel = navigation.viewModelForScreen<SendMoneroViewModel>(SendPage::class)
+        MoneroUtxoExpertModeScreen(
+            adapter = viewModel.adapter,
+            token = viewModel.wallet.token,
+            customUnspentOutputs = viewModel.customUnspentOutputs,
+            updateUnspentOutputs = {
+                viewModel.updateCustomUnspentOutputs(it)
+            },
+            onBackClick = {
+                navigation.removeLastOrNull()
+            }
+        )
+    }
+}
 
 @Composable
 fun SendMoneroScreen(
@@ -66,10 +109,22 @@ fun SendMoneroScreen(
         focusRequester.requestFocus()
     }
 
-    SendScreen(
+    HSScaffold(
         title = title,
-        onBack = { navigation.removeLastOrNull() }
+        onBack = { navigation.removeLastOrNull() },
+        menuItems = listOf(
+            MenuItem(
+                title = TranslatableString.ResString(R.string.SendEvmSettings_Title),
+                icon = R.drawable.manage_24,
+                onClick = { navigation.add(SendMoneroAdvancedSettingsPage) }
+            ),
+        ),
     ) {
+        Column(
+            modifier = Modifier
+                .verticalScroll(rememberScrollState())
+                .fillMaxSize()
+        ) {
         VSpacer(16.dp)
         if (uiState.showAddressInput) {
             HSAddressCell(
@@ -117,14 +172,38 @@ fun SendMoneroScreen(
         }
 
         VSpacer(16.dp)
-        HSFee(
-            coinCode = viewModel.feeToken.coin.code,
-            coinDecimal = viewModel.feeTokenMaxAllowedDecimals,
-            fee = fee,
-            amountInputType = amountInputType,
-            rate = viewModel.feeCoinRate,
-            navigation = navigation,
-        )
+        Column(
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .clip(RoundedCornerShape(16.dp))
+                .background(ComposeAppTheme.colors.lawrence)
+                .padding(vertical = 8.dp)
+        ) {
+            uiState.utxoData?.let { utxoData ->
+                UtxoCell(
+                    utxoData = utxoData,
+                    onClick = {
+                        navigation.add(MoneroUtxoExpertModePage)
+                    }
+                )
+                HsDivider(modifier = Modifier.fillMaxWidth())
+            }
+            HSFeeRaw(
+                coinCode = viewModel.feeToken.coin.code,
+                coinDecimal = viewModel.feeTokenMaxAllowedDecimals,
+                fee = fee,
+                amountInputType = amountInputType,
+                rate = viewModel.feeCoinRate,
+                navigation = navigation,
+            )
+        }
+
+        uiState.feeCaution?.let { caution ->
+            FeeRateCaution(
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp),
+                feeRateCaution = caution
+            )
+        }
 
         val forResult = navigation.slideFromBottomForResult<AddressRiskySheet.Result>(
             {
@@ -142,7 +221,11 @@ fun SendMoneroScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 16.dp),
-            title = stringResource(R.string.Button_Next),
+            title = when (uiState.syncState) {
+                is AdapterState.Synced -> stringResource(R.string.Button_Next)
+                is AdapterState.NotSynced -> stringResource(R.string.Swap_ErrorWalletNotSynced)
+                else -> stringResource(R.string.Swap_ErrorWalletSyncing)
+            },
             onClick = {
                 if (riskyAddress) {
                     keyboardController?.hide()
@@ -153,6 +236,7 @@ fun SendMoneroScreen(
             },
             enabled = proceedEnabled
         )
+        }
     }
 }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroViewModel.kt
@@ -128,12 +128,12 @@ class SendMoneroViewModel(
         addressService.setAddress(address)
     }
 
-    private fun handleBalanceAdapterUpdate() {
+    private suspend fun handleBalanceAdapterUpdate() {
         balanceState = balanceAdapter.balanceState
 
         // while the wallet scans, outputs appear and disappear; drop selections
         // that no longer reference an existing spendable output
-        val outputs = adapter.unspentOutputs
+        val outputs = adapter.getUnspentOutputs()
         customUnspentOutputs?.let { selection ->
             val validKeyImages = outputs.map { it.keyImage }.toSet()
             val pruned = selection.filter { it.keyImage in validKeyImages }
@@ -179,10 +179,10 @@ class SendMoneroViewModel(
         }
     }
 
-    private fun updateUtxoData() {
+    private suspend fun updateUtxoData() {
         // unlike Bitcoin, wallet2 does not reveal which inputs auto-selection will use
         // before the transaction is created, so Auto mode shows only the total count
-        val totalOutputs = adapter.unspentOutputs.size
+        val totalOutputs = adapter.getUnspentOutputs().size
         utxoData = SendBitcoinModule.UtxoData(
             type = if (customUnspentOutputs == null) SendBitcoinModule.UtxoType.Auto else SendBitcoinModule.UtxoType.Manual,
             value = customUnspentOutputs?.let { "${it.size} / $totalOutputs" } ?: "$totalOutputs"

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroViewModel.kt
@@ -26,7 +26,9 @@ import io.horizontalsystems.walletkit.modules.send.bitcoin.SendBitcoinModule
 import io.horizontalsystems.walletkit.modules.xrate.XRateService
 import io.horizontalsystems.walletkit.ui.compose.TranslatableString
 import io.horizontalsystems.marketkit.models.Token
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
@@ -120,9 +122,19 @@ class SendMoneroViewModel(
             merge(
                 balanceAdapter.balanceStateUpdatedFlowable.asFlow(),
                 balanceAdapter.balanceUpdatedFlowable.asFlow()
-            ).collect {
-                handleBalanceAdapterUpdate()
-            }
+            )
+                .catch { logger.warning("balance updates flow failed", it) }
+                .collect {
+                    // the handler reaches JNI; one native error must not kill
+                    // this collector for the rest of the screen's lifetime
+                    try {
+                        handleBalanceAdapterUpdate()
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Throwable) {
+                        logger.warning("handleBalanceAdapterUpdate failed", e)
+                    }
+                }
         }
 
         addressService.setAddress(address)

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroViewModel.kt
@@ -7,9 +7,13 @@ import androidx.lifecycle.viewModelScope
 import io.horizontalsystems.walletkit.R
 import io.horizontalsystems.walletkit.core.App
 import io.horizontalsystems.walletkit.core.AppLogger
+import io.horizontalsystems.walletkit.core.AdapterState
 import io.horizontalsystems.walletkit.core.HSCaution
+import io.horizontalsystems.walletkit.core.IBalanceAdapter
+import io.horizontalsystems.walletkit.core.ILocalStorage
 import io.horizontalsystems.walletkit.core.ISendMoneroAdapter
 import io.horizontalsystems.walletkit.core.LocalizedException
+import io.horizontalsystems.walletkit.core.MoneroUnspentOutput
 import io.horizontalsystems.walletkit.core.ViewModelUiState
 import io.horizontalsystems.walletkit.core.managers.RecentAddressManager
 import io.horizontalsystems.walletkit.entities.Address
@@ -18,12 +22,15 @@ import io.horizontalsystems.walletkit.modules.amount.SendAmountService
 import io.horizontalsystems.walletkit.modules.contacts.ContactsRepository
 import io.horizontalsystems.walletkit.modules.send.SendConfirmationData
 import io.horizontalsystems.walletkit.modules.send.SendResult
+import io.horizontalsystems.walletkit.modules.send.bitcoin.SendBitcoinModule
 import io.horizontalsystems.walletkit.modules.xrate.XRateService
 import io.horizontalsystems.walletkit.ui.compose.TranslatableString
 import io.horizontalsystems.marketkit.models.BlockchainType
 import io.horizontalsystems.marketkit.models.Token
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.withContext
 import java.math.BigDecimal
 import java.net.UnknownHostException
@@ -32,7 +39,7 @@ class SendMoneroViewModel(
     val wallet: Wallet,
     private val sendToken: Token,
     val feeToken: Token,
-    private val adapter: ISendMoneroAdapter,
+    val adapter: ISendMoneroAdapter,
     val coinMaxAllowedDecimals: Int,
     private val xRateService: XRateService,
     private val address: Address,
@@ -42,6 +49,8 @@ class SendMoneroViewModel(
     private val feeService: SendMoneroFeeService,
     private val contactsRepo: ContactsRepository,
     private val recentAddressManager: RecentAddressManager,
+    private val balanceAdapter: IBalanceAdapter,
+    private val localStorage: ILocalStorage,
 ) : ViewModelUiState<SendMoneroUiState>() {
     val blockchainType = wallet.token.blockchainType
     val feeTokenMaxAllowedDecimals = feeToken.decimals
@@ -51,6 +60,13 @@ class SendMoneroViewModel(
     private var addressState = addressService.stateFlow.value
     private var feeState = feeService.stateFlow.value
     private var memo: String? = null
+
+    private var utxoData: SendBitcoinModule.UtxoData? = null
+    private var utxoExpertModeEnabled = localStorage.utxoExpertModeEnabled
+    private var balanceState = balanceAdapter.balanceState
+
+    var customUnspentOutputs: List<MoneroUnspentOutput>? = null
+        private set
 
     var coinRate by mutableStateOf(xRateService.getRate(sendToken.coin.uid))
         private set
@@ -89,8 +105,50 @@ class SendMoneroViewModel(
                 feeCoinRate = it
             }
         }
+        viewModelScope.launch(Dispatchers.Default) {
+            updateUtxoData()
+
+            emitState()
+        }
+        viewModelScope.launch(Dispatchers.Default) {
+            localStorage.utxoExpertModeEnabledFlow.collect { enabled ->
+                utxoExpertModeEnabled = enabled
+
+                emitState()
+            }
+        }
+        viewModelScope.launch(Dispatchers.Default) {
+            merge(
+                balanceAdapter.balanceStateUpdatedFlowable.asFlow(),
+                balanceAdapter.balanceUpdatedFlowable.asFlow()
+            ).collect {
+                handleBalanceAdapterUpdate()
+            }
+        }
 
         addressService.setAddress(address)
+    }
+
+    private fun handleBalanceAdapterUpdate() {
+        balanceState = balanceAdapter.balanceState
+
+        // while the wallet scans, outputs appear and disappear; drop selections
+        // that no longer reference an existing spendable output
+        val outputs = adapter.unspentOutputs
+        customUnspentOutputs?.let { selection ->
+            val validKeyImages = outputs.map { it.keyImage }.toSet()
+            val pruned = selection.filter { it.keyImage in validKeyImages }
+            if (pruned.size != selection.size) {
+                customUnspentOutputs = pruned.ifEmpty { null }
+            }
+        }
+
+        amountService.setAvailableBalance(
+            customUnspentOutputs?.sumOf { it.amount } ?: adapter.balanceData.available
+        )
+        updateUtxoData()
+
+        emitState()
     }
 
 
@@ -98,12 +156,39 @@ class SendMoneroViewModel(
         availableBalance = amountState.availableBalance,
         amountCaution = amountState.amountCaution,
         addressError = addressState.addressError,
-        canBeSend = amountState.canBeSend && addressState.canBeSend && feeState.fee != null,
+        canBeSend = amountState.canBeSend && addressState.canBeSend && feeState.fee != null && balanceState is AdapterState.Synced,
         showAddressInput = showAddressInput,
         fee = feeState.fee,
         feeInProgress = feeState.inProgress,
-        address = address
+        address = address,
+        utxoData = if (utxoExpertModeEnabled) utxoData else null,
+        syncState = balanceState,
+        feeCaution = feeState.error?.let { createCaution(it) },
     )
+
+    fun updateCustomUnspentOutputs(customUnspentOutputs: List<MoneroUnspentOutput>) {
+        this.customUnspentOutputs = customUnspentOutputs.ifEmpty { null }
+
+        amountService.setAvailableBalance(
+            this.customUnspentOutputs?.sumOf { it.amount } ?: adapter.balanceData.available
+        )
+
+        viewModelScope.launch(Dispatchers.Default) {
+            updateUtxoData()
+
+            emitState()
+        }
+    }
+
+    private fun updateUtxoData() {
+        // unlike Bitcoin, wallet2 does not reveal which inputs auto-selection will use
+        // before the transaction is created, so Auto mode shows only the total count
+        val totalOutputs = adapter.unspentOutputs.size
+        utxoData = SendBitcoinModule.UtxoData(
+            type = if (customUnspentOutputs == null) SendBitcoinModule.UtxoType.Auto else SendBitcoinModule.UtxoType.Manual,
+            value = customUnspentOutputs?.let { "${it.size} / $totalOutputs" } ?: "$totalOutputs"
+        )
+    }
 
     fun onEnterAmount(amount: BigDecimal?) {
         amountService.setAmount(amount)
@@ -165,7 +250,12 @@ class SendMoneroViewModel(
             sendResult = SendResult.Sending
             logger.info("sending tx")
 
-            adapter.send(amountState.amount!!, addressState.address?.hex!!, memo)
+            adapter.send(
+                amountState.amount!!,
+                addressState.address?.hex!!,
+                memo,
+                customUnspentOutputs?.map { it.keyImage }
+            )
 
             sendResult = SendResult.Sent()
             logger.info("success")
@@ -193,4 +283,7 @@ data class SendMoneroUiState(
     val fee: BigDecimal?,
     val feeInProgress: Boolean,
     val address: Address,
+    val utxoData: SendBitcoinModule.UtxoData?,
+    val syncState: AdapterState,
+    val feeCaution: HSCaution?,
 )

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroViewModel.kt
@@ -25,7 +25,6 @@ import io.horizontalsystems.walletkit.modules.send.SendResult
 import io.horizontalsystems.walletkit.modules.send.bitcoin.SendBitcoinModule
 import io.horizontalsystems.walletkit.modules.xrate.XRateService
 import io.horizontalsystems.walletkit.ui.compose.TranslatableString
-import io.horizontalsystems.marketkit.models.BlockchainType
 import io.horizontalsystems.marketkit.models.Token
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.merge
@@ -260,7 +259,7 @@ class SendMoneroViewModel(
             sendResult = SendResult.Sent()
             logger.info("success")
 
-            recentAddressManager.setRecentAddress(addressState.address!!, BlockchainType.Ton)
+            recentAddressManager.setRecentAddress(addressState.address!!, wallet.token.blockchainType)
         } catch (e: Throwable) {
             sendResult = SendResult.Failed(createCaution(e))
             logger.warning("failed", e)

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/utxoexpert/MoneroUtxoExpertModeScreen.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/utxoexpert/MoneroUtxoExpertModeScreen.kt
@@ -1,0 +1,111 @@
+package io.horizontalsystems.walletkit.modules.send.monero.utxoexpert
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import io.horizontalsystems.walletkit.R
+import io.horizontalsystems.walletkit.core.ISendMoneroAdapter
+import io.horizontalsystems.walletkit.core.MoneroUnspentOutput
+import io.horizontalsystems.walletkit.modules.send.bitcoin.utxoexpert.UtxoInfoCell
+import io.horizontalsystems.walletkit.modules.send.bitcoin.utxoexpert.UtxoList
+import io.horizontalsystems.walletkit.ui.compose.components.ButtonSecondaryTransparent
+import io.horizontalsystems.walletkit.ui.compose.components.CellUniversalLawrenceSection
+import io.horizontalsystems.walletkit.ui.compose.components.HsDivider
+import io.horizontalsystems.walletkit.uiv3.components.HSScaffold
+import io.horizontalsystems.marketkit.models.Token
+
+@Composable
+fun MoneroUtxoExpertModeScreen(
+    adapter: ISendMoneroAdapter,
+    token: Token,
+    customUnspentOutputs: List<MoneroUnspentOutput>?,
+    updateUnspentOutputs: (List<MoneroUnspentOutput>) -> Unit,
+    onBackClick: () -> Unit
+) {
+
+    val viewModel: MoneroUtxoExpertModeViewModel = viewModel(
+        factory = MoneroUtxoExpertModeViewModel.Factory(
+            adapter,
+            token,
+            customUnspentOutputs
+        )
+    )
+    val uiState = viewModel.uiState
+
+    HSScaffold(
+        title = stringResource(R.string.Send_Utxos),
+        onBack = onBackClick,
+        bottomBar = {
+            Box(
+                modifier = Modifier
+                    .height(62.dp)
+                    .systemBarsPadding()
+                    .fillMaxWidth()
+            ) {
+                HsDivider(modifier = Modifier.fillMaxWidth())
+                Row(
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .fillMaxSize(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    ButtonSecondaryTransparent(
+                        title = stringResource(id = R.string.Send_Utxo_UnselectAll),
+                        enabled = uiState.unselectAllIsEnabled,
+                        onClick = {
+                            viewModel.unselectAll()
+                            updateUnspentOutputs(viewModel.customOutputs)
+                        }
+                    )
+                    ButtonSecondaryTransparent(
+                        title = stringResource(id = R.string.Send_Utxo_SelectAll),
+                        onClick = {
+                            viewModel.selectAll()
+                            updateUnspentOutputs(viewModel.customOutputs)
+                        }
+                    )
+                }
+            }
+        }
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+        ) {
+            CellUniversalLawrenceSection {
+                UtxoInfoCell(
+                    title = stringResource(R.string.Send_Utxo_AvailableBalance),
+                    value = uiState.availableBalanceInfo.value,
+                    subValue = uiState.availableBalanceInfo.subValue
+                )
+            }
+            Box(
+                modifier = Modifier.weight(1f)
+            ) {
+                UtxoList(
+                    utxos = uiState.utxoItems,
+                    onItemClicked = {
+                        viewModel.onUnspentOutputClicked(it)
+                        updateUnspentOutputs(viewModel.customOutputs)
+                    }
+                )
+            }
+        }
+    }
+}

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/utxoexpert/MoneroUtxoExpertModeViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/utxoexpert/MoneroUtxoExpertModeViewModel.kt
@@ -1,0 +1,136 @@
+package io.horizontalsystems.walletkit.modules.send.monero.utxoexpert
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import cash.z.ecc.android.sdk.ext.collectWith
+import io.horizontalsystems.walletkit.core.App
+import io.horizontalsystems.walletkit.core.ISendMoneroAdapter
+import io.horizontalsystems.walletkit.core.MoneroUnspentOutput
+import io.horizontalsystems.walletkit.core.ViewModelUiState
+import io.horizontalsystems.walletkit.helpers.DateHelper
+import io.horizontalsystems.walletkit.modules.send.bitcoin.utxoexpert.UtxoExpertModeModule
+import io.horizontalsystems.walletkit.modules.xrate.XRateService
+import io.horizontalsystems.marketkit.models.Token
+import java.math.BigDecimal
+import java.util.Date
+
+class MoneroUtxoExpertModeViewModel(
+    adapter: ISendMoneroAdapter,
+    private val token: Token,
+    initialCustomUnspentOutputs: List<MoneroUnspentOutput>?,
+    xRateService: XRateService,
+) : ViewModelUiState<UtxoExpertModeModule.UiState>() {
+
+    private val unspentOutputs = adapter.unspentOutputs
+    private var unspentOutputViewItems = listOf<UtxoExpertModeModule.UnspentOutputViewItem>()
+    private var selectedUnspentOutputs = listOf<String>()
+    private var coinRate = xRateService.getRate(token.coin.uid)
+    private var availableBalanceInfo = UtxoExpertModeModule.InfoItem(
+        value = App.numberFormatter.formatCoinFull(BigDecimal.ZERO, token.coin.code, token.decimals),
+        subValue = "",
+    )
+
+    val customOutputs: List<MoneroUnspentOutput>
+        get() = unspentOutputs.filter { selectedUnspentOutputs.contains(it.keyImage) }
+
+    init {
+        initialCustomUnspentOutputs?.forEach {
+            selectedUnspentOutputs = selectedUnspentOutputs + it.keyImage
+        }
+        xRateService.getRateFlow(token.coin.uid).collectWith(viewModelScope) {
+            coinRate = it
+            setUnspentOutputViewItems()
+            emitState()
+        }
+        setAvailableBalanceInfo()
+        setUnspentOutputViewItems()
+        emitState()
+    }
+
+    override fun createState() = UtxoExpertModeModule.UiState(
+        availableBalanceInfo = availableBalanceInfo,
+        utxoItems = unspentOutputViewItems,
+        unselectAllIsEnabled = selectedUnspentOutputs.isNotEmpty(),
+    )
+
+    private fun setAvailableBalanceInfo() {
+        var totalCoinValue = BigDecimal.ZERO
+        unspentOutputs.forEach { utxo ->
+            if (selectedUnspentOutputs.isEmpty() || selectedUnspentOutputs.contains(utxo.keyImage)) {
+                totalCoinValue += utxo.amount
+            }
+        }
+        availableBalanceInfo = availableBalanceInfo.copy(
+            value = App.numberFormatter.formatCoinFull(totalCoinValue, token.coin.code, token.decimals),
+            subValue = coinRate?.let { rate ->
+                rate.copy(value = totalCoinValue.times(rate.value)).getFormattedFull()
+            } ?: "",
+        )
+    }
+
+    private fun setUnspentOutputViewItems() {
+        unspentOutputViewItems = unspentOutputs.map { utxo ->
+            UtxoExpertModeModule.UnspentOutputViewItem(
+                id = utxo.keyImage,
+                outputIndex = 0,
+                date = utxo.timestamp?.let {
+                    DateHelper.shortDate(Date(it * 1000), "MMM d", "MM/dd/yyyy")
+                } ?: "",
+                amountToken = App.numberFormatter.formatCoinFull(utxo.amount, token.coin.code, token.decimals),
+                amountFiat = coinRate?.let { rate ->
+                    rate.copy(value = utxo.amount.times(rate.value)).getFormattedFull()
+                } ?: "",
+                address = utxo.address,
+                selected = selectedUnspentOutputs.contains(utxo.keyImage),
+            )
+        }
+    }
+
+    private fun updateUtxoSelectedState() {
+        unspentOutputViewItems = unspentOutputViewItems.map { utxo ->
+            utxo.copy(selected = selectedUnspentOutputs.contains(utxo.id))
+        }
+    }
+
+    fun onUnspentOutputClicked(id: String) {
+        selectedUnspentOutputs = if (selectedUnspentOutputs.contains(id)) {
+            selectedUnspentOutputs.filter { it != id }
+        } else {
+            selectedUnspentOutputs + id
+        }
+        updateUtxoSelectedState()
+        setAvailableBalanceInfo()
+        emitState()
+    }
+
+    fun unselectAll() {
+        selectedUnspentOutputs = listOf()
+        updateUtxoSelectedState()
+        setAvailableBalanceInfo()
+        emitState()
+    }
+
+    fun selectAll() {
+        selectedUnspentOutputs = unspentOutputViewItems.map { it.id }
+        updateUtxoSelectedState()
+        setAvailableBalanceInfo()
+        emitState()
+    }
+
+    class Factory(
+        private val adapter: ISendMoneroAdapter,
+        private val token: Token,
+        private val customUnspentOutputs: List<MoneroUnspentOutput>?,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return MoneroUtxoExpertModeViewModel(
+                adapter = adapter,
+                token = token,
+                initialCustomUnspentOutputs = customUnspentOutputs,
+                xRateService = XRateService(App.marketKit, App.currencyManager.baseCurrency)
+            ) as T
+        }
+    }
+}

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/utxoexpert/MoneroUtxoExpertModeViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/utxoexpert/MoneroUtxoExpertModeViewModel.kt
@@ -12,6 +12,8 @@ import io.horizontalsystems.walletkit.helpers.DateHelper
 import io.horizontalsystems.walletkit.modules.send.bitcoin.utxoexpert.UtxoExpertModeModule
 import io.horizontalsystems.walletkit.modules.xrate.XRateService
 import io.horizontalsystems.marketkit.models.Token
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import java.math.BigDecimal
 import java.util.Date
 
@@ -22,7 +24,7 @@ class MoneroUtxoExpertModeViewModel(
     xRateService: XRateService,
 ) : ViewModelUiState<UtxoExpertModeModule.UiState>() {
 
-    private val unspentOutputs = adapter.unspentOutputs
+    private var unspentOutputs = listOf<MoneroUnspentOutput>()
     private var unspentOutputViewItems = listOf<UtxoExpertModeModule.UnspentOutputViewItem>()
     private var selectedUnspentOutputs = listOf<String>()
     private var coinRate = xRateService.getRate(token.coin.uid)
@@ -43,8 +45,13 @@ class MoneroUtxoExpertModeViewModel(
             setUnspentOutputViewItems()
             emitState()
         }
-        setAvailableBalanceInfo()
-        setUnspentOutputViewItems()
+        // the output list comes from JNI and must not be fetched on the main thread
+        viewModelScope.launch(Dispatchers.IO) {
+            unspentOutputs = adapter.getUnspentOutputs()
+            setAvailableBalanceInfo()
+            setUnspentOutputViewItems()
+            emitState()
+        }
         emitState()
     }
 


### PR DESCRIPTION
#9216 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Monero “Send Advanced” settings with persisted UTXO expert mode.
  - Introduced manual Monero UTXO selection (expert mode) with select-all/unselect-all and custom input selection during sending.
  - Updated the Monero send experience with a dedicated advanced settings flow, refined fee UI, and improved sync-aware primary action labeling.

- **Bug Fixes**
  - Fixed Monero balance update flow wiring so the correct notifications are emitted.
  - Improved Monero fee estimation to gracefully handle no-connectivity scenarios.
  - Enriched available UTXO listing with unlock/freeze filtering and transaction timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->