### PR TITLE
Skip server tracking for app-tracked swap records

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/history/SwapSyncService.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/history/SwapSyncService.kt
@@ -50,6 +50,10 @@ class SwapSyncService(
     }
 
     private suspend fun syncRecord(record: SwapRecord) {
+        // A tracking handle means the app advances this record through its own
+        // tracking service — the server tracker must leave it alone.
+        if (record.trackingHandle != null) return
+
         if (record.providerId == AllBridgeProvider.id) {
             syncAllBridgeRecord(record)
             return


### PR DESCRIPTION
A `trackingHandle` on a SwapRecord means the app advances the record through its own tracking service (the handle is set only by app-side confirm flows, never by the stock one). `SwapSyncService` was still submitting such records to the track server — for providers in its track map (e.g. 1inch) this produced pointless requests and, if the server ever answered, could fight the app's own settlement. Records with a handle are now skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented server synchronization from updating swap records already managed by the app’s tracking service.
  * Preserved existing tracking state for records with an active tracking handle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->