### PR TITLE
Fix crash when replaced transaction is already in block

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/adapters/BitcoinBaseAdapter.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/adapters/BitcoinBaseAdapter.kt
@@ -12,6 +12,7 @@ import io.horizontalsystems.bitcoincore.models.TransactionInfo
 import io.horizontalsystems.bitcoincore.models.TransactionStatus
 import io.horizontalsystems.bitcoincore.models.TransactionType
 import io.horizontalsystems.bitcoincore.rbf.ReplacementTransaction
+import io.horizontalsystems.bitcoincore.rbf.ReplacementTransactionBuilder
 import io.horizontalsystems.bitcoincore.rbf.ReplacementTransactionInfo
 import io.horizontalsystems.bitcoincore.storage.FullTransaction
 import io.horizontalsystems.bitcoincore.storage.UnspentOutput
@@ -237,12 +238,16 @@ abstract class BitcoinBaseAdapter(
         return kit.getRawTransaction(transactionHash)
     }
 
-    fun speedUpTransactionInfo(transactionHash: String): ReplacementTransactionInfo? {
-        return kit.speedUpTransactionInfo(transactionHash)
+    fun speedUpTransactionInfo(transactionHash: String): ReplacementTransactionInfo? = try {
+        kit.speedUpTransactionInfo(transactionHash)
+    } catch (e: ReplacementTransactionBuilder.BuildError) {
+        null
     }
 
-    fun cancelTransactionInfo(transactionHash: String): ReplacementTransactionInfo? {
-        return kit.cancelTransactionInfo(transactionHash)
+    fun cancelTransactionInfo(transactionHash: String): ReplacementTransactionInfo? = try {
+        kit.cancelTransactionInfo(transactionHash)
+    } catch (e: ReplacementTransactionBuilder.BuildError) {
+        null
     }
 
     fun speedUpTransaction(transactionHash: String, minFee: Long): Pair<ReplacementTransaction, BitcoinTransactionRecord> {


### PR DESCRIPTION
#9405 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of transaction speed-up and cancellation requests.
  * Returns no transaction details when a replacement transaction cannot be built, preventing errors from surfacing unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->