### PR TITLE
Show swap time for P2P providers

### DIFF
--- a/translation_snapshot.json
+++ b/translation_snapshot.json
@@ -1315,7 +1315,7 @@
     "Swap_ErrorWalletNotSynced": "Wallet Not Synced",
     "Swap_ErrorWalletSyncing": "Wallet is Syncing",
     "Swap_EstimatedTime": "Est. Time",
-    "Swap_EstimatedTimeDescription": "Approximate time to receive funds. Swap processing and transaction confirmations may take some time depending on the network and route.",
+    "Swap_EstimatedTimeDescription": "This is the estimated time required to complete the swap and receive your funds. The actual time may be shorter or longer depending on network conditions, transaction confirmations, and the selected swap route.",
     "Swap_FromAmountTitle": "You Pay",
     "Swap_MinimumReceived": "Guaranteed",
     "Swap_MinimumReceivedDescription": "This amount is in the process of validation. As soon as the transaction status is validated you will be able to use these coins. The minimum amount a user is going",

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/storage/AppDatabase.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/storage/AppDatabase.kt
@@ -57,6 +57,7 @@ import io.horizontalsystems.walletkit.core.storage.migrations.Migration_79_80
 import io.horizontalsystems.walletkit.core.storage.migrations.Migration_80_81
 import io.horizontalsystems.walletkit.core.storage.migrations.Migration_81_82
 import io.horizontalsystems.walletkit.core.storage.migrations.Migration_82_83
+import io.horizontalsystems.walletkit.core.storage.migrations.Migration_83_84
 import io.horizontalsystems.walletkit.entities.ActiveAccount
 import io.horizontalsystems.walletkit.entities.BlockchainSettingRecord
 import io.horizontalsystems.walletkit.entities.EnabledWallet
@@ -90,7 +91,7 @@ import io.horizontalsystems.walletkit.modules.pin.core.PinDao
 import io.horizontalsystems.walletkit.modules.walletconnect.storage.WCSessionDao
 import io.horizontalsystems.walletkit.modules.walletconnect.storage.WalletConnectV2Session
 
-@Database(version = 83, exportSchema = false, entities = [
+@Database(version = 84, exportSchema = false, entities = [
     EnabledWallet::class,
     EnabledWalletCache::class,
     AccountRecord::class,
@@ -222,6 +223,7 @@ abstract class AppDatabase : RoomDatabase() {
                     Migration_80_81,
                     Migration_81_82,
                     Migration_82_83,
+                    Migration_83_84,
                 )
                 .build()
         }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/storage/migrations/Migration_83_84.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/storage/migrations/Migration_83_84.kt
@@ -1,0 +1,10 @@
+package io.horizontalsystems.walletkit.core.storage.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+object Migration_83_84 : Migration(83, 84) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE `SwapRecord` ADD COLUMN `estimatedTime` INTEGER")
+    }
+}

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/entities/SwapRecord.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/entities/SwapRecord.kt
@@ -43,4 +43,6 @@ data class SwapRecord(
     // opaque handle linking the record to an external settlement mechanism
     // (e.g. a smart-account userOp hash) until the real transactionHash is known
     val trackingHandle: String? = null,
+    // estimated swap duration in seconds, as quoted at swap time
+    val estimatedTime: Long? = null,
 )

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapConfirmPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapConfirmPage.kt
@@ -40,6 +40,7 @@ import io.horizontalsystems.walletkit.modules.confirm.ConfirmTransactionScreen
 import io.horizontalsystems.walletkit.modules.confirm.ErrorSheet
 import io.horizontalsystems.walletkit.modules.evmfee.ButtonsGroupWithShade
 import io.horizontalsystems.walletkit.modules.evmfee.Cautions
+import io.horizontalsystems.walletkit.modules.multiswap.providers.SwapProviderType
 import io.horizontalsystems.walletkit.modules.multiswap.settings.SwapSettingsRecipientPage
 import io.horizontalsystems.walletkit.modules.multiswap.settings.SwapSettingsSlippagePage
 import io.horizontalsystems.walletkit.modules.multiswap.settings.SwapTransactionNonceSettingsPage
@@ -306,14 +307,23 @@ private fun SwapConfirmInternal(
                     )
                 }
                 uiState.estimatedTime?.let { estimatedTime ->
-                    val infoTitle = stringResource(id = R.string.Swap_EstimatedTime)
+                    val infoTitle = stringResource(id = R.string.Swap_SwapTime)
                     val infoText = stringResource(id = R.string.Swap_EstimatedTimeDescription)
+                    val timeText = when (uiState.providerType) {
+                        SwapProviderType.CEX -> formatSwapTimeRange(estimatedTime)
+                        SwapProviderType.DEX -> "~${formatDuration(estimatedTime)}"
+                    }
+                    val timeColor = if (swapTimeStatus(estimatedTime, listOf(estimatedTime)) == SwapTimeStatus.Attention) {
+                        ComposeAppTheme.colors.jacob
+                    } else {
+                        ComposeAppTheme.colors.leah
+                    }
                     QuoteInfoRow(
-                        title = stringResource(id = R.string.Swap_EstimatedTime),
-                        value = "~${formatDuration(estimatedTime)}".hs(ComposeAppTheme.colors.leah),
+                        title = stringResource(id = R.string.Swap_SwapTime),
+                        value = timeText.hs(timeColor),
                         onInfoClick = {
                             navigation.slideFromBottom(
-                                SwapInfoSheet(SwapInfoSheet.Input(infoTitle, infoText))
+                                SwapInfoSheet(SwapInfoSheet.Input(infoTitle, infoText, R.drawable.ic_circle_clock_24))
                             )
                         }
                     )

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapConfirmViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapConfirmViewModel.kt
@@ -20,6 +20,7 @@ import io.horizontalsystems.walletkit.modules.multiswap.history.SwapStatus
 import io.horizontalsystems.walletkit.modules.multiswap.providers.IMultiSwapProvider
 import io.horizontalsystems.walletkit.modules.multiswap.providers.OneInchException
 import io.horizontalsystems.walletkit.modules.multiswap.providers.SwapHelper
+import io.horizontalsystems.walletkit.modules.multiswap.providers.SwapProviderType
 import io.horizontalsystems.walletkit.modules.multiswap.sendtransaction.AbstractSendTransactionService
 import io.horizontalsystems.walletkit.modules.multiswap.sendtransaction.SendTransactionResult
 import io.horizontalsystems.walletkit.modules.multiswap.sendtransaction.SendTransactionServiceFactory
@@ -235,6 +236,7 @@ class SwapConfirmViewModel(
         recipient = recipient,
         slippage = slippage,
         estimatedTime = estimatedTime,
+        providerType = swapProvider.type,
         error = error
     )
 
@@ -359,6 +361,7 @@ class SwapConfirmViewModel(
             toAsset = toAsset,
             depositAddress = depositAddress,
             status = SwapStatus.Depositing.name,
+            estimatedTime = estimatedTime,
         )
         App.swapRecordManager.save(record)
     }
@@ -436,5 +439,6 @@ data class SwapConfirmUiState(
     val recipient: Address?,
     val slippage: BigDecimal?,
     val estimatedTime: Long?,
+    val providerType: SwapProviderType,
     val error: Throwable?,
 )

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapInfoSheet.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapInfoSheet.kt
@@ -23,16 +23,16 @@ data class SwapInfoSheet(val input: Input) : HSBottomSheet() {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {
-        SwapInfoView(input.title, input.text) { navigation.removeLastOrNull() }
+        SwapInfoView(input.title, input.text, input.icon) { navigation.removeLastOrNull() }
     }
 
     @Serializable
-    data class Input(val title: String, val text: String)
+    data class Input(val title: String, val text: String, val icon: Int? = null)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SwapInfoView(title: String, text: String, onCloseClick: () -> Unit) {
+fun SwapInfoView(title: String, text: String, icon: Int? = null, onCloseClick: () -> Unit) {
     BottomSheetContent(
         onDismissRequest = onCloseClick,
         sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
@@ -46,7 +46,7 @@ fun SwapInfoView(title: String, text: String, onCloseClick: () -> Unit) {
         }
     ) {
         BottomSheetHeaderV3(
-            image72 = painterResource(R.drawable.book_24),
+            image72 = painterResource(icon ?: R.drawable.book_24),
             title = title
         )
         TextBlock(

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapPage.kt
@@ -70,6 +70,7 @@ import io.horizontalsystems.walletkit.core.stats.stat
 import io.horizontalsystems.walletkit.entities.CoinValue
 import io.horizontalsystems.walletkit.entities.Currency
 import io.horizontalsystems.walletkit.modules.multiswap.history.SwapHistoryPage
+import io.horizontalsystems.walletkit.modules.multiswap.providers.SwapProviderType
 import io.horizontalsystems.walletkit.modules.multiswap.swapterms.SwapTermsPage
 import io.horizontalsystems.walletkit.modules.multiswap.ui.RiskScore
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
@@ -427,6 +428,11 @@ private fun SwapScreenInner(
                                 },
                                 onClickProviderScoreInfo = {
                                     navigation.slideFromBottom(RiskLevelInfoSheet)
+                                },
+                                onClickSwapTimeInfo = { infoTitle, infoText ->
+                                    navigation.slideFromBottom(
+                                        SwapInfoSheet(SwapInfoSheet.Input(infoTitle, infoText, R.drawable.ic_circle_clock_24))
+                                    )
                                 }
                             )
                         }
@@ -576,6 +582,7 @@ private fun ProviderCellInfo(
     onClickPrice: () -> Unit,
     onClickProvider: () -> Unit,
     onClickProviderScoreInfo: () -> Unit,
+    onClickSwapTimeInfo: (title: String, text: String) -> Unit,
 ) {
     val swapPriceUIHelper = SwapPriceUIHelper(
         quote.tokenIn,
@@ -631,12 +638,24 @@ private fun ProviderCellInfo(
         )
         if (swapTimeStatus == SwapTimeStatus.Attention) {
             quote.estimationTime?.let { estimationTime ->
+                val infoTitle = stringResource(R.string.Swap_SwapTime)
+                val infoText = stringResource(R.string.Swap_EstimatedTimeDescription)
                 CellSecondary(
                     middle = {
-                        CellMiddleInfo(eyebrow = stringResource(R.string.Swap_SwapTime).hs)
+                        CellMiddleInfoTextIcon(
+                            text = infoTitle.hs,
+                            icon = painterResource(R.drawable.ic_info_24),
+                            iconTint = ComposeAppTheme.colors.grey,
+                        )
                     },
                     right = {
-                        SwapTime(estimationTime = estimationTime)
+                        SwapTime(
+                            estimationTime = estimationTime,
+                            providerType = quote.provider.type,
+                        )
+                    },
+                    onClick = {
+                        onClickSwapTimeInfo(infoTitle, infoText)
                     }
                 )
             }
@@ -648,6 +667,7 @@ private fun ProviderCellInfo(
 private fun SwapTime(
     modifier: Modifier = Modifier,
     estimationTime: Long,
+    providerType: SwapProviderType,
 ) {
     val color = ComposeAppTheme.colors.jacob
     Row(
@@ -655,7 +675,7 @@ private fun SwapTime(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
-            text = formatDurationShort(estimationTime),
+            text = formatSwapTime(estimationTime, providerType),
             style = ComposeAppTheme.typography.subheadSB,
             color = color,
             overflow = TextOverflow.Ellipsis,

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapSelectProviderPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapSelectProviderPage.kt
@@ -30,6 +30,7 @@ import io.horizontalsystems.walletkit.core.App
 import io.horizontalsystems.walletkit.core.stats.StatEvent
 import io.horizontalsystems.walletkit.core.stats.StatPage
 import io.horizontalsystems.walletkit.core.stats.stat
+import io.horizontalsystems.walletkit.modules.multiswap.providers.SwapProviderType
 import io.horizontalsystems.walletkit.modules.multiswap.ui.RiskScore
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.nav3.HSPage
@@ -48,6 +49,7 @@ import io.horizontalsystems.walletkit.uiv3.components.menu.MenuGroup
 import io.horizontalsystems.walletkit.uiv3.components.menu.MenuItemX
 import io.horizontalsystems.walletkit.uiv3.components.tabs.TabsSectionButtons
 import kotlinx.serialization.Serializable
+import kotlin.math.roundToLong
 
 @Serializable
 data class SwapSelectProviderPage(val parentScreenContentKey: String) : HSPage() {
@@ -203,7 +205,7 @@ private fun SwapSelectProviderScreenInner(
                                         )
                                         Text(
                                             text = viewItem.estimationTime?.let {
-                                                formatDurationShort(it)
+                                                formatSwapTime(it, provider.type)
                                             } ?: stringResource(R.string.NotAvailable),
                                             style = ComposeAppTheme.typography.subheadSB,
                                             color = if (viewItem.timeStatus == SwapTimeStatus.Attention) {
@@ -281,6 +283,27 @@ fun formatDurationShort(totalSeconds: Long): String {
         if (seconds > 0 || (hours == 0L && minutes == 0L)) append("${seconds}s")
     }.trim()
 }
+
+// CEX estimates are a measured average, so display them as a ±25% range;
+// DEX providers quote their own timing and keep the single value.
+fun formatSwapTime(estimationTime: Long, providerType: SwapProviderType): String =
+    when (providerType) {
+        SwapProviderType.CEX -> formatSwapTimeRange(estimationTime)
+        SwapProviderType.DEX -> formatDurationShort(estimationTime)
+    }
+
+fun formatSwapTimeRange(totalSeconds: Long): String {
+    val minSeconds = roundSecondsToMinutes(totalSeconds * 0.75)
+    val maxSeconds = roundSecondsToMinutes(totalSeconds * 1.25)
+    return if (minSeconds == maxSeconds) {
+        formatDurationShort(minSeconds)
+    } else {
+        "${formatDurationShort(minSeconds)}-${formatDurationShort(maxSeconds)}"
+    }
+}
+
+private fun roundSecondsToMinutes(seconds: Double): Long =
+    (seconds / 60).roundToLong().coerceAtLeast(1) * 60
 
 @Preview
 @Composable

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/history/SwapInfoPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/history/SwapInfoPage.kt
@@ -38,6 +38,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import io.horizontalsystems.walletkit.R
 import io.horizontalsystems.walletkit.helpers.HudHelper
 import io.horizontalsystems.walletkit.modules.evmfee.ButtonsGroupWithShade
+import io.horizontalsystems.walletkit.modules.multiswap.SwapInfoSheet
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.nav3.HSPage
 import io.horizontalsystems.walletkit.ui.compose.ComposeAppTheme
@@ -229,6 +230,36 @@ fun SwapInfoScreen(recordId: Int, navigation: HSNavigation) {
                         CellRightInfoTextIcon(text = uiState.formattedDate.hs(color = leah))
                     },
                 )
+                // Swap Time
+                uiState.swapTime?.let { swapTime ->
+                    val infoTitle = stringResource(R.string.Swap_SwapTime)
+                    val infoText = stringResource(R.string.Swap_EstimatedTimeDescription)
+                    CellSecondary(
+                        middle = {
+                            CellMiddleInfoTextIcon(
+                                text = infoTitle.hs,
+                                icon = painterResource(R.drawable.ic_info_24),
+                                iconTint = ComposeAppTheme.colors.grey,
+                            )
+                        },
+                        right = {
+                            CellRightInfoTextIcon(
+                                text = swapTime.hs(
+                                    color = if (uiState.swapTimeAttention) {
+                                        ComposeAppTheme.colors.jacob
+                                    } else {
+                                        leah
+                                    }
+                                )
+                            )
+                        },
+                        onClick = {
+                            navigation.slideFromBottom(
+                                SwapInfoSheet(SwapInfoSheet.Input(infoTitle, infoText, R.drawable.ic_circle_clock_24))
+                            )
+                        },
+                    )
+                }
                 // Recipient
                 uiState.recipientAddress?.let { address ->
                     CellSecondary(

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/history/SwapInfoViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/history/SwapInfoViewModel.kt
@@ -13,10 +13,15 @@ import io.horizontalsystems.walletkit.core.managers.CurrencyManager
 import io.horizontalsystems.walletkit.core.managers.MarketKitWrapper
 import io.horizontalsystems.walletkit.entities.SimulateFailSwapMode
 import io.horizontalsystems.walletkit.helpers.DateHelper
+import io.horizontalsystems.walletkit.modules.multiswap.SwapTimeStatus
+import io.horizontalsystems.walletkit.modules.multiswap.formatDuration
+import io.horizontalsystems.walletkit.modules.multiswap.formatSwapTimeRange
 import io.horizontalsystems.walletkit.modules.multiswap.providers.MayaProvider
 import io.horizontalsystems.walletkit.modules.multiswap.providers.MultiSwapProviderRegistry
+import io.horizontalsystems.walletkit.modules.multiswap.providers.SwapProviderType
 import io.horizontalsystems.walletkit.modules.multiswap.providers.ThorChainProvider
 import io.horizontalsystems.walletkit.modules.multiswap.providers.UProvider
+import io.horizontalsystems.walletkit.modules.multiswap.swapTimeStatus
 import io.horizontalsystems.marketkit.models.BlockchainType
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -55,6 +60,8 @@ class SwapInfoViewModel(
     private var sendingTxUrl: String? = null
     private var isSingleTransactionSwap: Boolean = false
     private var pauseReason: PauseReason? = null
+    private var swapTime: String? = null
+    private var swapTimeAttention: Boolean = false
 
     override fun createState() = SwapInfoUiState(
         tokenInImageUrl = tokenInImageUrl,
@@ -79,6 +86,8 @@ class SwapInfoViewModel(
         sendingTxUrl = sendingTxUrl,
         isSingleTransactionSwap = isSingleTransactionSwap,
         pauseReason = pauseReason,
+        swapTime = swapTime,
+        swapTimeAttention = swapTimeAttention,
     )
 
     init {
@@ -130,6 +139,14 @@ class SwapInfoViewModel(
             record.tokenOutBlockchainTypeUid,
         )
         pauseReason = PauseReason.fromApi(record.pauseReason)
+        swapTime = record.estimatedTime?.let { time ->
+            when (MultiSwapProviderRegistry.providerType(record.providerId)) {
+                SwapProviderType.CEX -> formatSwapTimeRange(time)
+                else -> "~${formatDuration(time)}"
+            }
+        }
+        swapTimeAttention =
+            swapTimeStatus(record.estimatedTime, listOf(record.estimatedTime)) == SwapTimeStatus.Attention
 
         emitState()
     }
@@ -228,4 +245,6 @@ data class SwapInfoUiState(
     val sendingTxUrl: String?,
     val isSingleTransactionSwap: Boolean,
     val pauseReason: PauseReason?,
+    val swapTime: String?,
+    val swapTimeAttention: Boolean,
 )

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/MultiSwapProviderRegistry.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/MultiSwapProviderRegistry.kt
@@ -35,4 +35,8 @@ object MultiSwapProviderRegistry {
         val provider = providersById[providerId] ?: return false
         return provider.isSingleTransactionSwap(tokenInBlockchainTypeUid, tokenOutBlockchainTypeUid)
     }
+
+    fun providerType(providerId: String): SwapProviderType? {
+        return providersById[providerId]?.type
+    }
 }

--- a/walletkit/src/main/res/values-de/strings.xml
+++ b/walletkit/src/main/res/values-de/strings.xml
@@ -605,7 +605,7 @@
     <string name="Swap_AmlError_Description">Kann momentan keine Antwort erhalten. Bitte versuchen Sie es erneut.</string>
     <string name="Swap_AmlError_Button">Wiederholen</string>
     <string name="Swap_EstimatedTime">Geschätzte Zeit</string>
-    <string name="Swap_EstimatedTimeDescription">Ungefähre Zeit zum Empfang der Gelder. Die Swap-Verarbeitung und Transaktionsbestätigungen können je nach Netzwerk und Route einige Zeit dauern.</string>
+    <string name="Swap_EstimatedTimeDescription">Dies ist die geschätzte Zeit, die erforderlich ist, um den Swap abzuschließen und Ihre Gelder zu erhalten. Die tatsächliche Zeit kann je nach Netzwerkbedingungen, Transaktionsbestätigungen und der ausgewählten Swap-Route kürzer oder länger sein.</string>
     <string name="Swap_MinimumReceived">Garantiebetrag</string>
     <string name="Swap_MinimumReceivedDescription">Dieser Betrag ist im Prozess der Validierung. Sobald der Transaktionsstatus bestätigt ist, können Sie diese Münzen verwenden. Der Mindestbetrag für den ein Benutzer geht </string>
     <string name="Swap_Slippage">Slippage</string>

--- a/walletkit/src/main/res/values-es/strings.xml
+++ b/walletkit/src/main/res/values-es/strings.xml
@@ -605,7 +605,7 @@
     <string name="Swap_AmlError_Description">No se puede obtener una respuesta en este momento. Por favor, inténtalo de nuevo.</string>
     <string name="Swap_AmlError_Button">Reintentar</string>
     <string name="Swap_EstimatedTime">Tiempo estimado</string>
-    <string name="Swap_EstimatedTimeDescription">Tiempo aproximado para recibir fondos. El procesamiento del swap y las confirmaciones de transacciones pueden tomar tiempo dependiendo de la red y la ruta.</string>
+    <string name="Swap_EstimatedTimeDescription">Este es el tiempo estimado requerido para completar el intercambio y recibir tus fondos. El tiempo real puede ser más corto o más largo dependiendo de las condiciones de la red, confirmaciones de transacciones y la ruta de intercambio seleccionada.</string>
     <string name="Swap_MinimumReceived">Garantizado</string>
     <string name="Swap_MinimumReceivedDescription">Esta cantidad está en proceso de validación. Tan pronto como el estado de la transacción sea validado, podrá utilizar estas monedas. La cantidad mínima que un usuario va </string>
     <string name="Swap_Slippage">Deslizar</string>

--- a/walletkit/src/main/res/values-fa/strings.xml
+++ b/walletkit/src/main/res/values-fa/strings.xml
@@ -695,7 +695,7 @@
     <string name="Swap_ProviderRisk">ریسک مسیر</string>
     <string name="Swap_AmlRisk_Description">ریسک های احتمالی برای این معامله شناسایی شد. در حین پردازش، ممکن است وجوه شما رد یا محدود شود. لطفاً مسیر دیگری را انتخاب کنید.</string>
     <string name="Swap_AmlRisk_Button">انتخاب مسیر دیگر</string>
-    <string name="Swap_EstimatedTimeDescription">زمان تقریبی برای دریافت وجوه. پردازش swap و تأیید معاملات بسته به شبکه و مسیر می‌تواند مدتی طول بکشد.</string>
+    <string name="Swap_EstimatedTimeDescription">این زمان تخمینی مورد نیاز برای تکمیل تبدیل و دریافت وجوه شما است. زمان واقعی ممکن است بسته به شرایط شبکه، تأیید تراکنش‌ها و مسیر تبدیل انتخاب شده کوتاه‌تر یا طولانی‌تر باشد.</string>
     <string name="SwapTerms_BottomText">همیشه مسیر swap را انتخاب کنید که با نیازهای شما مطابقت داشته باشد.</string>
     <string name="SwapInfo_Provider">مسیر</string>
     <string name="Balance_NoCoinsAlert">هیچ توکنی در اینجا نیست. یکی اضافه کنید تا شروع کنید.</string>

--- a/walletkit/src/main/res/values-fr/strings.xml
+++ b/walletkit/src/main/res/values-fr/strings.xml
@@ -605,7 +605,7 @@
     <string name="Swap_AmlError_Description">Impossible d\'obtenir une réponse pour le moment. Veuillez réessayer.</string>
     <string name="Swap_AmlError_Button">Réessayer</string>
     <string name="Swap_EstimatedTime">Est. Time</string>
-    <string name="Swap_EstimatedTimeDescription">Temps approximatif pour recevoir les fonds. Le traitement du swap et les confirmations de transaction peuvent prendre du temps selon le réseau et l\'itinéraire.</string>
+    <string name="Swap_EstimatedTimeDescription">Ceci est le temps estimé requis pour finaliser l\'échange et recevoir vos fonds. Le temps réel peut être plus court ou plus long selon les conditions du réseau, les confirmations de transaction et l\'itinéraire d\'échange sélectionné.</string>
     <string name="Swap_MinimumReceived">Garantie</string>
     <string name="Swap_MinimumReceivedDescription">Ce montant est en cours de validation. Dès que le statut de la transaction est validé, vous serez en mesure d\'utiliser ces pièces. Le montant minimum d\'un utilisateur va </string>
     <string name="Swap_Slippage">Slippage</string>

--- a/walletkit/src/main/res/values-ko/strings.xml
+++ b/walletkit/src/main/res/values-ko/strings.xml
@@ -1530,7 +1530,7 @@
     <string name="Swap_ProviderRisk">경로 위험도</string>
     <string name="Swap_AmlRisk_Description">이 거래에 대해 잠재적 위험이 식별되었습니다. 처리 중에 자금이 거부되거나 제한될 수 있습니다. 다른 경로를 선택하시기 바랍니다.</string>
     <string name="Swap_AmlRisk_Button">다른 경로 선택</string>
-    <string name="Swap_EstimatedTimeDescription">자금 수령 예상 시간입니다. 스왑 처리 및 거래 확인은 네트워크 및 경로에 따라 시간이 소요될 수 있습니다.</string>
+    <string name="Swap_EstimatedTimeDescription">이는 스왑을 완료하고 자금을 받기 위해 필요한 예상 시간입니다. 실제 시간은 네트워크 상태, 거래 확인 및 선택한 스왑 경로에 따라 더 짧거나 길 수 있습니다.</string>
     <string name="SwapTerms_BottomText">항상 귀하의 요구 사항과 일치하는 스왑 경로를 선택하세요.</string>
     <string name="SwapInfo_Provider">경로</string>
     <string name="SwapHistory_EmptyList">아직 대기 중이거나 이전의 스왑이 없습니다.</string>

--- a/walletkit/src/main/res/values-pt-rBR/strings.xml
+++ b/walletkit/src/main/res/values-pt-rBR/strings.xml
@@ -605,7 +605,7 @@
     <string name="Swap_AmlError_Description">Não foi possível obter uma resposta agora. Por favor, tente novamente.</string>
     <string name="Swap_AmlError_Button">Tentar de novo</string>
     <string name="Swap_EstimatedTime">Tempo estimado</string>
-    <string name="Swap_EstimatedTimeDescription">Tempo aproximado para receber fundos. O processamento do swap e as confirmações de transações podem levar tempo dependendo da rede e da rota.</string>
+    <string name="Swap_EstimatedTimeDescription">Este é o tempo estimado necessário para concluir a troca e receber seus fundos. O tempo real pode ser mais curto ou mais longo dependendo das condições da rede, confirmações de transação e da rota de troca selecionada.</string>
     <string name="Swap_MinimumReceived">Valor garantido</string>
     <string name="Swap_MinimumReceivedDescription">Este valor está em processo de validação. Assim que o status da transação for validado, você poderá usar essas moedas. A quantia mínima que um usuário perde </string>
     <string name="Swap_Slippage">Corrente</string>

--- a/walletkit/src/main/res/values-ru/strings.xml
+++ b/walletkit/src/main/res/values-ru/strings.xml
@@ -607,7 +607,7 @@
     <string name="Swap_AmlError_Description">Не удалось получить ответ прямо сейчас. Пожалуйста, попробуйте еще раз.</string>
     <string name="Swap_AmlError_Button">Повторить</string>
     <string name="Swap_EstimatedTime">Время</string>
-    <string name="Swap_EstimatedTimeDescription">Приблизительное время получения средств. Обработка обмена и подтверждение транзакций могут занять некоторое время в зависимости от сети и маршрута.</string>
+    <string name="Swap_EstimatedTimeDescription">Это приблизительное время, необходимое для завершения обмена и получения ваших средств. Фактическое время может быть короче или длиннее в зависимости от состояния сети, подтверждений транзакций и выбранного маршрута обмена.</string>
     <string name="Swap_MinimumReceived">Гарантированно</string>
     <string name="Swap_MinimumReceivedDescription">Эта сумма находится в процессе проверки. Как только состояние транзакции будет проверено, вы сможете использовать эти монеты. Минимальная сумма пользователя </string>
     <string name="Swap_Slippage">Отклонение от курса</string>

--- a/walletkit/src/main/res/values-tr/strings.xml
+++ b/walletkit/src/main/res/values-tr/strings.xml
@@ -1369,7 +1369,7 @@
     <string name="Swap_ProviderRisk">Rota Riski</string>
     <string name="Swap_AmlRisk_Description">Bu işlem için olası riskler tespit edildi. İşlem sırasında fonlarınız reddedilebilir veya kısıtlanabilir. Lütfen başka bir rota seçin.</string>
     <string name="Swap_AmlRisk_Button">Başka Rota Seç</string>
-    <string name="Swap_EstimatedTimeDescription">Fonları alma için tahmini zaman. Swap işleme ve işlem onayları ağ ve rotaya bağlı olarak biraz zaman alabilir.</string>
+    <string name="Swap_EstimatedTimeDescription">Bu, takası tamamlamak ve fonlarınızı almak için gereken tahmini süredir. Gerçek süre, ağ koşullarına, işlem onaylarına ve seçilen takas rotasına bağlı olarak daha kısa veya daha uzun olabilir.</string>
     <string name="SwapTerms_BottomText">Her zaman gereksinimlerinize uygun bir swap rotası seçin.</string>
     <string name="SwapInfo_Provider">Rota</string>
     <string name="SwapHistory_EmptyList">Henüz beklemede veya geçmiş takasınız yok.</string>

--- a/walletkit/src/main/res/values-zh/strings.xml
+++ b/walletkit/src/main/res/values-zh/strings.xml
@@ -604,7 +604,7 @@
     <string name="Swap_AmlError_Description">现在无法获得响应。请再试一次。</string>
     <string name="Swap_AmlError_Button">重试</string>
     <string name="Swap_EstimatedTime">估计时间</string>
-    <string name="Swap_EstimatedTimeDescription">接收资金的大约时间。交换处理和交易确认可能需要一些时间，具体取决于网络和路由。</string>
+    <string name="Swap_EstimatedTimeDescription">这是完成兑换并接收您资金所需的估计时间。实际时间可能会因网络状况、交易确认和选定的兑换路线而缩短或延长。</string>
     <string name="Swap_MinimumReceived">保证金额</string>
     <string name="Swap_MinimumReceivedDescription">这一数额正在审定过程中。 一旦交易状态得到验证，您将能够使用这些硬币。用户正在使用的最低金额 </string>
     <string name="Swap_Slippage">滑点</string>

--- a/walletkit/src/main/res/values/strings.xml
+++ b/walletkit/src/main/res/values/strings.xml
@@ -762,7 +762,7 @@
     <string name="Swap_AmlError_Button">Retry</string>
     <string name="Swap_EstimatedTime">Est. Time</string>
     <string name="Swap_SwapTime">Swap Time</string>
-    <string name="Swap_EstimatedTimeDescription">Approximate time to receive funds. Swap processing and transaction confirmations may take some time depending on the network and route.</string>
+    <string name="Swap_EstimatedTimeDescription">This is the estimated time required to complete the swap and receive your funds. The actual time may be shorter or longer depending on network conditions, transaction confirmations, and the selected swap route.</string>
     <string name="Swap_MinimumReceived">Guaranteed</string>
     <string name="Swap_MinimumReceivedDescription">This amount is in the process of validation. As soon as the transaction status is validated you will be able to use these coins. The minimum amount a user is going </string>
     <string name="Swap_Slippage">Slippage</string>


### PR DESCRIPTION
#9348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added estimated swap completion times throughout provider selection, confirmation, and swap history.
  * Displayed timing differently for centralized and decentralized providers, including ranges where applicable.
  * Added contextual swap-time information with a clock icon and explanatory details.
  * Saved estimated swap times with swap records for future reference.

* **Improvements**
  * Updated messaging to clarify that estimates vary based on network conditions, confirmations, and the selected route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->