### PR TITLE
Add USwap seams for app-executed swaps

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/storage/SwapRecordDao.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/storage/SwapRecordDao.kt
@@ -32,6 +32,9 @@ interface SwapRecordDao {
     @Query("UPDATE SwapRecord SET transactionHash = :hash WHERE id = :id")
     fun updateTransactionHash(id: Int, hash: String)
 
+    @Query("UPDATE SwapRecord SET trackingHandle = NULL WHERE id = :id")
+    fun clearTrackingHandle(id: Int)
+
     @Query("UPDATE SwapRecord SET outboundTransactionHash = :hash WHERE id = :id")
     fun updateOutboundTransactionHash(id: Int, hash: String)
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapFinalQuote.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapFinalQuote.kt
@@ -20,4 +20,7 @@ data class SwapFinalQuote(
     val fromAsset: String? = null,
     val toAsset: String? = null,
     val depositAddress: String? = null,
+    // Spender of the committed route's approval, when the provider reports one —
+    // it can differ from the transaction's `to` (routers vs. dedicated spenders).
+    val approvalSpender: String? = null,
 )

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapFinalQuote.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapFinalQuote.kt
@@ -20,6 +20,9 @@ data class SwapFinalQuote(
     val fromAsset: String? = null,
     val toAsset: String? = null,
     val depositAddress: String? = null,
+    // Memo the deposit transfer must carry, when the route demands one — vehicles
+    // with no memo channel must decline such routes instead of dropping it.
+    val depositMemo: String? = null,
     // Spender of the committed route's approval, when the provider reports one —
     // it can differ from the transaction's `to` (routers vs. dedicated spenders).
     val approvalSpender: String? = null,

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/history/SwapRecordManager.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/history/SwapRecordManager.kt
@@ -56,6 +56,15 @@ class SwapRecordManager(
         _recordsUpdatedFlow.tryEmit(Unit)
     }
 
+    /**
+     * Releases the record from app-side tracking: with the handle gone, the
+     * server-side sync loop owns the record's advancement.
+     */
+    fun clearTrackingHandle(id: Int) {
+        swapRecordDao.clearTrackingHandle(id)
+        _recordsUpdatedFlow.tryEmit(Unit)
+    }
+
     fun updateOutboundTransactionHash(id: Int, hash: String) {
         swapRecordDao.updateOutboundTransactionHash(id, hash)
         _recordsUpdatedFlow.tryEmit(Unit)

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/history/SwapTrackEnrichmentResolver.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/history/SwapTrackEnrichmentResolver.kt
@@ -1,0 +1,20 @@
+package io.horizontalsystems.walletkit.modules.multiswap.history
+
+import io.horizontalsystems.walletkit.entities.SwapRecord
+
+/**
+ * Registration seam for app-resolved track-request context. An app whose
+ * broadcast transactions do not originate from the user's own address (e.g.
+ * bundled or relayed sends, where the on-chain `from` is an operator account)
+ * registers a provider so the tracker still learns the real sending address.
+ */
+object SwapTrackEnrichmentResolver {
+
+    interface Provider {
+        /** The actual sending address for the record's inbound leg; null → nothing to add. */
+        fun fromAddress(record: SwapRecord): String?
+    }
+
+    @Volatile
+    var provider: Provider? = null
+}

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/history/SwapTrackRequestBuilder.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/history/SwapTrackRequestBuilder.kt
@@ -33,6 +33,9 @@ object SwapTrackRequestBuilder {
 
     fun build(record: SwapRecord): TrackCall {
         val providerApiName = apiProviderName(record.providerId)
+        // App-resolved sending address: when broadcasts are bundled/relayed, the
+        // on-chain `from` is an operator account, not the user's — the app knows better.
+        val fromAddress = SwapTrackEnrichmentResolver.provider?.fromAddress(record)
 
         return when {
             record.providerId == ThorChainProvider.id || record.providerId == MayaProvider.id -> TrackCall(
@@ -43,6 +46,7 @@ object SwapTrackRequestBuilder {
                     inboundTxHash = record.transactionHash,
                     depositAddress = if (record.transactionHash == null) record.depositAddress else null,
                     fromAsset = record.fromAsset,
+                    fromAddress = fromAddress,
                     toAsset = record.toAsset,
                     toAddress = record.recipientAddress,
                 )
@@ -57,6 +61,7 @@ object SwapTrackRequestBuilder {
                 UnstoppableAPI.Request.Track(
                     uuid = record.providerSwapId,
                     inboundTxHash = record.transactionHash,
+                    fromAddress = fromAddress,
                 )
             )
 
@@ -70,6 +75,7 @@ object SwapTrackRequestBuilder {
                     hash = record.transactionHash,
                     chainId = evmChainIds[record.tokenInBlockchainTypeUid],
                     fromAsset = record.fromAsset,
+                    fromAddress = fromAddress,
                     toAsset = record.toAsset,
                     toAddress = record.recipientAddress,
                 )

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
@@ -564,8 +564,13 @@ class USwapProvider(
             val signable = execution.primarySignable?.takeIf { it.kind == "evm" }
 
             if (signable == null) {
-                val depositAddress = execution.resolvedDepositAddress()
-                if (buildEvmDepositTransfer != null && depositAddress != null) {
+                // A transfer route committed without sourceAddress carries no
+                // server-built tx by design — the app builds the deposit transfer.
+                // Any other signable-less response is malformed and must fail.
+                val depositAddress = execution.takeIf { it.method == "transfer" }?.depositAddress
+                if (buildEvmDepositTransfer != null && depositAddress != null &&
+                    !shouldIncludeSourceAddress(tokenIn)
+                ) {
                     return buildEvmDepositTransfer.invoke(tokenIn, amountIn, depositAddress)
                 }
                 throw IllegalStateException("No evm tx found")

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
@@ -34,7 +34,12 @@ import retrofit2.http.Query
 import java.math.BigDecimal
 import java.math.BigInteger
 
-class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
+class USwapProvider(
+    private val provider: UProvider,
+    // Narrows the sell side to sources the host app can actually execute (e.g. a
+    // route-calldata provider offered only where contract calls are possible).
+    private val supportsSourceToken: (Token) -> Boolean = { true },
+) : IMultiSwapProvider {
     override val id = "u_${provider.id}"
     override val title = provider.title
     override val type = provider.type
@@ -253,6 +258,7 @@ class USwapProvider(private val provider: UProvider) : IMultiSwapProvider {
     }
 
     override fun supports(tokenFrom: Token, tokenTo: Token): Boolean {
+        if (!supportsSourceToken(tokenFrom)) return false
         return if (assetsMap.isNotEmpty()) {
             assetsMap.contains(tokenFrom) && assetsMap.contains(tokenTo)
         } else {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
@@ -538,6 +538,7 @@ class USwapProvider(
             fromAsset = assetsMap[tokenIn] ?: deriveIdentifier(tokenIn) ?: throw IllegalStateException("No identifier for tokenIn"),
             toAsset = assetsMap[tokenOut] ?: deriveIdentifier(tokenOut) ?: throw IllegalStateException("No identifier for tokenOut"),
             depositAddress = bestRoute.execution?.resolvedDepositAddress(),
+            approvalSpender = bestRoute.approvalSpenderOrExecution,
         )
     }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
@@ -621,7 +621,19 @@ class USwapProvider(
 
             BlockchainType.Tron -> {
                 val tx = execution.primarySignable?.takeIf { it.kind == "tron" }?.tx
-                    ?: throw IllegalStateException("No tron tx found")
+
+                if (tx == null) {
+                    // Same opt-out contract as the EVM branch: a bare transfer route
+                    // maps to the plain-transfer shape, but only without a memo — a
+                    // simple send cannot carry the provider's crediting identifier.
+                    val depositAddress = execution.takeIf { it.method == "transfer" }?.depositAddress
+                    if (depositAddress != null && execution.resolvedMemo() == null &&
+                        !shouldIncludeSourceAddress(tokenIn)
+                    ) {
+                        return SendTransactionData.Tron.Simple(depositAddress, amountIn)
+                    }
+                    throw IllegalStateException("No tron tx found")
+                }
 
                 val rawTransaction = APIClient.gson.fromJson(tx, CreatedTransaction::class.java)
                 return SendTransactionData.Tron.WithCreateTransaction(rawTransaction)

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
@@ -44,6 +44,10 @@ class USwapProvider(
     // batched into its own signer flow) turns it off so the server returns the
     // plain deposit route instead of building and gas-estimating a transaction.
     private val shouldIncludeSourceAddress: (Token) -> Boolean = { it.needsServerBuiltTx },
+    // Builds the EVM source leg of a transfer route committed without a server-built
+    // tx (sourceAddress omitted): the app supplies the deposit calldata its own
+    // signer executes. Without it such routes fail the final quote.
+    private val buildEvmDepositTransfer: ((tokenIn: Token, amountIn: BigDecimal, depositAddress: String) -> SendTransactionData.Evm)? = null,
 ) : IMultiSwapProvider {
     override val id = "u_${provider.id}"
     override val title = provider.title
@@ -558,7 +562,14 @@ class USwapProvider(
 
         if (blockchainType.isEvm) {
             val signable = execution.primarySignable?.takeIf { it.kind == "evm" }
-                ?: throw IllegalStateException("No evm tx found")
+
+            if (signable == null) {
+                val depositAddress = execution.resolvedDepositAddress()
+                if (buildEvmDepositTransfer != null && depositAddress != null) {
+                    return buildEvmDepositTransfer.invoke(tokenIn, amountIn, depositAddress)
+                }
+                throw IllegalStateException("No evm tx found")
+            }
 
             val transactionData = TransactionData(
                 to = Address(signable.to ?: throw IllegalStateException("No tx `to`")),

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
@@ -538,6 +538,7 @@ class USwapProvider(
             fromAsset = assetsMap[tokenIn] ?: deriveIdentifier(tokenIn) ?: throw IllegalStateException("No identifier for tokenIn"),
             toAsset = assetsMap[tokenOut] ?: deriveIdentifier(tokenOut) ?: throw IllegalStateException("No identifier for tokenOut"),
             depositAddress = bestRoute.execution?.resolvedDepositAddress(),
+            depositMemo = bestRoute.execution?.resolvedMemo(),
             approvalSpender = bestRoute.approvalSpenderOrExecution,
         )
     }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
@@ -39,6 +39,11 @@ class USwapProvider(
     // Narrows the sell side to sources the host app can actually execute (e.g. a
     // route-calldata provider offered only where contract calls are possible).
     private val supportsSourceToken: (Token) -> Boolean = { true },
+    // Whether /swap gets `sourceAddress` for this sell token — the server-built-tx
+    // signal. An app that builds the source leg itself (e.g. a deposit transfer
+    // batched into its own signer flow) turns it off so the server returns the
+    // plain deposit route instead of building and gas-estimating a transaction.
+    private val shouldIncludeSourceAddress: (Token) -> Boolean = { it.needsServerBuiltTx },
 ) : IMultiSwapProvider {
     override val id = "u_${provider.id}"
     override val title = provider.title
@@ -477,10 +482,10 @@ class USwapProvider(
         }
 
         // sourceAddress is the build signal — send it only for chains whose server-built tx
-        // we actually consume (EVM/Tron/TON/Solana), where it is also required for the
-        // signed_transaction `from`. For UTXO/Zcash/Monero/Zano/Stellar we omit it and build
-        // the transfer ourselves (e.g. multi-UTXO sweeps).
-        val sourceAddress = if (tokenIn.needsServerBuiltTx) {
+        // we actually consume (by default EVM/Tron/TON/Solana), where it is also required
+        // for the signed_transaction `from`. For UTXO/Zcash/Monero/Zano/Stellar (and any
+        // token the host app opts out of) we omit it and build the transfer ourselves.
+        val sourceAddress = if (shouldIncludeSourceAddress(tokenIn)) {
             SwapHelper.getSendingAddressForToken(tokenIn)
         } else {
             null
@@ -665,15 +670,6 @@ class USwapProvider(
 
         throw IllegalArgumentException("Not supported blockchainType: $blockchainType")
     }
-
-    // Chains where we consume the server-built tx from `execution` (so we send sourceAddress
-    // on /v2/swap). Everything else builds its own transfer to the deposit address.
-    private val Token.needsServerBuiltTx: Boolean
-        get() = blockchainType.isEvm || blockchainType in setOf(
-            BlockchainType.Tron,
-            BlockchainType.Ton,
-            BlockchainType.Solana,
-        )
 
     companion object {
         // Exolix's shielded Zcash route. Internal routing detail — the app always quotes ZEC.ZEC
@@ -1011,3 +1007,12 @@ interface UnstoppableAPI {
         }
     }
 }
+
+// Chains where we consume the server-built tx from `execution` (so we send sourceAddress
+// on /v2/swap). Everything else builds its own transfer to the deposit address.
+private val Token.needsServerBuiltTx: Boolean
+    get() = blockchainType.isEvm || blockchainType in setOf(
+        BlockchainType.Tron,
+        BlockchainType.Ton,
+        BlockchainType.Solana,
+    )


### PR DESCRIPTION
Four additive seams that let a host app execute USwap swaps through its own signing pipeline and hand records between app-side and server-side tracking:

- `USwapProvider(supportsSourceToken:)` — narrows the sell side to sources the app can execute (default permissive; registry unchanged)
- `SwapFinalQuote.approvalSpender` — the committed route's approval spender, which can differ from the transaction `to`
- `SwapRecordManager.clearTrackingHandle(id)` — releases a record from app-side tracking so the server sync loop owns its advancement
- `SwapTrackEnrichmentResolver` — app-resolved `fromAddress` on track requests, for apps whose broadcasts originate from an operator account

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Swap tracking requests can now include an app-resolved sending address (`fromAddress`) when available.
  - Added an option to clear released tracking handles and notify record-update subscribers.
  - Swap final quotes now expose optional route metadata, including an optional deposit memo and the committed approval spender.
  - Swap provider behavior is now configurable for source-token support and whether to include the source address in requests.

- **Bug Fixes**
  - Improved handling of missing EVM/Tron transaction data for supported transfer routes, preventing failures when the host can supply the needed details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->