### PR TITLE
Keep active-account TRC20 balances via the updated tron-kit

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,7 +75,7 @@ ethereumKit = "665021b"
 feeRateKit = "393cc14"
 marketKit = "13e2045"
 solanaKit = "b487161"
-tronKit = "caca84b"
+tronKit = "6fc27cf"
 thorchainKit = "fcbb556"
 zcashSdk = "2.5.2"
 


### PR DESCRIPTION
The account-info sync's watched-token zero-fill compared TronGrid's base58-keyed trc20 balance list against hex addresses — matching nothing — so every watched token was zero-filled right after its real balance was stored, wiping active-account TRC20 balances (inactive accounts were unaffected: they take the balanceOf RPC path). The updated tron-kit pin (horizontalsystems/tron-kit-android@6fc27cf) matches against base58.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the bundled TronKit version to the latest pinned release via the Gradle version catalog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->