### PR TITLE
Show Stellar swap transactions in coin history

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -68,7 +68,7 @@ unstoppableDomains = "v7.1.0"
 # Wallet Kits
 moneroKit = "69c75cf2"
 zanoKit = "d83a9a5"
-stellarKit = "8854237"
+stellarKit = "4ecccc5"
 tonKit = "947c48a"
 bitcoinKit = "7a552c4"
 ethereumKit = "665021b"

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/adapters/StellarTransactionRecord.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/adapters/StellarTransactionRecord.kt
@@ -50,6 +50,14 @@ class StellarTransactionRecord(
             val value: TransactionValue
         ) : Type()
 
+        // A swap on the own account: a path payment to self (Stellar DEX) or a contract
+        // call that both spent and received assets (Soroswap/Aquarius). valueIn is what
+        // was sold (negative), valueOut what was received.
+        data class Swap(
+            val valueIn: TransactionValue,
+            val valueOut: TransactionValue,
+        ) : Type()
+
         class Unsupported(val type: String) : Type()
 
         val mainValue: TransactionValue?
@@ -57,6 +65,7 @@ class StellarTransactionRecord(
                 is Receive -> value
                 is Send -> value
                 is ChangeTrust -> value
+                is Swap -> valueOut
                 is Unsupported -> null
             }
     }
@@ -76,6 +85,7 @@ class StellarTransactionRecord(
 
                 is Type.ChangeTrust,
                 is Type.Send,
+                is Type.Swap,
                 is Type.Unsupported -> listOf()
             }
     }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/factories/StellarContractMovement.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/factories/StellarContractMovement.kt
@@ -1,0 +1,69 @@
+package io.horizontalsystems.walletkit.core.factories
+
+import io.horizontalsystems.stellarkit.room.Operation
+import io.horizontalsystems.stellarkit.room.StellarAsset
+import java.math.BigDecimal
+
+// The account's net asset movements of one contract call, aggregated by asset across all
+// of Horizon's balance changes: repeated movements of one asset are summed, and an asset
+// appearing on both sides nets out. Signed amounts: sold negative, received positive.
+internal sealed class StellarContractMovement {
+    data class Movement(val asset: StellarAsset, val amount: BigDecimal)
+
+    data class Swap(val sold: Movement, val received: Movement) : StellarContractMovement()
+    data class Outgoing(val movement: Movement, val counterparty: String?) : StellarContractMovement()
+    data class Incoming(val movement: Movement, val counterparty: String?) : StellarContractMovement()
+
+    // No movement touches the account.
+    data object None : StellarContractMovement()
+
+    // More than one asset moved in one direction — the single-pair record types cannot
+    // state it truthfully, so the operation stays a generic contract call rather than
+    // showing understated amounts.
+    data object Unrepresentable : StellarContractMovement()
+
+    companion object {
+        fun resolve(changes: List<Operation.ContractBalanceChange>, accountId: String): StellarContractMovement {
+            val netByAsset = mutableMapOf<StellarAsset, BigDecimal>()
+            changes.forEach { change ->
+                if (change.from == accountId) {
+                    netByAsset.merge(change.asset, change.amount.negate(), BigDecimal::add)
+                }
+                if (change.to == accountId) {
+                    netByAsset.merge(change.asset, change.amount, BigDecimal::add)
+                }
+            }
+
+            val sold = netByAsset.filterValues { it.signum() < 0 }
+            val received = netByAsset.filterValues { it.signum() > 0 }
+
+            fun movement(entry: Map.Entry<StellarAsset, BigDecimal>) = Movement(entry.key, entry.value)
+
+            // The counterparty of the (single) moved asset — where it went or came from.
+            fun counterparty(asset: StellarAsset, outgoing: Boolean): String? = changes.firstOrNull {
+                it.asset == asset && (if (outgoing) it.from == accountId else it.to == accountId)
+            }?.let { if (outgoing) it.to else it.from }
+
+            return when {
+                sold.isEmpty() && received.isEmpty() -> None
+
+                sold.size == 1 && received.size == 1 -> Swap(
+                    sold = movement(sold.entries.first()),
+                    received = movement(received.entries.first()),
+                )
+
+                sold.size == 1 && received.isEmpty() -> {
+                    val entry = sold.entries.first()
+                    Outgoing(movement(entry), counterparty(entry.key, outgoing = true))
+                }
+
+                received.size == 1 && sold.isEmpty() -> {
+                    val entry = received.entries.first()
+                    Incoming(movement(entry), counterparty(entry.key, outgoing = false))
+                }
+
+                else -> Unrepresentable
+            }
+        }
+    }
+}

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/factories/StellarTransactionConverter.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/factories/StellarTransactionConverter.kt
@@ -131,44 +131,40 @@ class StellarTransactionConverter(
         }
 
         operation.contractBalanceChanges?.let { changes ->
-            // Horizon's per-asset balance movements of a contract call (SAC events). Sent
-            // one asset and received another — a swap (Soroswap/Aquarius); one-directional
-            // movements render as plain transfers (e.g. the Axelar ITS deposit).
-            val outgoing = changes.filter { it.from == selfAddress }
-            val incoming = changes.filter { it.to == selfAddress }
-
-            val outValue = outgoing.firstOrNull()?.let { change ->
-                val amount = outgoing.filter { it.asset == change.asset }.sumOf { it.amount }
-                transactionValue(change.asset, amount.negate()) to change
-            }
-            val inValue = incoming.firstOrNull()?.let { change ->
-                val amount = incoming.filter { it.asset == change.asset }.sumOf { it.amount }
-                transactionValue(change.asset, amount) to change
-            }
-
-            when {
-                outValue != null && inValue != null -> {
-                    type = Type.Swap(valueIn = outValue.first, valueOut = inValue.first)
+            // Horizon's per-asset balance movements of a contract call (SAC events),
+            // aggregated by asset. Sold one asset and received another — a swap
+            // (Soroswap/Aquarius); one-directional movements render as plain transfers
+            // (e.g. the Axelar ITS deposit); multi-asset movements stay Unsupported
+            // rather than showing understated amounts.
+            when (val movement = StellarContractMovement.resolve(changes, selfAddress)) {
+                is StellarContractMovement.Swap -> {
+                    type = Type.Swap(
+                        valueIn = transactionValue(movement.sold.asset, movement.sold.amount),
+                        valueOut = transactionValue(movement.received.asset, movement.received.amount),
+                    )
                 }
 
-                outValue != null -> {
+                is StellarContractMovement.Outgoing -> {
                     type = Type.Send(
-                        value = outValue.first,
-                        to = outValue.second.to ?: "",
+                        value = transactionValue(movement.movement.asset, movement.movement.amount),
+                        to = movement.counterparty ?: "",
                         sentToSelf = false,
                         comment = operation.memo,
                         accountCreated = false,
                     )
                 }
 
-                inValue != null -> {
+                is StellarContractMovement.Incoming -> {
                     type = Type.Receive(
-                        value = inValue.first,
-                        from = inValue.second.from ?: "",
+                        value = transactionValue(movement.movement.asset, movement.movement.amount),
+                        from = movement.counterparty ?: "",
                         comment = operation.memo,
                         accountCreated = false,
                     )
                 }
+
+                StellarContractMovement.None,
+                StellarContractMovement.Unrepresentable -> Unit
             }
         }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/factories/StellarTransactionConverter.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/factories/StellarTransactionConverter.kt
@@ -95,6 +95,83 @@ class StellarTransactionConverter(
             }
         }
 
+        operation.pathPayment?.let { pathPayment ->
+            val outgoing = pathPayment.from == selfAddress
+            val incoming = pathPayment.to == selfAddress
+
+            when {
+                // A path payment to self spends sourceAsset and delivers asset — a swap
+                // (the Stellar DEX route of the swap providers).
+                outgoing && incoming -> {
+                    type = Type.Swap(
+                        valueIn = transactionValue(pathPayment.sourceAsset, pathPayment.sourceAmount.negate()),
+                        valueOut = transactionValue(pathPayment.asset, pathPayment.amount),
+                    )
+                }
+
+                outgoing -> {
+                    type = Type.Send(
+                        value = transactionValue(pathPayment.sourceAsset, pathPayment.sourceAmount.negate()),
+                        to = pathPayment.to,
+                        sentToSelf = false,
+                        comment = operation.memo,
+                        accountCreated = false,
+                    )
+                }
+
+                incoming -> {
+                    type = Type.Receive(
+                        value = transactionValue(pathPayment.asset, pathPayment.amount),
+                        from = pathPayment.from,
+                        comment = operation.memo,
+                        accountCreated = false,
+                    )
+                }
+            }
+        }
+
+        operation.contractBalanceChanges?.let { changes ->
+            // Horizon's per-asset balance movements of a contract call (SAC events). Sent
+            // one asset and received another — a swap (Soroswap/Aquarius); one-directional
+            // movements render as plain transfers (e.g. the Axelar ITS deposit).
+            val outgoing = changes.filter { it.from == selfAddress }
+            val incoming = changes.filter { it.to == selfAddress }
+
+            val outValue = outgoing.firstOrNull()?.let { change ->
+                val amount = outgoing.filter { it.asset == change.asset }.sumOf { it.amount }
+                transactionValue(change.asset, amount.negate()) to change
+            }
+            val inValue = incoming.firstOrNull()?.let { change ->
+                val amount = incoming.filter { it.asset == change.asset }.sumOf { it.amount }
+                transactionValue(change.asset, amount) to change
+            }
+
+            when {
+                outValue != null && inValue != null -> {
+                    type = Type.Swap(valueIn = outValue.first, valueOut = inValue.first)
+                }
+
+                outValue != null -> {
+                    type = Type.Send(
+                        value = outValue.first,
+                        to = outValue.second.to ?: "",
+                        sentToSelf = false,
+                        comment = operation.memo,
+                        accountCreated = false,
+                    )
+                }
+
+                inValue != null -> {
+                    type = Type.Receive(
+                        value = inValue.first,
+                        from = inValue.second.from ?: "",
+                        comment = operation.memo,
+                        accountCreated = false,
+                    )
+                }
+            }
+        }
+
         operation.changeTrust?.let { changeTrust ->
             val token = getToken(changeTrust.asset)
 
@@ -133,6 +210,25 @@ class StellarTransactionConverter(
         }
 
         return StellarTransactionRecord(baseToken, source, operation, type, spam)
+    }
+
+    private fun transactionValue(asset: StellarAsset, amount: java.math.BigDecimal): TransactionValue {
+        val token = getToken(asset)
+        return if (token != null) {
+            TransactionValue.CoinValue(token, amount)
+        } else {
+            val assetCode = when (asset) {
+                StellarAsset.Native -> "XLM"
+                is StellarAsset.Asset -> asset.code
+            }
+            TransactionValue.TokenValue(
+                tokenName = assetCode,
+                tokenCode = assetCode,
+                tokenDecimals = 7,
+                value = amount,
+                coinIconPlaceholder = BlockchainType.Stellar.tokenIconPlaceholder
+            )
+        }
     }
 
     private fun getToken(asset: StellarAsset): Token? {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactionInfo/TransactionInfoViewItemFactory.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactionInfo/TransactionInfoViewItemFactory.kt
@@ -124,6 +124,19 @@ class TransactionInfoViewItemFactory(
                         )
                     }
 
+                    is StellarTransactionRecord.Type.Swap -> {
+                        itemSections.add(
+                            getSwapEventSectionItems(
+                                valueIn = transactionType.valueIn,
+                                valueOut = transactionType.valueOut,
+                                rates = rates,
+                                amount = null,
+                                hideAmount = transactionItem.hideAmount,
+                                hasRecipient = false
+                            )
+                        )
+                    }
+
                     is StellarTransactionRecord.Type.Unsupported -> {
                         itemSections.add(
                             listOf(

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactions/TransactionViewItemFactory.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactions/TransactionViewItemFactory.kt
@@ -575,6 +575,16 @@ class TransactionViewItemFactory(
                 iconX = singleValueIconType(recordType.value)
             }
 
+            is StellarTransactionRecord.Type.Swap -> {
+                title = Translator.getString(R.string.Transactions_Swap)
+                subtitle = ""
+
+                primaryValue = getColoredValue(recordType.valueOut, ColorName.Remus)
+                secondaryValue = getColoredValue(recordType.valueIn, ColorName.Leah)
+
+                iconX = doubleValueIconType(recordType.valueOut, recordType.valueIn)
+            }
+
             is StellarTransactionRecord.Type.Unsupported -> {
                 iconX = TransactionViewItem.Icon.Platform(record.blockchainType)
                 title = Translator.getString(R.string.Transactions_StellarTransaction)

--- a/walletkit/src/test/java/io/horizontalsystems/walletkit/core/factories/StellarContractMovementTest.kt
+++ b/walletkit/src/test/java/io/horizontalsystems/walletkit/core/factories/StellarContractMovementTest.kt
@@ -1,0 +1,106 @@
+package io.horizontalsystems.walletkit.core.factories
+
+import io.horizontalsystems.stellarkit.room.Operation.ContractBalanceChange
+import io.horizontalsystems.stellarkit.room.StellarAsset
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.math.BigDecimal
+
+class StellarContractMovementTest {
+
+    private val account = "GACCOUNT"
+    private val other = "GOTHER"
+    private val usdc = StellarAsset.Asset("USDC", "GISSUER")
+
+    private fun change(from: String?, to: String?, asset: StellarAsset, amount: String) =
+        ContractBalanceChange("transfer", from, to, asset, BigDecimal(amount))
+
+    @Test
+    fun soldOneAssetReceivedAnother_isSwap() {
+        val movement = StellarContractMovement.resolve(
+            listOf(
+                change(account, other, StellarAsset.Native, "5"),
+                change(other, account, usdc, "0.86"),
+            ),
+            account
+        )
+
+        assertEquals(
+            StellarContractMovement.Swap(
+                sold = StellarContractMovement.Movement(StellarAsset.Native, BigDecimal("-5")),
+                received = StellarContractMovement.Movement(usdc, BigDecimal("0.86")),
+            ),
+            movement
+        )
+    }
+
+    @Test
+    fun repeatedMovementsOfOneAsset_areSummed() {
+        val movement = StellarContractMovement.resolve(
+            listOf(
+                change(account, other, StellarAsset.Native, "3"),
+                change(account, other, StellarAsset.Native, "2"),
+                change(other, account, usdc, "0.86"),
+            ),
+            account
+        )
+
+        val swap = movement as StellarContractMovement.Swap
+        assertEquals(BigDecimal("-5"), swap.sold.amount)
+    }
+
+    @Test
+    fun assetOnBothSides_isNetted() {
+        // 5 XLM out, 1 XLM refunded back within the same call: net 4 sold.
+        val movement = StellarContractMovement.resolve(
+            listOf(
+                change(account, other, StellarAsset.Native, "5"),
+                change(other, account, StellarAsset.Native, "1"),
+                change(other, account, usdc, "0.70"),
+            ),
+            account
+        )
+
+        val swap = movement as StellarContractMovement.Swap
+        assertEquals(BigDecimal("-4"), swap.sold.amount)
+    }
+
+    @Test
+    fun multipleDistinctAssetsOneDirection_isUnrepresentable() {
+        val movement = StellarContractMovement.resolve(
+            listOf(
+                change(account, other, StellarAsset.Native, "5"),
+                change(account, other, usdc, "1"),
+            ),
+            account
+        )
+
+        assertEquals(StellarContractMovement.Unrepresentable, movement)
+    }
+
+    @Test
+    fun oneDirectionalMovement_isTransferWithCounterparty() {
+        val movement = StellarContractMovement.resolve(
+            listOf(change(account, other, StellarAsset.Native, "5")),
+            account
+        )
+
+        assertEquals(
+            StellarContractMovement.Outgoing(
+                movement = StellarContractMovement.Movement(StellarAsset.Native, BigDecimal("-5")),
+                counterparty = other,
+            ),
+            movement
+        )
+    }
+
+    @Test
+    fun changesNotTouchingTheAccount_areNone() {
+        val movement = StellarContractMovement.resolve(
+            listOf(change(other, "GTHIRD", StellarAsset.Native, "5")),
+            account
+        )
+
+        assertEquals(StellarContractMovement.None, movement)
+    }
+}


### PR DESCRIPTION
#9290

Swap transactions were invisible in the Stellar coin histories: the kit stored `path_payment_strict_send/receive` and `invoke_host_function` operations untyped and untagged, so the tag-driven per-asset queries never matched them.

With the updated kit (horizontalsystems/stellar-kit-android#4, pinned as `4ecccc5`):

- a path payment to self (Stellar DEX route) and a contract call that both spent and received assets (Soroswap/Aquarius) render as a **Swap** — both amounts in the list row, a You sent / You got section on the detail page, visible under both assets' histories and the Swap filter;
- one-directional contract movements render as plain transfers (e.g. the Axelar ITS deposit);
- kit DB bumped to v2 — operations resync from Horizon on first launch, so previously made swaps get classified too.

Verified on device: past XLM ⇄ USDC swaps appear in both histories with correct amounts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying Stellar swap transactions with incoming and outgoing amounts.
  * Added recognition of Stellar path payments and contract balance changes as swaps, sends, or receives.
  * Improved transaction details with swap-specific labels, formatting, and icons.
  * Added support for aggregating multi-asset contract movements and identifying counterparties for one-way transfers.
  * Updated Stellar transaction support to include phishing checks for swap transfer events.

* **Tests**
  * Added coverage for Stellar swaps, transfers, aggregation, and unrelated contract balance changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
