### PR TITLE
Fix history filter for custom tokens with checksummed address

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/adapters/EvmTransactionsAdapter.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/adapters/EvmTransactionsAdapter.kt
@@ -122,7 +122,10 @@ class EvmTransactionsAdapter(
 
     private fun coinTagName(token: Token) = when (val type = token.type) {
         TokenType.Native -> TransactionTag.EVM_COIN
-        is TokenType.Eip20 -> type.address
+        // EvmKit writes transaction tags with the contract address lowercased (Address.hex),
+        // but a user-added custom token can carry a checksummed address — normalize, or the
+        // token's history filter never matches (catalog tokens are already lowercase).
+        is TokenType.Eip20 -> type.address.lowercase()
         else -> ""
     }
 


### PR DESCRIPTION
EvmKit writes transaction tags with the contract address lowercased (`Address.hex`), but a user-added custom token can carry a checksummed address. The token's coin-page history filter compared them verbatim and never matched — the page showed an empty history while the same transactions were visible under ETH. Catalog tokens store lowercase addresses and are unaffected; the Tron adapter is intentionally untouched (base58 addresses are case-sensitive).

Found while testing the Axelar ITS bridge with the wrapped XLM ERC-20 added as a custom token (checksummed contract `0x8Cf7…7C8B`): both the delivery mint and the return burn were on-chain and in the ETH history, but the token page showed nothing. Verified on device after the fix — both appear.

Replaces #9427, which accidentally carried the #9426 commits before they were merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EIP-20 token transaction history filtering by consistently handling contract addresses regardless of letter casing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->