### PR TITLE
Keep Android escaping out of the translation JSON

### DIFF
--- a/.github/scripts/translate_strings.py
+++ b/.github/scripts/translate_strings.py
@@ -52,8 +52,8 @@ def has_cdata(value: str) -> bool:
 
 def escape_xml_value(value: str) -> str:
     """Escape characters that must be escaped in Android strings.xml values."""
-    # translations arrive as plain text — real newlines become Android \n escapes
-    value = value.replace('\n', '\\n')
+    # translations arrive as plain text — real newlines/tabs become Android escapes
+    value = value.replace('\n', '\\n').replace('\t', '\\t')
     # & first — convert XML quote entities to Android escapes, then
     # escape any bare & that isn't part of a remaining named entity
     value = value.replace('&apos;', "\\'")
@@ -104,8 +104,13 @@ def unescape_android(value: str) -> str:
     Asking the model to emit Android escapes inside JSON values produced
     invalid JSON (\\' is not a JSON escape; unescaped quotes end the string).
     """
-    value = value.replace("\\'", "'").replace('\\"', '"').replace("\\n", "\n")
-    value = value.replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&")
+    # backslash escapes: \n and \t map to their characters, any other
+    # escaped character (\', \", \@, \?, \\) drops the backslash
+    value = re.sub(r"\\(.)", lambda m: {"n": "\n", "t": "\t"}.get(m.group(1), m.group(1)), value)
+    # entities: quote entities too; &amp; last so it can't re-form others
+    value = value.replace("&lt;", "<").replace("&gt;", ">")
+    value = value.replace("&quot;", '"').replace("&apos;", "'")
+    value = value.replace("&amp;", "&")
     return value
 
 
@@ -148,11 +153,23 @@ No markdown fences, no explanation. Only the JSON object.
 
     text = re.sub(r"```(?:json)?\s*|\s*```", "", message.content[0].text).strip()
     try:
-        return json.loads(text)
+        data = json.loads(text)
     except json.JSONDecodeError as e:
         print(f"    Model response was not valid JSON ({e}); first 500 chars:")
         print(f"    {text[:500]!r}")
         raise
+
+    # json.loads only checks syntax — enforce {lang: {key: str}} before the
+    # result is written into XML files
+    if not isinstance(data, dict):
+        raise ValueError(f"Translation payload is {type(data).__name__}, expected object")
+    for lang, entries in data.items():
+        if not isinstance(entries, dict):
+            raise ValueError(f"Translations for {lang!r} are {type(entries).__name__}, expected object")
+        for key, translated in entries.items():
+            if not isinstance(translated, str):
+                raise ValueError(f"Translation {lang!r}/{key!r} is {type(translated).__name__}, expected string")
+    return data
 
 
 def apply_translations(lang_file: str, new_translations: dict[str, str], deleted_keys: set[str]) -> None:

--- a/.github/scripts/translate_strings.py
+++ b/.github/scripts/translate_strings.py
@@ -52,6 +52,8 @@ def has_cdata(value: str) -> bool:
 
 def escape_xml_value(value: str) -> str:
     """Escape characters that must be escaped in Android strings.xml values."""
+    # translations arrive as plain text — real newlines become Android \n escapes
+    value = value.replace('\n', '\\n')
     # & first — convert XML quote entities to Android escapes, then
     # escape any bare & that isn't part of a remaining named entity
     value = value.replace('&apos;', "\\'")
@@ -94,12 +96,26 @@ def save_snapshot(snapshot: dict) -> None:
         json.dump(snapshot, f, indent=2, ensure_ascii=False, sort_keys=True)
 
 
+def unescape_android(value: str) -> str:
+    """Android strings.xml value → plain text for the translation prompt.
+
+    The model works with plain text and standard JSON escaping only;
+    escape_xml_value() re-applies the Android escaping on the way back.
+    Asking the model to emit Android escapes inside JSON values produced
+    invalid JSON (\\' is not a JSON escape; unescaped quotes end the string).
+    """
+    value = value.replace("\\'", "'").replace('\\"', '"').replace("\\n", "\n")
+    value = value.replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&")
+    return value
+
+
 def translate_new_strings(new_strings: dict[str, str]) -> dict[str, dict[str, str]]:
-    """Call Claude API. Returns {lang_code: {key: translated_value}}."""
+    """Call Claude API. Returns {lang_code: {key: translated_value}} as plain text."""
     client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
 
     strings_block = "\n".join(
-        f'<string name="{k}">{v}</string>' for k, v in new_strings.items()
+        f'<string name="{k}">{unescape_android(v)}</string>'
+        for k, v in new_strings.items()
     )
     lang_list = "\n".join(f"- {code}: {name}" for code, name in LANGUAGES.items())
 
@@ -114,8 +130,7 @@ English strings:
 Rules:
 - Keep name attributes exactly as-is (never translate the keys)
 - Preserve all Android format placeholders: %s, %d, %1$s, %2$s, %3$s, etc.
-- Preserve literal \\n newline sequences as \\n
-- Preserve XML entities &amp; &lt; &gt; — do NOT use &apos; or &quot;, use \' and \" instead (Android requirement)
+- Values are plain text: use standard JSON string escaping ONLY. Do not apply Android escaping — no backslash-apostrophe sequences, no XML entities. Multi-line values use the JSON \\n escape.
 - Return ONLY valid JSON with this exact structure:
 {{
   "de": {{"KeyName": "translated value", ...}},
@@ -127,12 +142,17 @@ No markdown fences, no explanation. Only the JSON object.
 
     message = client.messages.create(
         model="claude-haiku-4-5-20251001",
-        max_tokens=8192,
+        max_tokens=16000,
         messages=[{"role": "user", "content": prompt}],
     )
 
     text = re.sub(r"```(?:json)?\s*|\s*```", "", message.content[0].text).strip()
-    return json.loads(text)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as e:
+        print(f"    Model response was not valid JSON ({e}); first 500 chars:")
+        print(f"    {text[:500]!r}")
+        raise
 
 
 def apply_translations(lang_file: str, new_translations: dict[str, str], deleted_keys: set[str]) -> None:


### PR DESCRIPTION
The auto-translate workflow failed on JSON parsing (run 30626581005): the prompt instructed the model to use Android escaping (`\'`, `\"`) inside JSON string values — `\'` is not a valid JSON escape, and quote handling under that rule can terminate a JSON string early ("Expecting ',' delimiter"). The two escaping layers were conflated, and the failure surfaced with the first long multi-line string carrying quotes and entities.

The script already owns Android escaping via `escape_xml_value`, so the layers are now separated: source values are unescaped to plain text before prompting, the model returns plain text with standard JSON escaping only, and `escape_xml_value` re-applies Android escaping (gaining the newline → \n conversion). Round-tripped locally against the exact string that broke the run. Also bumps max_tokens to 16000 for headroom and prints the offending response head on a parse failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation handling for multiline text and Android/XML escape sequences.
  * Added clearer validation and diagnostic messages when translation responses are malformed or incorrectly formatted.
  * Increased support for longer translation outputs, reducing the likelihood of incomplete translations.
  * Improved compatibility with standard JSON formatting to help preserve translated text accurately.
  * Improved reliability when preserving line breaks and special characters in translated content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->