### PR TITLE
Let a bottom sheet opt into opening fully expanded

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/BottomSheetSceneStrategy.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/BottomSheetSceneStrategy.kt
@@ -3,6 +3,7 @@ package io.horizontalsystems.walletkit.modules.nav3
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.ModalBottomSheetProperties
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.scene.OverlayScene
@@ -19,6 +20,7 @@ internal class BottomSheetScene<T : Any>(
     override val overlaidEntries: List<NavEntry<T>>,
     private val entry: NavEntry<T>,
     private val modalBottomSheetProperties: ModalBottomSheetProperties,
+    private val skipPartiallyExpanded: Boolean,
     private val onBack: () -> Unit,
 ) : OverlayScene<T> {
 
@@ -27,6 +29,7 @@ internal class BottomSheetScene<T : Any>(
     override val content: @Composable (() -> Unit) = {
         ModalBottomSheet(
             onDismissRequest = onBack,
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = skipPartiallyExpanded),
             properties = modalBottomSheetProperties,
             dragHandle = null
         ) {
@@ -55,6 +58,7 @@ class BottomSheetSceneStrategy<T : Any> : SceneStrategy<T> {
                 overlaidEntries = entries.dropLast(1),
                 entry = lastEntry,
                 modalBottomSheetProperties = properties,
+                skipPartiallyExpanded = lastEntry.metadata[BOTTOM_SHEET_EXPANDED_KEY] == true,
                 onBack = onBack
             )
         }
@@ -67,12 +71,19 @@ class BottomSheetSceneStrategy<T : Any> : SceneStrategy<T> {
          *
          * @param modalBottomSheetProperties properties that should be passed to the containing
          * [ModalBottomSheet].
+         * @param skipPartiallyExpanded opens the sheet at full height instead of the
+         * half-screen stop — for tall content that would otherwise show partially.
          */
         @OptIn(ExperimentalMaterial3Api::class)
         fun bottomSheet(
-            modalBottomSheetProperties: ModalBottomSheetProperties = ModalBottomSheetProperties()
-        ): Map<String, Any> = mapOf(BOTTOM_SHEET_KEY to modalBottomSheetProperties)
+            modalBottomSheetProperties: ModalBottomSheetProperties = ModalBottomSheetProperties(),
+            skipPartiallyExpanded: Boolean = false,
+        ): Map<String, Any> = mapOf(
+            BOTTOM_SHEET_KEY to modalBottomSheetProperties,
+            BOTTOM_SHEET_EXPANDED_KEY to skipPartiallyExpanded,
+        )
 
         internal const val BOTTOM_SHEET_KEY = "bottomsheet"
+        internal const val BOTTOM_SHEET_EXPANDED_KEY = "bottomsheet_expanded"
     }
 }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/HSPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/HSPage.kt
@@ -19,6 +19,9 @@ import java.util.UUID
 @Serializable
 abstract class HSPage(
     val bottomSheet: Boolean = false,
+    // opens the sheet at full height instead of the half-screen stop —
+    // for tall sheet content that would otherwise show partially
+    val expandedBottomSheet: Boolean = false,
     val screenshotEnabled: Boolean = true,
     var resultKey: String? = null,
     val uuid: String = UUID.randomUUID().toString(),
@@ -30,7 +33,7 @@ abstract class HSPage(
     @OptIn(ExperimentalMaterial3Api::class)
     fun getMetadata() = buildMap {
         if (bottomSheet) {
-            putAll(BottomSheetSceneStrategy.bottomSheet())
+            putAll(BottomSheetSceneStrategy.bottomSheet(skipPartiallyExpanded = expandedBottomSheet))
         }
 
         putAll(getAnimationMetadata())

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/ui/extensions/HSBottomSheet.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/ui/extensions/HSBottomSheet.kt
@@ -37,7 +37,10 @@ import io.horizontalsystems.walletkit.ui.compose.components.subhead2_grey
 import kotlinx.serialization.Serializable
 
 @Serializable
-abstract class HSBottomSheet : HSPage(bottomSheet = true)
+abstract class HSBottomSheet(
+    // opt-in for tall sheets: open fully expanded instead of at the half stop
+    val expanded: Boolean = false,
+) : HSPage(bottomSheet = true, expandedBottomSheet = expanded)
 
 @Composable
 fun BottomSheetHeader(


### PR DESCRIPTION
The Nav3 bottom-sheet scene uses the default sheet state, so any sheet whose content is taller than half the screen opens at the partial-expand stop. Short sheets are unaffected, but instructional sheets with long content show cut off until the user drags.

HSBottomSheet gains an `expanded` opt-in (default false — no behavior change for existing sheets) that flows through HSPage metadata into the scene strategy, which creates the ModalBottomSheet's state with `skipPartiallyExpanded` accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring bottom sheets to open fully expanded.
  * Bottom sheets can now optionally skip partial expansion, with existing behavior preserved by default.
  * Added expanded-sheet support to page and bottom-sheet configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->