### PR TITLE
Constrain translations with a structured output schema

### DIFF
--- a/.github/scripts/translate_strings.py
+++ b/.github/scripts/translate_strings.py
@@ -114,6 +114,24 @@ def unescape_android(value: str) -> str:
     return value
 
 
+def response_schema(keys) -> dict:
+    """JSON schema for the translation payload — constrained decoding makes
+    invalid JSON impossible (prompt-only compliance broke on long multilingual
+    values) and pins the exact {lang: {key: str}} shape."""
+    entry = {
+        "type": "object",
+        "properties": {key: {"type": "string"} for key in keys},
+        "required": list(keys),
+        "additionalProperties": False,
+    }
+    return {
+        "type": "object",
+        "properties": {lang: entry for lang in LANGUAGES},
+        "required": list(LANGUAGES),
+        "additionalProperties": False,
+    }
+
+
 def translate_new_strings(new_strings: dict[str, str]) -> dict[str, dict[str, str]]:
     """Call Claude API. Returns {lang_code: {key: translated_value}} as plain text."""
     client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
@@ -148,6 +166,7 @@ No markdown fences, no explanation. Only the JSON object.
     message = client.messages.create(
         model="claude-haiku-4-5-20251001",
         max_tokens=16000,
+        output_config={"format": {"type": "json_schema", "schema": response_schema(new_strings.keys())}},
         messages=[{"role": "user", "content": prompt}],
     )
 


### PR DESCRIPTION
The auto-translate run on #9431 failed again with a JSON parse error — this time not from Android-escape conflation (#9432 fixed that; the response head shows correct JSON escaping) but from the model slipping an unescaped quote deep in the ~7K-char multilingual payload. Prompt-level compliance is not reliable at this length.

This switches the API call to structured outputs: the request now carries a JSON schema built from the known language codes and string keys (`output_config.format`), so the response is constrained-decoded — invalid JSON and wrong payload shapes become impossible rather than merely discouraged. Structured outputs are GA on the API (no beta header) and supported by Haiku 4.5.

The existing `json.loads` + shape validation stays as a belt-and-braces check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation processing by enforcing a consistent, valid response format.
  * Reduced the risk of malformed or incomplete translation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->