### PR TITLE
Stop re.sub from expanding Android escapes in translations

### DIFF
--- a/.github/scripts/translate_strings.py
+++ b/.github/scripts/translate_strings.py
@@ -217,7 +217,9 @@ def apply_translations(lang_file: str, new_translations: dict[str, str], deleted
         )
         new_entry = f'<string name="{key}">{value}</string>'
         if existing_pat.search(content):
-            content = existing_pat.sub(new_entry, content)
+            # lambda keeps new_entry literal — as a replacement template,
+            # re.sub would turn the Android \n escapes into real newlines
+            content = existing_pat.sub(lambda _: new_entry, content)
         else:
             content = content.replace("</resources>", f"    {new_entry}\n</resources>")
 


### PR DESCRIPTION
The structured-output run on #9431 produced valid JSON and correct plain-text translations, but the committed XML contained real newlines instead of `\n` escapes — Android collapses those to spaces, so the numbered GPM steps would render as one paragraph.

Root cause: `apply_translations` passes the escaped entry to `existing_pat.sub()` as a regex **replacement template**, and `re.sub` interprets template escapes — `\n` becomes a literal newline, while non-letter escapes like `\"` and `\'` pass through untouched. That matches the mangled output exactly. The bug only fires on the update path (key already present in the language file, true for all 9 files here) and only became reachable once #9432 started emitting `\n` escapes; the append path uses `str.replace` and was always safe.

Fix: substitute via `lambda _: new_entry` so the replacement is taken literally. Verified locally by replaying the exact failing update against the pre-run German file — old script reproduces the raw newlines, fixed script writes proper escapes and the value round-trips back to the original plain text.

After this merges, the bad bot commit on #9431 gets dropped and the branch rebased so the workflow regenerates correct translations.