### PR TITLE
Trigger dev deploy on push to version branches

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -1,7 +1,8 @@
 name: Deploy Dev to Firebase
 
 on:
-  workflow_dispatch:
+  push:
+    branches: [ version/* ]
 
 jobs:
   build:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Development deployments now run automatically when changes are pushed to `version/*` branches.
  * Manual triggering is no longer required for these deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->