### PR TITLE
Fix account scoping and address validation issues in swap recipient flow

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/enteraddress/EnterAddressScreen.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/enteraddress/EnterAddressScreen.kt
@@ -231,14 +231,7 @@ fun AddressCheck(
     if (addressValidationInProgress) {
         //show nothing
     } else if (addressValidationError != null) {
-        // our own validation errors carry a translated, user-facing message (e.g.
-        // send-to-self, transparent-Zcash-only); raw parser exceptions get generic text
-        val customMessage = when (addressValidationError) {
-            is AddressValidationError.InvalidAddress,
-            is AddressValidationError.SendToSelfForbidden -> addressValidationError.message
-
-            else -> null
-        }
+        val customMessage = addressValidationError.getErrorMessage()
         AlertCard(
             modifier = Modifier
                 .padding(horizontal = 16.dp)
@@ -303,13 +296,20 @@ fun AddressCheck(
     }
 }
 
+// Null means no user-facing text: the generic invalid-address description is shown
+// instead of a raw parser exception message
 @Composable
 private fun Throwable.getErrorMessage() = when (this) {
     is StellarAssetAdapter.NoTrustlineError -> {
-        stringResource(R.string.Error_AssetNotEnabled, code)
+        stringResource(R.string.Swap_RecipientAddress_NoTrustline, code)
     }
 
-    else -> this.message
+    // our own validation errors carry a translated, user-facing message
+    // (transparent-Zcash-only, missing trustline, send-to-self)
+    is AddressValidationError.InvalidAddress,
+    is AddressValidationError.SendToSelfForbidden -> message
+
+    else -> null
 }
 
 @Composable

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapSelectCoinViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapSelectCoinViewModel.kt
@@ -35,10 +35,10 @@ class SwapSelectCoinViewModel(
     // delivered to an external address the user enters before confirmation
     private val allowExternalReceive: Boolean,
 ) : ViewModel() {
-    private val activeAccount = App.accountManager.activeAccount
-    private val coinsProvider = activeAccount?.let {
-        FullCoinsProvider(App.marketKit, it, filterByAccountSupport = !allowExternalReceive)
-    }
+    // Account-scoped state is resolved per call, not snapshotted at construction:
+    // the picker can outlive an account switch, and a long-lived snapshot would mix
+    // old-account sections with new-account filtering
+    private var coinsProvider: FullCoinsProvider? = null
     private val adapterManager = App.adapterManager
     private val currencyManager = App.currencyManager
     private val marketKit = App.marketKit
@@ -64,11 +64,30 @@ class SwapSelectCoinViewModel(
         private set
 
     init {
-        coinsProvider?.setActiveWallets(App.walletManager.activeWallets)
         viewModelScope.launch {
             loadSections()
             emitState()
         }
+    }
+
+    // Returns a provider bound to the currently active account, rebuilding it after
+    // an account switch so search never serves results scoped to a stale account
+    private fun currentCoinsProvider(): FullCoinsProvider? {
+        val account = App.accountManager.activeAccount ?: run {
+            coinsProvider = null
+            return null
+        }
+
+        coinsProvider?.let { cached ->
+            if (cached.activeAccount == account) return cached
+        }
+
+        return FullCoinsProvider(App.marketKit, account, filterByAccountSupport = !allowExternalReceive)
+            .apply {
+                setActiveWallets(App.walletManager.activeWallets)
+                setQuery(query)
+            }
+            .also { coinsProvider = it }
     }
 
     fun setQuery(q: String) {
@@ -135,11 +154,13 @@ class SwapSelectCoinViewModel(
         val top = mutableListOf<CoinBalanceItem>()
         val topCoins = marketKit.fullCoins("", 100)
             .sortedBy { it.coin.marketCapRank ?: Int.MAX_VALUE }
+        // read at call time: the picker can outlive an account switch
+        val accountType = App.accountManager.activeAccount?.type
         for (fullCoin in topCoins) {
             if (top.size >= 25) break
 
-            val eligible = if (activeAccount != null && !allowExternalReceive) {
-                fullCoin.eligibleTokens(activeAccount.type)
+            val eligible = if (accountType != null && !allowExternalReceive) {
+                fullCoin.eligibleTokens(accountType)
             } else {
                 externallyReceivableTokens(fullCoin)
             }
@@ -159,14 +180,16 @@ class SwapSelectCoinViewModel(
 
     private suspend fun search(q: String): List<CoinBalanceItem> = withContext(Dispatchers.Default) {
         val activeWallets = App.walletManager.activeWallets
+        val coinsProvider = currentCoinsProvider()
 
-        if (coinsProvider != null && activeAccount != null) {
+        if (coinsProvider != null) {
+            val accountType = coinsProvider.activeAccount.type
             coinsProvider.getItems()
                 .map { fullCoin ->
                     if (allowExternalReceive) {
                         externallyReceivableTokens(fullCoin)
                     } else {
-                        fullCoin.eligibleTokens(activeAccount.type)
+                        fullCoin.eligibleTokens(accountType)
                     }
                 }
                 .flatten()

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/address/EnterAddressValidator.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/address/EnterAddressValidator.kt
@@ -148,7 +148,8 @@ class StellarAddressValidator(private val token: Token) : EnterAddressValidator 
                 throw e
             } catch (_: StellarAssetAdapter.NoTrustlineError) {
                 false
-            } catch (_: Throwable) {
+            } catch (_: Exception) {
+                // fatal Errors (OOM, LinkageError) are left to propagate
                 null
             }
         }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/address/EnterAddressValidator.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/address/EnterAddressValidator.kt
@@ -10,6 +10,7 @@ import io.horizontalsystems.walletkit.core.ISendStellarAdapter
 import io.horizontalsystems.walletkit.core.ISendThorchainAdapter
 import io.horizontalsystems.walletkit.core.ISendTronAdapter
 import io.horizontalsystems.walletkit.core.ISendZcashAdapter
+import io.horizontalsystems.walletkit.core.adapters.StellarAssetAdapter
 import io.horizontalsystems.walletkit.core.adapters.zcash.ZcashAdapter.ZcashError
 import io.horizontalsystems.walletkit.core.providers.Translator
 import io.horizontalsystems.walletkit.entities.Address
@@ -31,6 +32,7 @@ import io.horizontalsystems.stellarkit.StellarKit
 import io.horizontalsystems.stellarkit.room.StellarAsset
 import io.horizontalsystems.thorchainkit.network.Network
 import io.horizontalsystems.tonkit.FriendlyAddress
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -120,32 +122,39 @@ class TonAddressValidator : EnterAddressValidator {
 
 class StellarAddressValidator(private val token: Token) : EnterAddressValidator {
     private val sendAdapter by lazy { App.adapterManager.getAdapterForToken<ISendStellarAdapter>(token) }
-    override suspend fun validate(address: Address) {
-        val adapter = sendAdapter
-        if (adapter != null) {
-            adapter.validate(address.hex)
-            return
-        }
 
-        // no enabled wallet (external swap recipient) — static format check, plus the
-        // same trustline requirement the adapter enforces: a non-native asset sent to
-        // an account without the trustline is rejected by the network
+    override suspend fun validate(address: Address) {
+        // format is decided locally and is authoritative
         StellarKit.validateAddress(address.hex)
 
-        val tokenType = token.type
-        if (tokenType is TokenType.Asset) {
-            val enabled = withContext(Dispatchers.IO) {
-                StellarKit.isAssetEnabled(
+        // native XLM needs no trustline
+        val tokenType = token.type as? TokenType.Asset ?: return
+
+        // A non-native asset sent to an account without the trustline is rejected by the
+        // network, so the recipient's trustline is part of address validity. Null means
+        // the state could not be resolved (Horizon unreachable) — a well-formed address
+        // must not be rejected for that; the network stays the authority at send time.
+        val trustlineEstablished = withContext(Dispatchers.IO) {
+            try {
+                sendAdapter?.let { adapter ->
+                    adapter.validate(address.hex)
+                    true
+                } ?: StellarKit.isAssetEnabled(
                     StellarNetwork.MainNet,
                     StellarAsset.Asset(tokenType.code, tokenType.issuer),
                     address.hex
                 )
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: StellarAssetAdapter.NoTrustlineError) {
+                false
+            } catch (_: Throwable) {
+                null
             }
-            if (!enabled) {
-                throw AddressValidationError.InvalidAddress(
-                    Translator.getString(R.string.Swap_RecipientAddress_NoTrustline, tokenType.code)
-                )
-            }
+        }
+
+        if (trustlineEstablished == false) {
+            throw StellarAssetAdapter.NoTrustlineError(tokenType.code)
         }
     }
 }


### PR DESCRIPTION
Follow-up fixes to #9443 from audit review.

## Changes

- **Account-scoped picker state** — `SwapSelectCoinViewModel` snapshotted `activeAccount` and `coinsProvider` at construction while `supportedByAccount` already read the account per call, so after an account switch with a live picker (e.g. duress unlock) recent/popular filtered by the new account while top/search stayed bound to the old one. The provider is now rebuilt when the active account changes, and top tokens read the account when built.
- **Specific validation error messages** — the address error card always rendered the generic invalid-address description, so a missing trustline or a shielded-Zcash rejection read as "doesn't fit the selected network". The text now goes through the `getErrorMessage` helper that already existed for `NoTrustlineError` but was never called.
- **Stellar trustline resolution** — the adapter's `validate()` blocks on a Horizon request but ran on the caller's `Dispatchers.Default`, and any non-404 Horizon failure surfaced as an invalid address. Both branches now resolve the trustline on `Dispatchers.IO` and treat an unresolvable state as no verdict, matching the policy documented in `StellarSwapProvider.activationAction`. Both also throw the same `NoTrustlineError`, so a single message covers them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address validation messaging with clearer, localized errors and a consistent fallback for invalid addresses.
  * Stellar native XLM addresses can now be validated without a trustline; asset trustline requirements are checked correctly.
  * Address validation now handles cancellation reliably.
  * Swap coin selection refreshes correctly when the active account changes, ensuring current wallets, tokens, popular coins, recent selections, and search results are shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->