### PR TITLE
Add Lizex and Bitania to MultiSwap providers

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/MultiSwapProviderRegistry.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/MultiSwapProviderRegistry.kt
@@ -23,6 +23,8 @@ object MultiSwapProviderRegistry {
         USwapProvider(UProvider.Exolix),
         USwapProvider(UProvider.Cce),
         USwapProvider(UProvider.Swapuz),
+        USwapProvider(UProvider.Lizex),
+        USwapProvider(UProvider.Bitania),
         USwapProvider(UProvider.Barter),
         USwapProvider(UProvider.Circle),
         USwapProvider(UProvider.Pegasus),

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/UProvider.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/UProvider.kt
@@ -99,6 +99,30 @@ enum class UProvider(
         isSingleTransactionSwap = false,
         supportsSimpleUtxoTransactions = true
     ),
+    Lizex(
+        "LIZEX",
+        "Lizex",
+        SwapProviderType.CEX,
+        true,
+        false,
+        true,
+        RiskLevel.GOOD,
+        isEvm = false,
+        isSingleTransactionSwap = false,
+        supportsSimpleUtxoTransactions = true
+    ),
+    Bitania(
+        "BITANIA",
+        "Bitania",
+        SwapProviderType.CEX,
+        true,
+        false,
+        true,
+        RiskLevel.GOOD,
+        isEvm = false,
+        isSingleTransactionSwap = false,
+        supportsSimpleUtxoTransactions = true
+    ),
     Barter(
         "BARTER",
         "Barter",


### PR DESCRIPTION
#9449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Lizex and Bitania as supported multi-swap providers.
  * Enabled swaps through these providers with AML safeguards, required terms, and UTXO transaction support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->