### PR TITLE
Fix swap time icon click in swap history

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/history/SwapInfoPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/history/SwapInfoPage.kt
@@ -240,6 +240,11 @@ fun SwapInfoScreen(recordId: Int, navigation: HSNavigation) {
                                 text = infoTitle.hs,
                                 icon = painterResource(R.drawable.ic_info_24),
                                 iconTint = ComposeAppTheme.colors.grey,
+                                onIconClick = {
+                                    navigation.slideFromBottom(
+                                        SwapInfoSheet(SwapInfoSheet.Input(infoTitle, infoText, R.drawable.ic_circle_clock_24))
+                                    )
+                                },
                             )
                         },
                         right = {
@@ -251,11 +256,6 @@ fun SwapInfoScreen(recordId: Int, navigation: HSNavigation) {
                                         leah
                                     }
                                 )
-                            )
-                        },
-                        onClick = {
-                            navigation.slideFromBottom(
-                                SwapInfoSheet(SwapInfoSheet.Input(infoTitle, infoText, R.drawable.ic_circle_clock_24))
                             )
                         },
                     )


### PR DESCRIPTION
#9348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated swap history information interactions so the details sheet opens when tapping the information icon, improving interaction precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->