### PR TITLE
Include blockchain name in insufficient fee error

### DIFF
--- a/walletkit-chain-solana/src/main/java/io/horizontalsystems/walletkit/modules/send/solana/SendSolanaViewModel.kt
+++ b/walletkit-chain-solana/src/main/java/io/horizontalsystems/walletkit/modules/send/solana/SendSolanaViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewModelScope
 import io.horizontalsystems.walletkit.R
 import io.horizontalsystems.walletkit.core.App
+import io.horizontalsystems.walletkit.core.coinCodeWithNetwork
 import io.horizontalsystems.walletkit.core.EvmError
 import io.horizontalsystems.walletkit.core.HSCaution
 import io.horizontalsystems.walletkit.core.ISendSolanaAdapter
@@ -161,7 +162,7 @@ class SendSolanaViewModel(
     private fun createCaution(error: Throwable) = when (error) {
         is UnknownHostException -> HSCaution(TranslatableString.ResString(R.string.Hud_Text_NoInternet))
         is LocalizedException -> HSCaution(TranslatableString.ResString(error.errorTextRes))
-        is EvmError.InsufficientBalanceWithFee -> SendErrorInsufficientBalance(feeToken.coin.code)
+        is EvmError.InsufficientBalanceWithFee -> SendErrorInsufficientBalance(feeToken.coinCodeWithNetwork)
         else -> HSCaution(TranslatableString.PlainString(error.cause?.message ?: error.message ?: ""))
     }
 

--- a/walletkit-chain-zano/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/sendtransaction/SendTransactionServiceZano.kt
+++ b/walletkit-chain-zano/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/sendtransaction/SendTransactionServiceZano.kt
@@ -2,6 +2,7 @@ package io.horizontalsystems.walletkit.modules.multiswap.sendtransaction
 
 import io.horizontalsystems.walletkit.R
 import io.horizontalsystems.walletkit.core.App
+import io.horizontalsystems.walletkit.core.coinCodeWithNetwork
 import io.horizontalsystems.walletkit.core.adapters.ZanoAdapter
 import io.horizontalsystems.walletkit.core.ethereum.CautionViewItem
 import io.horizontalsystems.walletkit.core.providers.Translator
@@ -76,7 +77,7 @@ class SendTransactionServiceZano(
                 result.add(
                     CautionViewItem(
                         title = Translator.getString(R.string.EthereumTransaction_Error_InsufficientBalance_Title),
-                        text = Translator.getString(R.string.EthereumTransaction_Error_InsufficientBalanceForFee, feeToken.coin.code),
+                        text = Translator.getString(R.string.EthereumTransaction_Error_InsufficientBalanceForFee, feeToken.coinCodeWithNetwork),
                         type = CautionViewItem.Type.Error
                     )
                 )

--- a/walletkit-chain-zano/src/main/java/io/horizontalsystems/walletkit/modules/send/zano/SendZanoViewModel.kt
+++ b/walletkit-chain-zano/src/main/java/io/horizontalsystems/walletkit/modules/send/zano/SendZanoViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import io.horizontalsystems.walletkit.R
 import io.horizontalsystems.walletkit.core.App
 import io.horizontalsystems.walletkit.core.AppLogger
+import io.horizontalsystems.walletkit.core.coinCodeWithNetwork
 import io.horizontalsystems.walletkit.core.HSCaution
 import io.horizontalsystems.walletkit.core.ISendZanoAdapter
 import io.horizontalsystems.walletkit.core.LocalizedException
@@ -126,7 +127,7 @@ class SendZanoViewModel(
             type = HSCaution.Type.Error,
             description = TranslatableString.ResString(
                 R.string.EthereumTransaction_Error_InsufficientBalanceForFee,
-                feeToken.coin.code
+                feeToken.coinCodeWithNetwork
             )
         )
     }

--- a/walletkit-chain-zcash/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/sendtransaction/SendTransactionServiceZcash.kt
+++ b/walletkit-chain-zcash/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/sendtransaction/SendTransactionServiceZcash.kt
@@ -3,6 +3,7 @@ package io.horizontalsystems.walletkit.modules.multiswap.sendtransaction
 import cash.z.ecc.android.sdk.ext.convertZatoshiToZec
 import cash.z.ecc.android.sdk.model.Proposal
 import io.horizontalsystems.walletkit.core.App
+import io.horizontalsystems.walletkit.core.coinCodeWithNetwork
 import io.horizontalsystems.walletkit.core.InsufficientBalance
 import io.horizontalsystems.walletkit.core.adapters.zcash.ZcashAdapter
 import io.horizontalsystems.walletkit.core.ethereum.CautionViewItem
@@ -65,7 +66,7 @@ class SendTransactionServiceZcash(
         } catch (e: Throwable) {
             val message = e.message
             error = if (message != null && message.contains("Insufficient balance", ignoreCase = true)) {
-                InsufficientBalance(feeToken.coin.code)
+                InsufficientBalance(feeToken.coinCodeWithNetwork)
             } else {
                 e
             }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/MarketKitExtensions.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/MarketKitExtensions.kt
@@ -573,6 +573,9 @@ private val noBadgeCoinCodes by lazy {
     listOf("AVAX", "XLM", "DASH", "ZEC", "XMR", "XEC", "POL", "SOL", "XDAI", "FTM")
 }
 
+val Token.coinCodeWithNetwork: String
+    get() = "${coin.code} (${blockchain.name})"
+
 val Token.badge: String?
     get() {
         val tokenType = type

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/ethereum/CautionViewItemFactory.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/ethereum/CautionViewItemFactory.kt
@@ -3,6 +3,7 @@ package io.horizontalsystems.walletkit.core.ethereum
 import io.horizontalsystems.walletkit.R
 import io.horizontalsystems.walletkit.core.EvmError
 import io.horizontalsystems.walletkit.core.Warning
+import io.horizontalsystems.walletkit.core.coinCodeWithNetwork
 import io.horizontalsystems.walletkit.core.convertedError
 import io.horizontalsystems.walletkit.core.providers.Translator
 import io.horizontalsystems.walletkit.modules.evmfee.FeeSettingsError
@@ -55,7 +56,7 @@ class CautionViewItemFactory(
                     Translator.getString(R.string.EthereumTransaction_Error_InsufficientBalance_Title),
                     Translator.getString(
                         R.string.EthereumTransaction_Error_InsufficientBalanceForFee,
-                        baseCoinService.token.coin.code
+                        baseCoinService.token.coinCodeWithNetwork
                     ),
                     CautionViewItem.Type.Error
                 )
@@ -81,7 +82,7 @@ class CautionViewItemFactory(
                     Translator.getString(R.string.EthereumTransaction_Error_Title),
                     Translator.getString(
                         R.string.EthereumTransaction_Error_InsufficientBalanceForFee,
-                        baseCoinService.token.coin.code
+                        baseCoinService.token.coinCodeWithNetwork
                     )
                 )
             }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/sendtransaction/SendTransactionServiceTron.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/sendtransaction/SendTransactionServiceTron.kt
@@ -2,6 +2,7 @@ package io.horizontalsystems.walletkit.modules.multiswap.sendtransaction
 
 import io.horizontalsystems.walletkit.R
 import io.horizontalsystems.walletkit.core.App
+import io.horizontalsystems.walletkit.core.coinCodeWithNetwork
 import io.horizontalsystems.walletkit.core.HSCaution
 import io.horizontalsystems.walletkit.core.HSCaution.Type
 import io.horizontalsystems.walletkit.core.ISendTronAdapter
@@ -90,7 +91,7 @@ class SendTransactionServiceTron(token: Token) : AbstractSendTransactionService(
                         description = TranslatableString.PlainString(
                             Translator.getString(
                                 R.string.EthereumTransaction_Error_InsufficientBalanceForFee,
-                                nativeToken.coin.code
+                                nativeToken.coinCodeWithNetwork
                             )
                         )
                     ).toCautionViewItem()

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/tron/SendTronViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/tron/SendTronViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import io.horizontalsystems.walletkit.R
 import io.horizontalsystems.walletkit.core.App
 import io.horizontalsystems.walletkit.core.AppLogger
+import io.horizontalsystems.walletkit.core.coinCodeWithNetwork
 import io.horizontalsystems.walletkit.core.HSCaution
 import io.horizontalsystems.walletkit.core.ISendTronAdapter
 import io.horizontalsystems.walletkit.core.LocalizedException
@@ -155,7 +156,7 @@ class SendTronViewModel(
                     description = TranslatableString.PlainString(
                         Translator.getString(
                             R.string.EthereumTransaction_Error_InsufficientBalanceForFee,
-                            feeToken.coin.code
+                            feeToken.coinCodeWithNetwork
                         )
                     )
                 )


### PR DESCRIPTION
#9463

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved insufficient-balance and insufficient-fee messages across supported networks.
  * Fee-related warnings now identify tokens with their blockchain network, reducing ambiguity when similarly named assets are involved.
  * Updated send and multi-send flows for Solana, Zano, Zcash, Ethereum-compatible networks, and Tron.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->