### PR TITLE
Simplify swap time attention logic to an absolute threshold

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapConfirmPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapConfirmPage.kt
@@ -331,7 +331,7 @@ private fun SwapConfirmInternal(
                         SwapProviderType.CEX -> formatSwapTimeRange(estimatedTime)
                         SwapProviderType.DEX -> "~${formatDuration(estimatedTime)}"
                     }
-                    val timeColor = if (swapTimeStatus(estimatedTime, listOf(estimatedTime)) == SwapTimeStatus.Attention) {
+                    val timeColor = if (swapTimeStatus(estimatedTime, uiState.providerType) == SwapTimeStatus.Attention) {
                         ComposeAppTheme.colors.jacob
                     } else {
                         ComposeAppTheme.colors.leah

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapPage.kt
@@ -667,29 +667,28 @@ private fun ProviderCellInfo(
             },
             onClick = onClickProviderScoreInfo
         )
-        if (swapTimeStatus == SwapTimeStatus.Attention) {
-            quote.estimationTime?.let { estimationTime ->
-                val infoTitle = stringResource(R.string.Swap_SwapTime)
-                val infoText = stringResource(R.string.Swap_EstimatedTimeDescription)
-                CellSecondary(
-                    middle = {
-                        CellMiddleInfoTextIcon(
-                            text = infoTitle.hs,
-                            icon = painterResource(R.drawable.ic_info_24),
-                            iconTint = ComposeAppTheme.colors.grey,
-                        )
-                    },
-                    right = {
-                        SwapTime(
-                            estimationTime = estimationTime,
-                            providerType = quote.provider.type,
-                        )
-                    },
-                    onClick = {
-                        onClickSwapTimeInfo(infoTitle, infoText)
-                    }
-                )
-            }
+        quote.estimationTime?.let { estimationTime ->
+            val infoTitle = stringResource(R.string.Swap_SwapTime)
+            val infoText = stringResource(R.string.Swap_EstimatedTimeDescription)
+            CellSecondary(
+                middle = {
+                    CellMiddleInfoTextIcon(
+                        text = infoTitle.hs,
+                        icon = painterResource(R.drawable.ic_info_24),
+                        iconTint = ComposeAppTheme.colors.grey,
+                    )
+                },
+                right = {
+                    SwapTime(
+                        estimationTime = estimationTime,
+                        providerType = quote.provider.type,
+                        timeStatus = swapTimeStatus,
+                    )
+                },
+                onClick = {
+                    onClickSwapTimeInfo(infoTitle, infoText)
+                }
+            )
         }
     }
 }
@@ -699,8 +698,13 @@ private fun SwapTime(
     modifier: Modifier = Modifier,
     estimationTime: Long,
     providerType: SwapProviderType,
+    timeStatus: SwapTimeStatus,
 ) {
-    val color = ComposeAppTheme.colors.jacob
+    val color = if (timeStatus == SwapTimeStatus.Attention) {
+        ComposeAppTheme.colors.jacob
+    } else {
+        ComposeAppTheme.colors.grey
+    }
     Row(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapSelectProviderPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapSelectProviderPage.kt
@@ -302,7 +302,7 @@ fun formatSwapTimeRange(totalSeconds: Long): String {
     }
 }
 
-private fun roundSecondsToMinutes(seconds: Double): Long =
+fun roundSecondsToMinutes(seconds: Double): Long =
     (seconds / 60).roundToLong().coerceAtLeast(1) * 60
 
 @Preview

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapSelectProviderViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapSelectProviderViewModel.kt
@@ -57,8 +57,6 @@ class SwapSelectProviderViewModel(
 
     private fun getViewItems(quotes: List<SwapProviderQuote>): List<QuoteViewItem> {
         val fiatAmountIn = getFiatValue(amountIn, rateTokenIn)
-        val allEstimationTimes = quotes.map { it.estimationTime }
-
         return quotes.map { quote ->
             val fiatAmountOut = getFiatValue(quote.amountOut, rateTokenOut)
             val tokenAmount = App.numberFormatter.formatCoinFull(
@@ -77,7 +75,7 @@ class SwapSelectProviderViewModel(
                 tokenAmount = tokenAmount,
                 priceImpactData = priceImpactData,
                 estimationTime = quote.estimationTime,
-                timeStatus = swapTimeStatus(quote.estimationTime, allEstimationTimes),
+                timeStatus = swapTimeStatus(quote.estimationTime, quote.provider.type),
             )
         }
     }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapTimeStatus.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapTimeStatus.kt
@@ -1,33 +1,36 @@
 package io.horizontalsystems.walletkit.modules.multiswap
 
+import io.horizontalsystems.walletkit.modules.multiswap.providers.SwapProviderType
+
 enum class SwapTimeStatus {
     None,
     Attention,
 }
 
 private const val SWAP_TIME_THRESHOLD_SECONDS = 30 * 60L // 30 minutes
-private const val SWAP_TIME_RATIO = 2.0
 
 /**
- * Swap time is highlighted (yellow) only when it is critical for the user, see swap_time_spec_v2.
+ * Swap time is highlighted (orange) when the highest time the user may have to wait is 30 min or more.
  *
- * - Multiple providers: attention when ratio >= 2 (relative to the fastest provider) AND time > 30 min.
- * - Single provider: attention when time > 30 min (no relative comparison possible).
- *
- * In both modes the absolute threshold is a strict "> 30 min", so exactly 30 min stays silent.
+ * The comparison uses the same upper limit that is displayed:
+ * - CEX providers show a ±25% range, so the top of that range is used.
+ * - DEX providers show the single quoted value, which is used directly.
  */
-fun swapTimeStatus(estimationTime: Long?, allEstimationTimes: List<Long?>): SwapTimeStatus {
-    if (estimationTime == null || estimationTime <= SWAP_TIME_THRESHOLD_SECONDS) {
+fun swapTimeStatus(estimationTime: Long?, providerType: SwapProviderType?): SwapTimeStatus {
+    if (estimationTime == null || providerType == null) {
         return SwapTimeStatus.None
     }
 
-    val knownTimes = allEstimationTimes.filterNotNull()
-    if (knownTimes.size <= 1) {
-        // single provider — only the absolute threshold applies
-        return SwapTimeStatus.Attention
+    val upperLimitSeconds = swapTimeUpperLimitSeconds(estimationTime, providerType)
+    return if (upperLimitSeconds >= SWAP_TIME_THRESHOLD_SECONDS) {
+        SwapTimeStatus.Attention
+    } else {
+        SwapTimeStatus.None
     }
-
-    val baseline = knownTimes.min()
-    val ratio = estimationTime.toDouble() / baseline
-    return if (ratio >= SWAP_TIME_RATIO) SwapTimeStatus.Attention else SwapTimeStatus.None
 }
+
+private fun swapTimeUpperLimitSeconds(estimationTime: Long, providerType: SwapProviderType): Long =
+    when (providerType) {
+        SwapProviderType.CEX -> roundSecondsToMinutes(estimationTime * 1.25)
+        SwapProviderType.DEX -> estimationTime
+    }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapViewModel.kt
@@ -271,7 +271,7 @@ class SwapViewModel(
         initialShowRegularPrice = initialShowRegularPrice,
         swapTimeStatus = swapTimeStatus(
             quoteState.quote?.estimationTime,
-            quoteState.quotes.map { it.estimationTime }
+            quoteState.quote?.provider?.type
         ),
         allowanceActionSuppressed = allowanceActionSuppressed(),
         externalRecipientRequired = externalRecipientRequired(quoteState.tokenOut),

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/history/SwapInfoViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/history/SwapInfoViewModel.kt
@@ -146,7 +146,10 @@ class SwapInfoViewModel(
             }
         }
         swapTimeAttention =
-            swapTimeStatus(record.estimatedTime, listOf(record.estimatedTime)) == SwapTimeStatus.Attention
+            swapTimeStatus(
+                record.estimatedTime,
+                MultiSwapProviderRegistry.providerType(record.providerId)
+            ) == SwapTimeStatus.Attention
 
         emitState()
     }


### PR DESCRIPTION
#9348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap-time status calculations based on the selected provider type.
  * Swap estimates are now displayed whenever available, with attention coloring applied only when appropriate.
  * Updated swap history and confirmation views to show more accurate timing information.
  * Provider-specific timing thresholds now better reflect CEX and DEX estimate behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->