### PR TITLE
Remove eth_sign method from WalletConnect

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/entities/Account.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/entities/Account.kt
@@ -1,6 +1,5 @@
 package io.horizontalsystems.walletkit.entities
 
-import io.horizontalsystems.walletkit.core.managers.EvmKitManagerRegistry
 import io.horizontalsystems.ethereumkit.core.signer.Signer
 import io.horizontalsystems.ethereumkit.models.Chain
 import io.horizontalsystems.hdwalletkit.HDExtendedKey
@@ -11,7 +10,6 @@ import io.horizontalsystems.hdwalletkit.WordList
 import io.horizontalsystems.marketkit.models.BlockchainType
 import io.horizontalsystems.marketkit.models.TokenType
 import io.horizontalsystems.walletkit.R
-import io.horizontalsystems.walletkit.core.App
 import io.horizontalsystems.walletkit.core.managers.PassphraseValidator
 import io.horizontalsystems.walletkit.core.providers.Translator
 import io.horizontalsystems.walletkit.core.shorten
@@ -435,23 +433,6 @@ sealed class AccountType {
         else -> null
     }
 
-    fun sign(message: ByteArray, isLegacy: Boolean = false): ByteArray? {
-        val signer = when (this) {
-            is Mnemonic -> {
-                Signer.getInstance(seed, EvmKitManagerRegistry.getChain(BlockchainType.Ethereum))
-            }
-            is EvmPrivateKey -> {
-                Signer.getInstance(key, EvmKitManagerRegistry.getChain(BlockchainType.Ethereum))
-            }
-            else -> null
-        } ?: return null
-
-        return if (isLegacy) {
-            signer.signByteArrayLegacy(message)
-        } else {
-            signer.signByteArray(message)
-        }
-    }
 }
 
 val HDWallet.Purpose.derivation: AccountType.Derivation

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/handler/WCHandlerEvm.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/handler/WCHandlerEvm.kt
@@ -22,7 +22,6 @@ class WCHandlerEvm(
     override val supportedMethods = listOf(
         "eth_sendTransaction",
         "personal_sign",
-        "eth_sign",
         "eth_signTransaction",
         "eth_signTypedData",
         "eth_signTypedData_v4",
@@ -44,7 +43,6 @@ class WCHandlerEvm(
 
         val title = when (method) {
             "personal_sign" -> "Personal Sign Request"
-            "eth_sign" -> "Standard Sign Request"
             "eth_signTypedData" -> "Typed Sign Request"
             "eth_sendTransaction" -> "Approve Transaction"
             "eth_signTransaction" -> "Sign Transaction"
@@ -53,7 +51,6 @@ class WCHandlerEvm(
 
         val shortTitle = when (method) {
             "personal_sign" -> "Sign"
-            "eth_sign" -> "Sign"
             "eth_signTypedData" -> "Sign"
             "eth_sendTransaction" -> "Approve"
             "eth_signTransaction" -> "Sign"

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/WCRequestEvmViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/WCRequestEvmViewModel.kt
@@ -22,7 +22,6 @@ import kotlin.coroutines.suspendCoroutine
 private const val PERSONAL_SIGN_METHOD = "personal_sign"
 private const val TYPED_DATA_METHOD = "eth_signTypedData"
 private const val TYPED_DATA_METHOD_V4 = "eth_signTypedData_v4"
-private const val ETH_SIGN_METHOD = "eth_sign"
 private const val SEND_TRANSACTION_METHOD = "eth_sendTransaction"
 private const val SIGN_TRANSACTION_METHOD = "eth_signTransaction"
 
@@ -89,15 +88,6 @@ class WCRequestEvmViewModel(
                 extractMessageParamFromPersonalSign(sessionRequest.params)
             }
 
-            ETH_SIGN_METHOD -> {
-                val params = JsonParser.parseString(sessionRequest.params).asJsonArray
-                if (params.size() >= 2) {
-                    params.get(1).asString
-                } else {
-                    throw Exception("Invalid Data")
-                }
-            }
-
             TYPED_DATA_METHOD, TYPED_DATA_METHOD_V4, SEND_TRANSACTION_METHOD, SIGN_TRANSACTION_METHOD -> {
                 val params = JsonParser.parseString(sessionRequest.params).asJsonArray
                 params.firstOrNull { it.isJsonObject }?.asJsonObject?.toString()
@@ -138,15 +128,6 @@ class WCRequestEvmViewModel(
             val sessionRequest = sessionRequestUi as? SessionRequestUI.Content
             if (sessionRequest != null) {
                 val result = when (sessionRequest.method) {
-                    ETH_SIGN_METHOD -> {
-                        val message = sessionRequest.param.hexStringToByteArray()
-                        if (message.size == 32) {
-                            signer.signByteArrayLegacy(message = message)
-                        } else {
-                            signer.signByteArray(message = message)
-                        }
-                    }
-
                     PERSONAL_SIGN_METHOD -> {
                         signer.signByteArray(message = sessionRequest.param.toByteArray())
                     }
@@ -155,7 +136,7 @@ class WCRequestEvmViewModel(
                         signer.signTypedData(rawJsonMessage = sessionRequest.param)
                     }
 
-                    else -> throw Exception("Unsupported Chain")
+                    else -> throw Exception("Unsupported method: ${sessionRequest.method}")
                 }
 
                 WCDelegate.discardActiveSessionRequest(sessionRequest.requestId)


### PR DESCRIPTION
#9472

Removes the deprecated `eth_sign` method from the WalletConnect namespace and request handling, and drops the unused `AccountType.sign` helper. Other major wallets removed this method some time ago, and the remaining signing methods cover all current dApp use cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Removed support for legacy `eth_sign` WalletConnect requests.
  * WalletConnect signing continues to support personal message signing and typed-data signing methods.
  * Unsupported request errors now identify the unsupported method more clearly.
  * Removed the legacy account message-signing option, helping ensure signing requests use the supported, more secure methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->