### PR TITLE
Fix warning-level audit findings

### DIFF
--- a/walletkit-chain-ton/src/main/java/io/horizontalsystems/walletkit/core/managers/TonConnectManager.kt
+++ b/walletkit-chain-ton/src/main/java/io/horizontalsystems/walletkit/core/managers/TonConnectManager.kt
@@ -56,13 +56,14 @@ class TonConnectManager(
         _pendingDappRequest.value = null
     }
 
+    /**
+     * Throws when the request cannot be read. Callers decide how to report it — the scanner turns
+     * a failure into a visible "invalid QR code" message, which swallowing it here defeated: a
+     * malformed code looked exactly like nothing having happened.
+     */
     suspend fun handle(scannedText: String, closeAppOnResult: Boolean = false) {
-        try {
-            val dAppRequest = kit.readData(scannedText)
-            _pendingDappRequest.value = DAppRequestEntityWrapper(dAppRequest, closeAppOnResult)
-        } catch (e: Throwable) {
-            Timber.e(e, "Reading TonConnect request failed")
-        }
+        val dAppRequest = kit.readData(scannedText)
+        _pendingDappRequest.value = DAppRequestEntityWrapper(dAppRequest, closeAppOnResult)
     }
 }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/analytics/CoinAnalyticsService.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/analytics/CoinAnalyticsService.kt
@@ -78,9 +78,14 @@ class CoinAnalyticsService(
     }
 
     private suspend fun preview() {
-        val addresses = accountManager.accounts.mapNotNull { account ->
-            ChainRegistry.all.firstNotNullOfOrNull { it.analyticsAddress(account.type) }
-        }
+        // Only the active account. Sending every account's address in one request tells the server
+        // that all of those wallets belong to the same person, which is a correlation the user
+        // never asked for and cannot undo.
+        val addresses = listOfNotNull(
+            accountManager.activeAccount?.let { account ->
+                ChainRegistry.all.firstNotNullOfOrNull { it.analyticsAddress(account.type) }
+            }
+        )
 
         try {
             marketKit.analyticsPreviewSingle(fullCoin.coin.uid, addresses).await()

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainViewModel.kt
@@ -35,9 +35,11 @@ import io.horizontalsystems.walletkit.modules.walletconnect.WCManager
 import io.horizontalsystems.walletkit.modules.walletconnect.WCSessionManager
 import io.horizontalsystems.walletkit.modules.walletconnect.list.WCListPage
 import io.horizontalsystems.marketkit.models.TokenType
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.asFlow
+import timber.log.Timber
 
 class MainViewModel(
     private val pinComponent: IPinComponent,
@@ -467,7 +469,16 @@ class MainViewModel(
                 // so we don't need closing app in this case
                 val closeApp = returnParam != "none"
                 viewModelScope.launch {
-                    plugin.handleDeepLink(deeplinkString, closeApp)
+                    try {
+                        plugin.handleDeepLink(deeplinkString, closeApp)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        // A malformed link must not escape the coroutine and take the app down.
+                        // This screen has no error surface, so it stays silent here, unlike the
+                        // scanner path which reports it.
+                        Timber.e(e, "Handling deep link failed")
+                    }
                 }
                 return
             }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/Nav3.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/Nav3.kt
@@ -65,7 +65,7 @@ fun Nav3(entryPage: HSPage) {
     IntentEffect(mainActivityViewModel, hsNavigation)
     Validate(mainActivityViewModel)
     HandleWcEvent(mainActivityViewModel, hsNavigation)
-    ToggleScreenshot(hsNavigation)
+    ToggleScreenshot(hsNavigation, isLocked)
 
     LaunchedEffect(isLocked) {
         if (!isLocked) {
@@ -256,13 +256,17 @@ private fun HandleWcEvent(
 }
 
 @Composable
-private fun ToggleScreenshot(navigation: HSNavigation) {
+private fun ToggleScreenshot(navigation: HSNavigation, isLocked: Boolean) {
     val activity = LocalActivity.current
     val currentScreen = navigation.lastOrNull()
-    LaunchedEffect(currentScreen) {
+    LaunchedEffect(currentScreen, isLocked) {
         if (activity != null) {
             activity.currentFocus?.hideKeyboard(activity)
-            if (currentScreen?.screenshotEnabled == false) {
+            // The unlock keypad is drawn as an overlay rather than pushed as a page, so it has no
+            // screenshotEnabled of its own. Without the lock state here the flag stays however the
+            // page underneath left it, and locking over an ordinary screen leaves passcode entry
+            // recordable.
+            if (isLocked || currentScreen?.screenshotEnabled == false) {
                 activity.window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
             } else {
                 activity.window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/Nav3.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/Nav3.kt
@@ -7,8 +7,8 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalActivity
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
@@ -103,7 +103,10 @@ fun Nav3(entryPage: HSPage) {
         AnimatedVisibility(
             visible = isLocked,
             enter = fadeIn(),
-            exit = fadeOut()
+            // Leaves immediately rather than fading. The secure flag is cleared as soon as the app
+            // unlocks, so an exit animation would keep the keypad composited on a surface that is
+            // capturable again. Entering is unaffected: the flag is set before the fade in starts.
+            exit = ExitTransition.None
         ) {
             PinUnlock(isLocked = isLocked)
         }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/list/ui/WCSessionList.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/list/ui/WCSessionList.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -50,10 +51,16 @@ fun WCSessionList(
     val uiState by viewModel.uiState.collectAsState(initial = WalletConnectListUiState())
     var revealedCardId by remember { mutableStateOf<String?>(null) }
 
+    val view = LocalView.current
+
+    // Both calls used to run straight from the composition pass, so the hud fired again on every
+    // recomposition until the state cleared, and errorShown() wrote view model state while the
+    // frame was still composing. Keyed on the message so it runs once per error.
     uiState.showError?.let { message ->
-        val view = LocalView.current
-        HudHelper.showErrorMessage(view, text = message)
-        viewModel.errorShown()
+        LaunchedEffect(message) {
+            HudHelper.showErrorMessage(view, text = message)
+            viewModel.errorShown()
+        }
     }
 
     LazyColumn(contentPadding = PaddingValues(top = 12.dp, bottom = 32.dp)) {


### PR DESCRIPTION
Continues the v0.49 bug-hunt audit, this time the warning-level findings. Refs #9452. Follows #9453 and #9466, which covered the criticals.

Every one of the 25 warnings was re-checked against current `version/0.50` before any work, because the audit is months old and the codebase has moved a long way — `app/` became `walletkit/`, chains were extracted into `walletkit-chain-*` modules. That triage changed the picture substantially: two findings were already fixed, several were narrowed by the critical fixes that landed earlier, and a few turned out to be recommendations that should not be followed.

## Fixes

**Passcode entry was recordable.** `FLAG_SECURE` is driven by the `screenshotEnabled` of the top page in the nav stack, but the unlock keypad is drawn as an `AnimatedVisibility` overlay beside `NavDisplay` rather than pushed as a page, so it has none of its own and never triggered the effect. Locking over an ordinary screen left the flag cleared and the keypad open to screen recording — while every screen for *setting* or *confirming* a passcode already opted out. The screenshot policy now takes lock state into account and is keyed on it, so it re-runs when the app locks and unlocks.

This one is not in the audit. It surfaced while triaging W19, and it is the most valuable change in the branch.

**Coin analytics correlated every wallet you own.** Opening the analytics tab for any coin falls back to `preview()` whenever the auth token is missing or invalid, and that harvested an address from *every* account and sent them joined in a single request. Individually those addresses are public; together in one request they tell the server that this particular set of wallets belongs to one person — including watch-only accounts added to observe someone else. Now sends the active account's address only. The response carries nothing per address and the provider already treats an empty list as no address, so the preview itself is unaffected.

**Unreadable TonConnect codes were silent.** The scanner already turns a failed deep link into a visible "invalid QR code" message, but `TonConnectManager` caught the failure and returned normally, so that message could never appear — a malformed code looked exactly like nothing having happened. The failure now propagates to the caller that reports it. The deep-link path launches without a catch of its own and is guarded too: it has no error surface to show, but a malformed link must not escape the coroutine.

**WalletConnect list error looped.** The hud was shown straight from the composition pass, so it fired again on every recomposition while the error was set, and `errorShown()` wrote view model state during the frame being composed. Both moved into an effect keyed on the message.

## Already fixed, no change needed

- **Monero recent address under the wrong chain** — `b20b6b52a`
- **Stellar recent address under the wrong chain** — `537a33245`

## Findings deliberately not fixed

Three of the audit's recommendations would make things worse if applied as written, and are worth recording so they are not re-raised:

- **BIP-39 passphrase ASCII whitelist.** The audit reads the create/restore asymmetry as drift and recommends dropping the whitelist. But the whitelist is applied only at *creation* points, never on entry or restore — so nobody is ever locked out of a wallet created elsewhere, and both paths already normalize identically with `normalizeNFKD()`. Dropping it would let users create passphrases they may not be able to reproduce on another keyboard or platform, which is permanent fund loss. The asymmetry points the safe way.
- **WebAuthn `origin` / `clientDataHash`.** These are the privileged-caller parameters, intended for browsers relaying a third party's relying party. A first-party app is meant to omit them so Credential Manager derives caller identity from the signing certificate and validates it against Digital Asset Links — which is set up correctly here (`assetlinks/assetlinks.json`, `RP_ID` bound to `appLinksHost`). Passing them would weaken the flow. The second half of that finding, that the assertion is never inspected, is accurate but low impact: there is no relying-party server and key material comes from the PRF output rather than a signature the app trusts.
- **`collectAsStateWithLifecycle` in `WCSessionList`.** That API appears in exactly one file across the whole repo, so this is the prevailing pattern rather than an isolated slip. Changing one call site would make it inconsistent with everything around it while fixing nothing observable. A codebase-wide convention change is reasonable to want, but it is a team decision, not an audit fix.

## Two things worth raising separately

**Nothing ever sets an auth token.** `UserSubscriptionManager.authToken` is initialised to `""` and the only assignment anywhere in the repo is `= null` on a 401/403. `ILocalStorage.authToken` has a complete SharedPreferences accessor that nothing reads or writes. So the first authenticated request each launch sends an empty bearer token, gets rejected, and every subsequent one throws `NoAuthTokenException`. `preview()` is therefore not an error fallback — it is the only path, for every user including subscribers, and authenticated analytics can never succeed.

**Passkey accounts are saved with `backedUp = true`** (`CreateAccountPasskeyViewModel`), where the normal create path passes `false`. A passkey wallet is an ordinary BIP-39 mnemonic wallet whose entropy comes solely from the passkey's PRF output. Marking it backed up suppresses the backup prompt and the settings badge, and `ManageAccountViewModel` shows "Backup Recommended" instead of "Backup Required". The phrase is still reachable manually, but the premise of passkey onboarding is that there is no phrase to write down, so users have no reason to look. Lose the passkey and the wallet goes with it, having been told throughout that it was safe. Flipping the flag contradicts the feature's selling point, so it needs a product decision rather than a patch.

## Not addressed

Left alone as either large refactors with no user-visible benefit (seed and mnemonic memory lifetime), organizational rather than code (shipped API keys, which have not been rotated and gained a new hardcoded `THORCHAIN_API_KEY` since the audit; the `ci` flavour pairing production keys with `subscriptions-dev`), or product decisions (telemetry default-on with a pre-consent install UUID, a pairing interstitial, chain-switch consent).

## Testing

`:app:compileBaseDebugKotlin` and `:walletkit:testDebugUnitTest` green after rebasing onto current `version/0.50`.

The screenshot and overlay behaviour is window-flag wiring with no practical unit test and has not been confirmed on a device — worth checking that locking the app from an ordinary screen actually blocks a screenshot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Prevented screenshots of the PIN overlay while the app is locked.

* **Bug Fixes**
  * Improved handling of malformed wallet deep links without disrupting the app.
  * WalletConnect error messages now appear consistently and only once per error.
  * Improved Ton Connect request failure handling.
  * Analytics previews now use addresses from the active account only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->