### PR TITLE
Honour server-published swap provider suspensions

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/App.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/App.kt
@@ -327,7 +327,7 @@ abstract class App : CoreApp(), WorkConfiguration.Provider, ImageLoaderFactory {
         recentAddressManager = RecentAddressManager(accountManager, appDatabase.recentAddressDao(), ActionCompletedDelegate)
         swapRecordManager = SwapRecordManager(accountManager, appDatabase.swapRecordDao())
         swapSyncService = SwapSyncService(swapRecordManager, appConfigProvider)
-        swapProviderInfoManager = SwapProviderInfoManager(appConfigProvider)
+        swapProviderInfoManager = SwapProviderInfoManager(appConfigProvider, localStorage)
         evmBlockchainManager = EvmBlockchainManager(marketKit)
 
         val tronAccountManager = TronAccountManager(

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/Interfaces.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/Interfaces.kt
@@ -70,6 +70,8 @@ interface ILocalStorage {
     var roiPerformanceCoins: List<PerformanceCoin>
     var marketSearchRecentCoinUids: List<String>
     var swapRecentTokenQueryIds: List<String>
+    var uSwapSuspensions: String?
+    var uSwapSuspensionsSyncTime: Long
     var zcashAccountIds: Set<String>
     var autoLockInterval: AutoLockInterval
     var chartIndicatorsEnabled: Boolean

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/managers/LocalStorageManager.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/managers/LocalStorageManager.kt
@@ -101,6 +101,8 @@ class LocalStorageManager(
     private val UI_STATS_ENABLED = "ui_stats_enabled"
     private val LAST_MIGRATION_VERSION = "last_migration_version"
     private val ENABLED_PAID_ACTIONS = "enabled_paid_actions"
+    private val USWAP_SUSPENSIONS = "uswap_suspensions"
+    private val USWAP_SUSPENSIONS_SYNC_TIME = "uswap_suspensions_sync_time"
 
     private val coroutineScope = CoroutineScope(Dispatchers.Default)
     private val _utxoExpertModeEnabledFlow = MutableStateFlow(preferences.getBoolean(UTXO_EXPERT_MODE, false))
@@ -155,6 +157,21 @@ class LocalStorageManager(
             ?.split(",")?.filter { it.isNotBlank() } ?: listOf()
         set(value) {
             preferences.edit { putString("swapRecentTokenQueryIds", value.joinToString(",")) }
+        }
+
+    // Provider suspensions as JSON, cached so a cold launch keeps honouring them until the next
+    // sync. Null means never stored, which is what makes the manager sync regardless of the
+    // interval.
+    override var uSwapSuspensions: String?
+        get() = preferences.getString(USWAP_SUSPENSIONS, null)
+        set(value) {
+            preferences.edit { putString(USWAP_SUSPENSIONS, value) }
+        }
+
+    override var uSwapSuspensionsSyncTime: Long
+        get() = preferences.getLong(USWAP_SUSPENSIONS_SYNC_TIME, 0)
+        set(value) {
+            preferences.edit { putLong(USWAP_SUSPENSIONS_SYNC_TIME, value) }
         }
 
     override var zcashAccountIds: Set<String>

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapQuoteService.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapQuoteService.kt
@@ -1,17 +1,21 @@
 package io.horizontalsystems.walletkit.modules.multiswap
 
 import android.util.Log
+import io.horizontalsystems.walletkit.core.App
 import io.horizontalsystems.walletkit.modules.multiswap.providers.IMultiSwapProvider
 import io.horizontalsystems.walletkit.modules.multiswap.providers.MultiSwapProviderRegistry
+import io.horizontalsystems.walletkit.modules.multiswap.providers.SwapProviderInfoManager
 import io.horizontalsystems.marketkit.models.Token
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
@@ -21,8 +25,11 @@ class SwapQuoteService(
     // Callers with restricted execution capabilities (e.g. smart accounts that
     // can only broadcast a subset of providers) pass their own set.
     private val allProviders: List<IMultiSwapProvider> = MultiSwapProviderRegistry.allProviders,
+    private val providerInfoManager: SwapProviderInfoManager = App.swapProviderInfoManager,
 ) {
     private val tag = "SwapQuoteService"
+
+    private var suspensions = providerInfoManager.suspensionsFlow.value
 
     private var amountIn: BigDecimal? = null
     private var tokenIn: Token? = null
@@ -56,6 +63,25 @@ class SwapQuoteService(
             startProviders()
             runQuotation()
         }
+
+        coroutineScope.launch {
+            providerInfoManager.sync()
+        }
+
+        coroutineScope.launch {
+            // Dropping the current value: it already seeded `suspensions`, and re-quoting on it
+            // would cancel the quotation the launch above has just started. A sync that only
+            // changes which PAIRS a provider may serve leaves the token selection untouched, so
+            // this is the only thing that re-runs quotation for it.
+            providerInfoManager.suspensionsFlow.drop(1).collect {
+                suspensions = it
+                runQuotation(silent = true)
+            }
+        }
+    }
+
+    fun clear() {
+        coroutineScope.cancel()
     }
 
     fun restart(onRestart: () -> Unit) {
@@ -109,7 +135,13 @@ class SwapQuoteService(
         val amountIn = amountIn
 
         if (tokenIn != null && tokenOut != null) {
-            val supportedProviders = allProviders.filter { it.supports(tokenIn, tokenOut) }
+            val supportedProviders = allProviders.filter { provider ->
+                // Checked here, in the one place every provider passes through, rather than inside
+                // each `supports` implementation — and it is the only enforcement that exists for
+                // the providers this app quotes natively, since those never reach the server.
+                !suspensions.isSuspended(provider.id, tokenIn, tokenOut) &&
+                    provider.supports(tokenIn, tokenOut)
+            }
 
             if (supportedProviders.isEmpty()) {
                 error = NoSupportedSwapProvider()

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapQuoteService.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapQuoteService.kt
@@ -7,6 +7,7 @@ import io.horizontalsystems.walletkit.modules.multiswap.providers.IMultiSwapProv
 import io.horizontalsystems.walletkit.modules.multiswap.providers.MultiSwapProviderRegistry
 import io.horizontalsystems.walletkit.modules.multiswap.providers.SwapProviderInfoManager
 import io.horizontalsystems.marketkit.models.Token
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -62,16 +63,16 @@ class SwapQuoteService(
         // still reads as a change rather than arriving as the collector's own first value.
         val startingSuspensions = providerInfoManager.suspensionsFlow.value
 
-        val initialQuotation = coroutineScope.launch {
+        val initialQuotation = launchGuarded("initial quotation") {
             startProviders()
             runQuotation()
         }
 
-        coroutineScope.launch {
+        launchGuarded("suspension sync") {
             providerInfoManager.sync()
         }
 
-        coroutineScope.launch {
+        launchGuarded("suspension updates") {
             // Waiting for the first quotation: re-running it before the providers have started
             // would quote against a registry that supports nothing yet and surface "no supported
             // provider" for as long as the startup takes.
@@ -86,9 +87,11 @@ class SwapQuoteService(
                 .collect {
                     try {
                         runQuotation()
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Throwable) {
-                        // The collector is the only path back from a suspension change, so it has
-                        // to outlive a failed run.
+                        // Caught per emission, not just at the launch: the collector is the only
+                        // path back from a suspension change, so it has to outlive a failed run.
                         Log.e(tag, "error on re-quoting after a suspension change", e)
                     }
                 }
@@ -98,6 +101,21 @@ class SwapQuoteService(
     override fun clear() {
         coroutineScope.cancel()
     }
+
+    /**
+     * The service scope is not a supervisor, so an exception escaping any one of these coroutines
+     * would cancel the others with it — the sync collector included.
+     */
+    private fun launchGuarded(what: String, block: suspend CoroutineScope.() -> Unit) =
+        coroutineScope.launch {
+            try {
+                block()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                Log.e(tag, "error on $what", e)
+            }
+        }
 
     fun restart(onRestart: () -> Unit) {
         startProvidersJob?.cancel()

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapQuoteService.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapQuoteService.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
@@ -58,7 +58,11 @@ class SwapQuoteService(
     private var startProvidersJob: Job? = null
 
     fun start() {
-        coroutineScope.launch {
+        // Read before the sync is launched, so an index landing before the collector subscribes
+        // still reads as a change rather than arriving as the collector's own first value.
+        val startingSuspensions = providerInfoManager.suspensionsFlow.value
+
+        val initialQuotation = coroutineScope.launch {
             startProviders()
             runQuotation()
         }
@@ -68,13 +72,26 @@ class SwapQuoteService(
         }
 
         coroutineScope.launch {
-            // Dropping the current value: quotation already reads it, and re-quoting on it would
-            // cancel the quotation the launch above has just started. A sync that only changes
-            // which PAIRS a provider may serve leaves the token selection untouched, so this is
-            // the only thing that re-runs quotation for it.
-            providerInfoManager.suspensionsFlow.drop(1).collect {
-                runQuotation(silent = true)
-            }
+            // Waiting for the first quotation: re-running it before the providers have started
+            // would quote against a registry that supports nothing yet and surface "no supported
+            // provider" for as long as the startup takes.
+            initialQuotation.join()
+
+            // A sync that only changes which PAIRS a provider may serve leaves the token
+            // selection untouched, so this is the only thing that re-runs quotation for it. Not
+            // silent: the visible quotes may name a provider that has just been suspended, and
+            // the index only emits when it actually changed, so the refresh is rare.
+            providerInfoManager.suspensionsFlow
+                .dropWhile { it == startingSuspensions }
+                .collect {
+                    try {
+                        runQuotation()
+                    } catch (e: Throwable) {
+                        // The collector is the only path back from a suspension change, so it has
+                        // to outlive a failed run.
+                        Log.e(tag, "error on re-quoting after a suspension change", e)
+                    }
+                }
         }
     }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapQuoteService.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapQuoteService.kt
@@ -2,6 +2,7 @@ package io.horizontalsystems.walletkit.modules.multiswap
 
 import android.util.Log
 import io.horizontalsystems.walletkit.core.App
+import io.horizontalsystems.walletkit.core.Clearable
 import io.horizontalsystems.walletkit.modules.multiswap.providers.IMultiSwapProvider
 import io.horizontalsystems.walletkit.modules.multiswap.providers.MultiSwapProviderRegistry
 import io.horizontalsystems.walletkit.modules.multiswap.providers.SwapProviderInfoManager
@@ -26,10 +27,8 @@ class SwapQuoteService(
     // can only broadcast a subset of providers) pass their own set.
     private val allProviders: List<IMultiSwapProvider> = MultiSwapProviderRegistry.allProviders,
     private val providerInfoManager: SwapProviderInfoManager = App.swapProviderInfoManager,
-) {
+) : Clearable {
     private val tag = "SwapQuoteService"
-
-    private var suspensions = providerInfoManager.suspensionsFlow.value
 
     private var amountIn: BigDecimal? = null
     private var tokenIn: Token? = null
@@ -69,18 +68,17 @@ class SwapQuoteService(
         }
 
         coroutineScope.launch {
-            // Dropping the current value: it already seeded `suspensions`, and re-quoting on it
-            // would cancel the quotation the launch above has just started. A sync that only
-            // changes which PAIRS a provider may serve leaves the token selection untouched, so
-            // this is the only thing that re-runs quotation for it.
+            // Dropping the current value: quotation already reads it, and re-quoting on it would
+            // cancel the quotation the launch above has just started. A sync that only changes
+            // which PAIRS a provider may serve leaves the token selection untouched, so this is
+            // the only thing that re-runs quotation for it.
             providerInfoManager.suspensionsFlow.drop(1).collect {
-                suspensions = it
                 runQuotation(silent = true)
             }
         }
     }
 
-    fun clear() {
+    override fun clear() {
         coroutineScope.cancel()
     }
 
@@ -135,6 +133,10 @@ class SwapQuoteService(
         val amountIn = amountIn
 
         if (tokenIn != null && tokenOut != null) {
+            // Read once, here: quotation runs from both the main thread and the sync collector, so
+            // the flow's own atomic read is what keeps the two from seeing different indexes.
+            val suspensions = providerInfoManager.suspensionsFlow.value
+
             val supportedProviders = allProviders.filter { provider ->
                 // Checked here, in the one place every provider passes through, rather than inside
                 // each `supports` implementation — and it is the only enforcement that exists for

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapViewModel.kt
@@ -244,6 +244,12 @@ class SwapViewModel(
             it.token.coin.uid == token.coin.uid && it.token.blockchainType == token.blockchainType
         }?.token ?: token
 
+    override fun onCleared() {
+        // The quote service keeps a standing subscription to provider suspensions, so it stays
+        // referenced until its own scope is cancelled.
+        quoteService.clear()
+    }
+
     private fun requoteIfTimeout() {
         if (requoteOnTimeout && timerState.timeout) {
             reQuote()

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/SwapProviderInfoManager.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/SwapProviderInfoManager.kt
@@ -7,6 +7,8 @@ import io.horizontalsystems.walletkit.core.managers.APIClient
 import io.horizontalsystems.walletkit.core.providers.IAppConfigProvider
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 class SwapProviderInfoManager(
     appConfigProvider: IAppConfigProvider,
@@ -18,7 +20,9 @@ class SwapProviderInfoManager(
     ).create(UnstoppableAPI::class.java)
 
     private val gson = Gson()
+    private val fetchMutex = Mutex()
 
+    @Volatile
     private var cache: Map<String, UnstoppableAPI.Response.Provider>? = null
 
     private val _suspensionsFlow = MutableStateFlow(restoredSuspensions())
@@ -32,9 +36,8 @@ class SwapProviderInfoManager(
     suspend fun getInfo(providerName: String): UnstoppableAPI.Response.Provider? {
         // Contact details are needed for whatever provider the record names, so this ignores the
         // sync interval and only asks whether this process has the response in hand yet.
-        if (cache == null) {
-            fetch()
-        }
+        fetchIf { cache == null }
+
         return cache?.get(providerName.uppercase())
     }
 
@@ -42,8 +45,7 @@ class SwapProviderInfoManager(
      * Refreshes suspensions if the cached ones are stale. Cheap to call on every swap screen open.
      */
     suspend fun sync() {
-        if (isFresh()) return
-        fetch()
+        fetchIf { !isFresh() }
     }
 
     private fun isFresh(): Boolean {
@@ -54,24 +56,38 @@ class SwapProviderInfoManager(
         // hit and does not force a fetch on every launch.
         localStorage.uSwapSuspensions ?: return false
 
-        return System.currentTimeMillis() - localStorage.uSwapSuspensionsSyncTime < SYNC_INTERVAL
+        // A negative age means the stored timestamp is in the future — a clock correction, which
+        // would otherwise read as fresh until the clock caught up.
+        val age = System.currentTimeMillis() - localStorage.uSwapSuspensionsSyncTime
+        return age in 0 until SYNC_INTERVAL
     }
 
-    private suspend fun fetch() {
-        try {
-            val responses = unstoppableAPI.providers()
+    /**
+     * Fetches under a lock, re-testing [needed] once it is held: a swap screen open and a refund
+     * sheet can ask at the same time, and two responses landing concurrently would publish one
+     * index while persisting the other.
+     */
+    private suspend fun fetchIf(needed: () -> Boolean) {
+        if (!needed()) return
 
-            // Suspended providers stay in the metadata cache: a swap made before the suspension
-            // still needs its refund contacts.
-            cache = responses.associateBy { it.provider.uppercase() }
+        fetchMutex.withLock {
+            if (!needed()) return
 
-            val index = SwapSuspensionIndex.from(responses)
-            _suspensionsFlow.value = index
+            try {
+                val responses = unstoppableAPI.providers()
 
-            localStorage.uSwapSuspensions = gson.toJson(index)
-            localStorage.uSwapSuspensionsSyncTime = System.currentTimeMillis()
-        } catch (e: Throwable) {
-            Log.e(TAG, "Failed to load providers", e)
+                // Suspended providers stay in the metadata cache: a swap made before the
+                // suspension still needs its refund contacts.
+                cache = responses.associateBy { it.provider.uppercase() }
+
+                val index = SwapSuspensionIndex.from(responses)
+                _suspensionsFlow.value = index
+
+                localStorage.uSwapSuspensions = gson.toJson(index)
+                localStorage.uSwapSuspensionsSyncTime = System.currentTimeMillis()
+            } catch (e: Throwable) {
+                Log.e(TAG, "Failed to load providers", e)
+            }
         }
     }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/SwapProviderInfoManager.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/SwapProviderInfoManager.kt
@@ -5,6 +5,7 @@ import com.google.gson.Gson
 import io.horizontalsystems.walletkit.core.ILocalStorage
 import io.horizontalsystems.walletkit.core.managers.APIClient
 import io.horizontalsystems.walletkit.core.providers.IAppConfigProvider
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.sync.Mutex
@@ -85,6 +86,10 @@ class SwapProviderInfoManager(
 
                 localStorage.uSwapSuspensions = gson.toJson(index)
                 localStorage.uSwapSuspensionsSyncTime = System.currentTimeMillis()
+            } catch (e: CancellationException) {
+                // The caller's screen went away mid-request. Not a fetch failure, and swallowing
+                // it would leave its coroutine looking like it completed.
+                throw e
             } catch (e: Throwable) {
                 Log.e(TAG, "Failed to load providers", e)
             }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/SwapProviderInfoManager.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/SwapProviderInfoManager.kt
@@ -1,27 +1,97 @@
 package io.horizontalsystems.walletkit.modules.multiswap.providers
 
 import android.util.Log
+import com.google.gson.Gson
+import io.horizontalsystems.walletkit.core.ILocalStorage
 import io.horizontalsystems.walletkit.core.managers.APIClient
 import io.horizontalsystems.walletkit.core.providers.IAppConfigProvider
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 class SwapProviderInfoManager(
     appConfigProvider: IAppConfigProvider,
+    private val localStorage: ILocalStorage,
 ) {
     private val unstoppableAPI = APIClient.build(
         appConfigProvider.uswapApiBaseUrl,
         mapOf("x-api-key" to appConfigProvider.uswapApiKey),
     ).create(UnstoppableAPI::class.java)
 
+    private val gson = Gson()
+
     private var cache: Map<String, UnstoppableAPI.Response.Provider>? = null
 
+    private val _suspensionsFlow = MutableStateFlow(restoredSuspensions())
+
+    /**
+     * Scoped asset/chain/pair suspensions, indexed by provider id. Applied by [SwapQuoteService]
+     * when it decides which providers can serve the current pair.
+     */
+    val suspensionsFlow = _suspensionsFlow.asStateFlow()
+
     suspend fun getInfo(providerName: String): UnstoppableAPI.Response.Provider? {
+        // Contact details are needed for whatever provider the record names, so this ignores the
+        // sync interval and only asks whether this process has the response in hand yet.
         if (cache == null) {
-            try {
-                cache = unstoppableAPI.providers().associateBy { it.provider.uppercase() }
-            } catch (e: Throwable) {
-                Log.e("SwapProviderInfoManager", "Failed to load providers", e)
-            }
+            fetch()
         }
         return cache?.get(providerName.uppercase())
+    }
+
+    /**
+     * Refreshes suspensions if the cached ones are stale. Cheap to call on every swap screen open.
+     */
+    suspend fun sync() {
+        if (isFresh()) return
+        fetch()
+    }
+
+    private fun isFresh(): Boolean {
+        // A missing cache counts as stale even when the timestamp is recent. Upgrading from a
+        // build that predates suspensions can leave a fresh timestamp beside an empty cache, and
+        // the first hour after the update is precisely the window where a live suspension matters.
+        // An empty rule set still round-trips as a stored `{}`, so "no suspensions anywhere" is a
+        // hit and does not force a fetch on every launch.
+        localStorage.uSwapSuspensions ?: return false
+
+        return System.currentTimeMillis() - localStorage.uSwapSuspensionsSyncTime < SYNC_INTERVAL
+    }
+
+    private suspend fun fetch() {
+        try {
+            val responses = unstoppableAPI.providers()
+
+            // Suspended providers stay in the metadata cache: a swap made before the suspension
+            // still needs its refund contacts.
+            cache = responses.associateBy { it.provider.uppercase() }
+
+            val index = SwapSuspensionIndex.from(responses)
+            _suspensionsFlow.value = index
+
+            localStorage.uSwapSuspensions = gson.toJson(index)
+            localStorage.uSwapSuspensionsSyncTime = System.currentTimeMillis()
+        } catch (e: Throwable) {
+            Log.e(TAG, "Failed to load providers", e)
+        }
+    }
+
+    /**
+     * Suspensions must survive a cold launch: they are refreshed at most hourly, so without this a
+     * restart would quote a suspended provider until the next sync completes.
+     */
+    private fun restoredSuspensions(): SwapSuspensionIndex {
+        val json = localStorage.uSwapSuspensions ?: return SwapSuspensionIndex()
+
+        return try {
+            gson.fromJson(json, SwapSuspensionIndex::class.java) ?: SwapSuspensionIndex()
+        } catch (e: Throwable) {
+            Log.e(TAG, "Failed to restore swap suspensions", e)
+            SwapSuspensionIndex()
+        }
+    }
+
+    companion object {
+        private const val TAG = "SwapProviderInfoManager"
+        private const val SYNC_INTERVAL = 60 * 60 * 1000L // 1 hour
     }
 }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/SwapSuspension.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/SwapSuspension.kt
@@ -1,0 +1,260 @@
+package io.horizontalsystems.walletkit.modules.multiswap.providers
+
+import com.google.gson.annotations.SerializedName
+import io.horizontalsystems.marketkit.models.BlockchainType
+import io.horizontalsystems.marketkit.models.Token
+import io.horizontalsystems.marketkit.models.TokenType
+import java.time.Instant
+
+/**
+ * A scoped restriction published by uswap-server on `GET /providers`.
+ *
+ * Two kinds of provider need this and for different reasons:
+ *  - Providers uswap-server quotes: it already refuses a suspended request, so honouring the rule
+ *    here is purely so the user never sees a card that is going to fail.
+ *  - Providers the APP quotes itself (Uniswap, PancakeSwap, AllBridge, and 1inch/THORChain/Maya,
+ *    which have native implementations here): no server call happens at all, so this filter is the
+ *    ONLY enforcement that exists. Dropping it would make those providers unsuspendable.
+ *
+ * Every field is nullable with a default so the class round-trips through Gson in both directions
+ * — it is parsed straight off the wire AND out of the local cache, where an older or truncated
+ * payload must degrade to "matches nothing" rather than throw.
+ */
+data class SwapSuspension(
+    val kind: Kind? = null,
+    val side: Side? = null,
+    /**
+     * The CANONICAL asset ID (`ETH.0XA0B86991…`, `BTC.BTC`, `ETH-ETH`) — an ordinary asset
+     * identifier, the same vocabulary a quote request uses, but exactly ONE spelling per asset.
+     *
+     * The server normalizes here because an asset has several valid identifiers and which one we
+     * send depends on the sub-provider — this app spells USDC `ETH.USDC-0XA0B8…` via the asset map,
+     * `ETH.0xa0b8…` for LI.FI and a bare `0xa0b8…` for Barter. Comparing our request string against
+     * whichever spelling an operator typed would catch one and silently miss the rest, so both
+     * sides normalize first ([CanonicalAssetId.of]) and compare the result.
+     */
+    val asset: String? = null,
+    val chain: String? = null,
+    val sellAsset: String? = null,
+    val buyAsset: String? = null,
+    val expiresAt: String? = null,
+) {
+    enum class Kind {
+        @SerializedName("asset")
+        Asset,
+
+        @SerializedName("chain")
+        Chain,
+
+        @SerializedName("pair")
+        Pair,
+    }
+
+    /**
+     * Which side of the swap the rule covers. Provider deposit and payout capability break
+     * independently, so "either side" is a default, not the only option.
+     */
+    enum class Side {
+        @SerializedName("any")
+        Any,
+
+        @SerializedName("sell")
+        Sell,
+
+        @SerializedName("buy")
+        Buy,
+    }
+
+    fun matches(sell: String?, buy: String?, now: Instant): Boolean = isLive(now) && when (kind) {
+        Kind.Asset -> matchesSided(sell, buy) { it == asset }
+        Kind.Chain -> matchesSided(sell, buy) { CanonicalAssetId.chainOf(it) == chain }
+        // Directed — the reverse direction is a separate rule.
+        Kind.Pair -> sell != null && buy != null && sell == sellAsset && buy == buyAsset
+        // A kind this build does not know is inert rather than treated as one of the kinds it
+        // does: a rule we cannot evaluate must not disable a provider on a guess.
+        null -> false
+    }
+
+    /**
+     * The server already filters expired rules out, but a cached list outlives its own contents —
+     * a rule that expires during the hour we hold the response must stop applying on its own.
+     *
+     * An unparseable timestamp reads as no expiry, keeping the rule in force: a malformed date is
+     * not a reason to start serving a pair the operator switched off.
+     */
+    private fun isLive(now: Instant): Boolean {
+        val raw = expiresAt ?: return true
+        val expiry = runCatching { Instant.parse(raw) }.getOrNull() ?: return true
+        return expiry.isAfter(now)
+    }
+
+    private inline fun matchesSided(sell: String?, buy: String?, test: (String) -> Boolean): Boolean {
+        // An absent side is `any`, which is also what an unrecognized one degrades to — the
+        // widest reading of a rule the server did mean to publish.
+        if (side != Side.Buy && sell != null && test(sell)) return true
+        if (side != Side.Sell && buy != null && test(buy)) return true
+        return false
+    }
+}
+
+/**
+ * Builds uswap-server's canonical asset ID for a local [Token].
+ *
+ * This is the client half of a two-implementation contract (the other is the server's
+ * `canonicalAsset`). It is deliberately the SMALLER half: the server has to parse every identifier
+ * spelling a client might send, whereas here the token is already structured — a blockchain and a
+ * token type — so this only has to FORMAT, never parse. Keep it that way; if this ever starts
+ * string-splitting identifiers, the two will drift.
+ */
+object CanonicalAssetId {
+    /**
+     * Chain codes as uswap-server spells them, which is what the ID is built from. A blockchain
+     * absent here yields no ID, so no rule can match it — the safe direction: a provider stays
+     * quotable rather than being silently suspended by a mapping gap.
+     */
+    private val chainCodes = mapOf(
+        BlockchainType.Bitcoin to "BTC",
+        BlockchainType.BitcoinCash to "BCH",
+        BlockchainType.ECash to "XEC",
+        BlockchainType.Litecoin to "LTC",
+        BlockchainType.Dash to "DASH",
+        BlockchainType.Zcash to "ZEC",
+        BlockchainType.Monero to "XMR",
+        BlockchainType.Zano to "ZANO",
+        BlockchainType.Ethereum to "ETH",
+        BlockchainType.BinanceSmartChain to "BSC",
+        BlockchainType.Polygon to "POL",
+        BlockchainType.Avalanche to "AVAX",
+        BlockchainType.Optimism to "OP",
+        BlockchainType.ArbitrumOne to "ARB",
+        BlockchainType.Gnosis to "GNO",
+        BlockchainType.Base to "BASE",
+        BlockchainType.Tron to "TRON",
+        BlockchainType.Solana to "SOL",
+        BlockchainType.Ton to "TON",
+        BlockchainType.Stellar to "XLM",
+        BlockchainType.Thorchain to "THOR",
+    )
+
+    /**
+     * The gas asset's ticker per chain — NOT always the chain code (`BASE.ETH`, `BSC.BNB`,
+     * `GNO.XDAI`), which is exactly why this is a table and not a derivation.
+     */
+    private val nativeTickers = mapOf(
+        BlockchainType.Bitcoin to "BTC",
+        BlockchainType.BitcoinCash to "BCH",
+        BlockchainType.ECash to "XEC",
+        BlockchainType.Litecoin to "LTC",
+        BlockchainType.Dash to "DASH",
+        BlockchainType.Zcash to "ZEC",
+        BlockchainType.Monero to "XMR",
+        BlockchainType.Zano to "ZANO",
+        BlockchainType.Ethereum to "ETH",
+        BlockchainType.BinanceSmartChain to "BNB",
+        BlockchainType.Polygon to "POL",
+        BlockchainType.Avalanche to "AVAX",
+        BlockchainType.Optimism to "ETH",
+        BlockchainType.ArbitrumOne to "ETH",
+        BlockchainType.Gnosis to "XDAI",
+        BlockchainType.Base to "ETH",
+        BlockchainType.Tron to "TRX",
+        BlockchainType.Solana to "SOL",
+        BlockchainType.Ton to "TON",
+        BlockchainType.Stellar to "XLM",
+        BlockchainType.Thorchain to "RUNE",
+    )
+
+    private const val WSOL_MINT = "So11111111111111111111111111111111111111112"
+
+    fun of(token: Token): String? {
+        val chain = chainCodes[token.blockchainType] ?: return null
+
+        return when (val type = token.type) {
+            // Derivation / address type are wallet-side concerns; on the server they are all one
+            // asset (`BTC.BTC`).
+            TokenType.Native,
+            is TokenType.Derived,
+            is TokenType.AddressTyped,
+                -> nativeTickers[token.blockchainType]?.let { "$chain.$it" }
+
+            // Covers EVM hex and Tron base58 alike — both are upper-cased, matching the catalog
+            // identifier's own convention (`ETH.USDC-0XA0B8…`).
+            is TokenType.Eip20 -> "$chain.${type.address.uppercase()}"
+
+            // Wrapped SOL is native SOL everywhere on the server.
+            is TokenType.Spl -> if (type.address == WSOL_MINT) "$chain.SOL" else "$chain.${type.address.uppercase()}"
+
+            is TokenType.Jetton -> "$chain.${type.address.uppercase()}"
+
+            // The CODE stays verbatim — Stellar codes are case-sensitive (`yXLM` ≠ `YXLM`). The
+            // issuer is StrKey, uppercase-only, so normalizing it is safe.
+            is TokenType.Asset -> "$chain.${type.code}-${type.issuer.uppercase()}"
+
+            // THORChain secured (`eth-eth` in x/bank). Deliberately NOT chain-prefixed: the
+            // canonical id is the identifier a quote itself uses, and [chainOf] treats a dot-less
+            // id as THORChain — which is where the asset actually lives.
+            is TokenType.ThorchainAsset -> type.denom.uppercase()
+
+            is TokenType.ZanoAsset,
+            is TokenType.Unsupported,
+                -> null
+        }
+    }
+
+    /**
+     * The chain a canonical ID belongs to — what a chain-scoped rule matches on. A dot-less id can
+     * only be a THORChain secured asset (`ETH-ETH`), which lives in THORChain's x/bank — so a
+     * `THOR` chain rule covers it and an `ETH` one correctly does not.
+     */
+    fun chainOf(id: String): String = id.substringBefore('.', "THOR")
+}
+
+/**
+ * The provider-id → rules index, plus the one question the swap screen asks.
+ *
+ * Both properties are keyed by the server's spelling of a provider id, so any lookup goes through
+ * [serverId] first.
+ */
+data class SwapSuspensionIndex(
+    /** Whole-provider kill switch: no pair at all, so it never reaches the per-pair rules. */
+    val suspendedProviders: Set<String> = setOf(),
+    val rulesByProvider: Map<String, List<SwapSuspension>> = mapOf(),
+) {
+    /**
+     * May this provider be offered for this pair?
+     *
+     * A token we cannot normalize (an unmapped blockchain) yields `null` and therefore never
+     * matches — deliberately failing OPEN. The alternative, treating "unknown" as suspended, would
+     * let one missing chain-code entry silently disable providers with no visible cause.
+     */
+    fun isSuspended(providerId: String, tokenIn: Token, tokenOut: Token): Boolean {
+        val key = serverId(providerId)
+
+        if (key in suspendedProviders) return true
+
+        val rules = rulesByProvider[key]
+        if (rules.isNullOrEmpty()) return false
+
+        val sell = CanonicalAssetId.of(tokenIn)
+        val buy = CanonicalAssetId.of(tokenOut)
+        val now = Instant.now()
+
+        return rules.any { it.matches(sell, buy, now) }
+    }
+
+    companion object {
+        /**
+         * The server names a provider bare and upper-case (`NEAR`); the app prefixes the ids it
+         * routes through uswap-server (`u_NEAR`) and lower-cases the ones it implements natively
+         * (`oneinch`).
+         */
+        fun serverId(providerId: String) = providerId.removePrefix("u_").uppercase()
+
+        fun from(responses: List<UnstoppableAPI.Response.Provider>) = SwapSuspensionIndex(
+            suspendedProviders = responses.filter { it.suspended }.map { serverId(it.provider) }.toSet(),
+            rulesByProvider = responses
+                .filter { !it.suspended && !it.suspensions.isNullOrEmpty() }
+                .associate { serverId(it.provider) to it.suspensions.orEmpty() },
+        )
+    }
+}

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
@@ -839,6 +839,12 @@ interface UnstoppableAPI {
             val amlPolicy: String? = null,
             val amlPolicyDescription: String? = null,
             val contacts: Contacts? = null,
+            // Whole-provider kill switch.
+            val suspended: Boolean = false,
+            // Scoped restrictions — asset, chain or directed pair. See SwapSuspension. Nullable
+            // because the field is absent for the many providers that carry no rules, and Gson
+            // fills absent fields with null rather than the declared default.
+            val suspensions: List<SwapSuspension>? = null,
         ) {
             data class Contacts(
                 val email: String? = null,

--- a/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/multiswap/providers/SwapSuspensionTest.kt
+++ b/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/multiswap/providers/SwapSuspensionTest.kt
@@ -1,0 +1,221 @@
+package io.horizontalsystems.walletkit.modules.multiswap.providers
+
+import com.google.gson.Gson
+import io.horizontalsystems.marketkit.models.Blockchain
+import io.horizontalsystems.marketkit.models.Coin
+import io.horizontalsystems.marketkit.models.BlockchainType
+import io.horizontalsystems.marketkit.models.Token
+import io.horizontalsystems.marketkit.models.TokenType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.Instant
+
+class SwapSuspensionTest {
+
+    private fun token(blockchainType: BlockchainType, type: TokenType) = Token(
+        coin = Coin("uid", "Name", "CODE"),
+        blockchain = Blockchain(blockchainType, "Name", null),
+        type = type,
+        decimals = 8,
+    )
+
+    private val btc = token(BlockchainType.Bitcoin, TokenType.Native)
+    private val usdc = token(BlockchainType.Ethereum, TokenType.Eip20("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"))
+    private val eth = token(BlockchainType.Ethereum, TokenType.Native)
+    private val sol = token(BlockchainType.Solana, TokenType.Native)
+
+    private fun index(vararg rules: SwapSuspension) = SwapSuspensionIndex(
+        rulesByProvider = mapOf("NEAR" to rules.toList()),
+    )
+
+    // --- canonical asset ids ---
+
+    @Test
+    fun `native tokens use the chain gas ticker, not the chain code`() {
+        assertEquals("BTC.BTC", CanonicalAssetId.of(btc))
+        assertEquals("BASE.ETH", CanonicalAssetId.of(token(BlockchainType.Base, TokenType.Native)))
+        assertEquals("BSC.BNB", CanonicalAssetId.of(token(BlockchainType.BinanceSmartChain, TokenType.Native)))
+        assertEquals("GNO.XDAI", CanonicalAssetId.of(token(BlockchainType.Gnosis, TokenType.Native)))
+    }
+
+    @Test
+    fun `derivation and address type collapse into the native asset`() {
+        val bip84 = token(BlockchainType.Bitcoin, TokenType.Derived(TokenType.Derivation.Bip84))
+        val type145 = token(BlockchainType.BitcoinCash, TokenType.AddressTyped(TokenType.AddressType.Type145))
+
+        assertEquals("BTC.BTC", CanonicalAssetId.of(bip84))
+        assertEquals("BCH.BCH", CanonicalAssetId.of(type145))
+    }
+
+    @Test
+    fun `contract addresses are upper-cased`() {
+        assertEquals("ETH.0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48", CanonicalAssetId.of(usdc))
+    }
+
+    @Test
+    fun `wrapped sol is native sol`() {
+        val wsol = token(BlockchainType.Solana, TokenType.Spl("So11111111111111111111111111111111111111112"))
+
+        assertEquals("SOL.SOL", CanonicalAssetId.of(wsol))
+    }
+
+    @Test
+    fun `stellar keeps the case-sensitive asset code and upper-cases the issuer`() {
+        val yxlm = token(BlockchainType.Stellar, TokenType.Asset("yXLM", "gabc"))
+
+        assertEquals("XLM.yXLM-GABC", CanonicalAssetId.of(yxlm))
+    }
+
+    @Test
+    fun `thorchain secured assets stay unprefixed and read as thorchain`() {
+        val secured = token(BlockchainType.Thorchain, TokenType.ThorchainAsset("eth-eth"))
+
+        assertEquals("ETH-ETH", CanonicalAssetId.of(secured))
+        assertEquals("THOR", CanonicalAssetId.chainOf("ETH-ETH"))
+        assertEquals("ETH", CanonicalAssetId.chainOf("ETH.0XA0B8"))
+    }
+
+    @Test
+    fun `an unmapped token yields no id`() {
+        assertNull(CanonicalAssetId.of(token(BlockchainType.Zano, TokenType.ZanoAsset("ref"))))
+        assertNull(CanonicalAssetId.of(token(BlockchainType.Unsupported("nope"), TokenType.Native)))
+    }
+
+    // --- matching ---
+
+    @Test
+    fun `asset rule without a side covers both sides`() {
+        val rule = SwapSuspension(kind = SwapSuspension.Kind.Asset, asset = "BTC.BTC")
+
+        assertTrue(index(rule).isSuspended("u_NEAR", btc, usdc))
+        assertTrue(index(rule).isSuspended("u_NEAR", usdc, btc))
+        assertFalse(index(rule).isSuspended("u_NEAR", usdc, eth))
+    }
+
+    @Test
+    fun `a sided asset rule leaves the other side quotable`() {
+        val rule = SwapSuspension(
+            kind = SwapSuspension.Kind.Asset,
+            side = SwapSuspension.Side.Sell,
+            asset = "BTC.BTC",
+        )
+
+        assertTrue(index(rule).isSuspended("u_NEAR", btc, usdc))
+        assertFalse(index(rule).isSuspended("u_NEAR", usdc, btc))
+    }
+
+    @Test
+    fun `chain rule covers every asset on the chain`() {
+        val rule = SwapSuspension(kind = SwapSuspension.Kind.Chain, chain = "ETH")
+
+        assertTrue(index(rule).isSuspended("u_NEAR", usdc, btc))
+        assertTrue(index(rule).isSuspended("u_NEAR", eth, btc))
+        assertFalse(index(rule).isSuspended("u_NEAR", btc, sol))
+    }
+
+    @Test
+    fun `pair rule is directed`() {
+        val rule = SwapSuspension(
+            kind = SwapSuspension.Kind.Pair,
+            sellAsset = "BTC.BTC",
+            buyAsset = "ETH.ETH",
+        )
+
+        assertTrue(index(rule).isSuspended("u_NEAR", btc, eth))
+        assertFalse(index(rule).isSuspended("u_NEAR", eth, btc))
+    }
+
+    @Test
+    fun `an expired rule stops applying without a resync`() {
+        val expired = SwapSuspension(
+            kind = SwapSuspension.Kind.Asset,
+            asset = "BTC.BTC",
+            expiresAt = Instant.now().minusSeconds(60).toString(),
+        )
+        val live = expired.copy(expiresAt = Instant.now().plusSeconds(60).toString())
+
+        assertFalse(index(expired).isSuspended("u_NEAR", btc, usdc))
+        assertTrue(index(live).isSuspended("u_NEAR", btc, usdc))
+    }
+
+    @Test
+    fun `a malformed expiry keeps the rule in force`() {
+        val rule = SwapSuspension(kind = SwapSuspension.Kind.Asset, asset = "BTC.BTC", expiresAt = "soon")
+
+        assertTrue(index(rule).isSuspended("u_NEAR", btc, usdc))
+    }
+
+    @Test
+    fun `a rule this build cannot evaluate is inert`() {
+        val unknownKind = SwapSuspension(kind = null, asset = "BTC.BTC")
+        val unmappedToken = SwapSuspension(kind = SwapSuspension.Kind.Chain, chain = "ZANO")
+        val zano = token(BlockchainType.Zano, TokenType.ZanoAsset("ref"))
+
+        assertFalse(index(unknownKind).isSuspended("u_NEAR", btc, usdc))
+        assertFalse(index(unmappedToken).isSuspended("u_NEAR", zano, btc))
+    }
+
+    @Test
+    fun `rules only bind the provider they were published for`() {
+        val rule = SwapSuspension(kind = SwapSuspension.Kind.Asset, asset = "BTC.BTC")
+
+        assertFalse(index(rule).isSuspended("u_EXOLIX", btc, usdc))
+    }
+
+    @Test
+    fun `a suspended provider serves no pair`() {
+        val suspended = SwapSuspensionIndex(suspendedProviders = setOf("ONEINCH"))
+
+        assertTrue(suspended.isSuspended("oneinch", usdc, eth))
+        assertFalse(suspended.isSuspended("uniswap_v3", usdc, eth))
+    }
+
+    // --- wire and cache formats ---
+
+    @Test
+    fun `rules parse from the server payload`() {
+        val json = """
+            [
+              {"provider":"NEAR","suspensions":[{"kind":"pair","side":"sell","sellAsset":"BTC.BTC","buyAsset":"ETH.ETH"}]},
+              {"provider":"EXOLIX","suspended":true},
+              {"provider":"ONEINCH"}
+            ]
+        """.trimIndent()
+        val responses = Gson().fromJson(json, Array<UnstoppableAPI.Response.Provider>::class.java).toList()
+
+        val index = SwapSuspensionIndex.from(responses)
+
+        assertEquals(setOf("EXOLIX"), index.suspendedProviders)
+        assertEquals(setOf("NEAR"), index.rulesByProvider.keys)
+        assertTrue(index.isSuspended("u_NEAR", btc, eth))
+        assertTrue(index.isSuspended("u_EXOLIX", btc, eth))
+        assertFalse(index.isSuspended("oneinch", btc, eth))
+    }
+
+    @Test
+    fun `the index survives a cache round-trip`() {
+        val gson = Gson()
+        val index = SwapSuspensionIndex(
+            suspendedProviders = setOf("EXOLIX"),
+            rulesByProvider = mapOf(
+                "NEAR" to listOf(
+                    SwapSuspension(
+                        kind = SwapSuspension.Kind.Chain,
+                        side = SwapSuspension.Side.Buy,
+                        chain = "ETH",
+                        expiresAt = "2030-01-01T00:00:00Z",
+                    )
+                )
+            ),
+        )
+
+        val restored = gson.fromJson(gson.toJson(index), SwapSuspensionIndex::class.java)
+
+        assertEquals(index, restored)
+        assertTrue(restored.isSuspended("u_NEAR", btc, usdc))
+        assertFalse(restored.isSuspended("u_NEAR", usdc, btc))
+    }
+}

--- a/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/multiswap/providers/SwapSuspensionTest.kt
+++ b/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/multiswap/providers/SwapSuspensionTest.kt
@@ -218,4 +218,14 @@ class SwapSuspensionTest {
         assertTrue(restored.isSuspended("u_NEAR", btc, usdc))
         assertFalse(restored.isSuspended("u_NEAR", usdc, btc))
     }
+
+    @Test
+    fun `a cache missing both members restores to an empty index`() {
+        // Every property carries a default, so Kotlin emits a no-arg constructor and Gson fills
+        // absent members with the defaults instead of leaving the non-null collections null.
+        val restored = Gson().fromJson("{}", SwapSuspensionIndex::class.java)
+
+        assertEquals(SwapSuspensionIndex(), restored)
+        assertFalse(restored.isSuspended("u_NEAR", btc, usdc))
+    }
 }


### PR DESCRIPTION
Filters swap providers by the availability rules uswap-server publishes on `GET /providers` — a whole-provider kill switch plus scoped asset / chain / directed-pair rules — so a provider that cannot serve a pair is never quoted, including the providers the app quotes natively.

Closes #9469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic synchronization of swap provider availability.
  * Providers can now be restricted by provider, blockchain, asset, or trading pair.
  * Suspension information is stored locally and refreshed periodically.
* **Improvements**
  * Swap quotes exclude unavailable providers and refresh when availability changes.
  * Added safer handling for expired, incomplete, or invalid suspension information.
* **Bug Fixes**
  * Improved cleanup of swap services when leaving the swap screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->