### PR TITLE
Match PancakeSwap's swap provider id to the server's spelling

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/SwapSuspension.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/SwapSuspension.kt
@@ -244,11 +244,26 @@ data class SwapSuspensionIndex(
 
     companion object {
         /**
+         * Ids the two sides spell differently, and which therefore cannot be reconciled by
+         * normalizing alone. Renaming the provider instead is not an option: its id is persisted
+         * on every swap record and is what the history and refund flows look swaps up by.
+         *
+         * This mapping is load-bearing rather than cosmetic — PancakeSwap is quoted by the app
+         * itself, so an unmatched id means no suspension for it can be enforced at all.
+         */
+        private val serverIdOverrides = mapOf(
+            PANCAKE_V3_PROVIDER_ID.uppercase() to "PANCAKESWAP",
+        )
+
+        /**
          * The server names a provider bare and upper-case (`NEAR`); the app prefixes the ids it
          * routes through uswap-server (`u_NEAR`) and lower-cases the ones it implements natively
          * (`oneinch`).
          */
-        fun serverId(providerId: String) = providerId.removePrefix("u_").uppercase()
+        fun serverId(providerId: String): String {
+            val normalized = providerId.removePrefix("u_").uppercase()
+            return serverIdOverrides[normalized] ?: normalized
+        }
 
         fun from(responses: List<UnstoppableAPI.Response.Provider>) = SwapSuspensionIndex(
             suspendedProviders = responses.filter { it.suspended }.map { serverId(it.provider) }.toSet(),

--- a/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/multiswap/providers/SwapProviderIdMappingTest.kt
+++ b/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/multiswap/providers/SwapProviderIdMappingTest.kt
@@ -1,0 +1,43 @@
+package io.horizontalsystems.walletkit.modules.multiswap.providers
+
+import com.google.gson.Gson
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the provider-id half of the suspension contract against a captured `GET /providers`
+ * response. A rule can only be enforced if the id it is published under resolves to the id the app
+ * offers that provider by, and nothing else in the app compares the two — an id the server spells
+ * differently produces no error, just a provider that quietly cannot be suspended.
+ *
+ * The fixture is deliberately trimmed to ids and rules; it is not a snapshot of live policy, and
+ * this test asserts nothing about which rules happen to be configured.
+ */
+class SwapProviderIdMappingTest {
+
+    private val responses: List<UnstoppableAPI.Response.Provider> = Gson().fromJson(
+        javaClass.classLoader!!.getResource("providers-dev.json")!!.readText(),
+        Array<UnstoppableAPI.Response.Provider>::class.java,
+    ).toList()
+
+    // The registry cannot be built in a unit test — its providers reach for App at construction —
+    // so the ids are listed from their declaration sites.
+    private val appProviderIds = UProvider.entries.map { "u_${it.id}" } + listOf(
+        "allbridge",
+        "u_STELLARBROKER",
+        THORCHAIN_PROVIDER_ID,
+        MAYA_PROVIDER_ID,
+        ONEINCH_PROVIDER_ID,
+        UNISWAP_V3_PROVIDER_ID,
+        PANCAKE_V3_PROVIDER_ID,
+    )
+
+    @Test
+    fun `every provider the app offers resolves to a server provider id`() {
+        val serverIds = responses.map { it.provider }.toSet()
+
+        val unmatched = appProviderIds.filterNot { SwapSuspensionIndex.serverId(it) in serverIds }
+
+        assertEquals(listOf<String>(), unmatched)
+    }
+}

--- a/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/multiswap/providers/SwapSuspensionTest.kt
+++ b/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/multiswap/providers/SwapSuspensionTest.kt
@@ -166,6 +166,15 @@ class SwapSuspensionTest {
     }
 
     @Test
+    fun `provider ids the server spells differently still resolve`() {
+        // PancakeSwap is quoted by the app itself, so an unmatched id would mean no suspension
+        // for it could be enforced at all.
+        assertEquals("PANCAKESWAP", SwapSuspensionIndex.serverId("pancake_v3"))
+        assertEquals("UNISWAP_V3", SwapSuspensionIndex.serverId("uniswap_v3"))
+        assertEquals("NEAR", SwapSuspensionIndex.serverId("u_NEAR"))
+    }
+
+    @Test
     fun `a suspended provider serves no pair`() {
         val suspended = SwapSuspensionIndex(suspendedProviders = setOf("ONEINCH"))
 

--- a/walletkit/src/test/resources/providers-dev.json
+++ b/walletkit/src/test/resources/providers-dev.json
@@ -1,0 +1,314 @@
+[
+  {
+    "provider": "THORCHAIN",
+    "quotes": true,
+    "suspensions": [
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "MAYACHAIN",
+    "quotes": true,
+    "suspensions": [
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "ONEINCH",
+    "quotes": true,
+    "suspensions": [
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "BARTER",
+    "quotes": true,
+    "suspensions": [
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "CIRCLE",
+    "quotes": true,
+    "suspensions": [
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "CCE",
+    "quotes": true,
+    "suspensions": [
+      {
+        "asset": "DOGE.DOGE",
+        "kind": "asset",
+        "side": "buy"
+      },
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "EXOLIX",
+    "quotes": true,
+    "suspensions": [
+      {
+        "asset": "ETH.0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48",
+        "kind": "asset",
+        "side": "any"
+      },
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "LETSEXCHANGE",
+    "quotes": true,
+    "suspensions": [
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "NEAR",
+    "quotes": true,
+    "suspensions": [
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "PEGASUS",
+    "quotes": true,
+    "suspensions": [
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "QUICKEX",
+    "quotes": true,
+    "suspensions": [
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "STEALTHEX",
+    "quotes": true,
+    "suspensions": [
+      {
+        "chain": "POL",
+        "kind": "chain",
+        "side": "any"
+      },
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "SWAPUZ",
+    "quotes": true,
+    "suspensions": [
+      {
+        "buyAsset": "ETH.ETH",
+        "kind": "pair",
+        "sellAsset": "BTC.BTC",
+        "side": "any"
+      },
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "JUPITER",
+    "quotes": true,
+    "suspensions": [
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "LIFI",
+    "quotes": true,
+    "suspensions": [
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "STELLARBROKER",
+    "quotes": true,
+    "suspensions": [
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "SOROSWAP",
+    "quotes": true,
+    "suspensions": [
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "AQUARIUS",
+    "quotes": true,
+    "suspensions": [
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "STELLAR_DEX",
+    "quotes": true,
+    "suspensions": [
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "AXELAR_ITS",
+    "quotes": true,
+    "suspensions": [
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "NEAR_CONFIDENTIAL",
+    "quotes": true,
+    "suspensions": [
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "LIZEX",
+    "quotes": true,
+    "suspensions": [
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "BITANIA",
+    "quotes": true,
+    "suspensions": [
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "UNISWAP_V3",
+    "quotes": false,
+    "suspensions": [
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      },
+      {
+        "chain": "ETH",
+        "kind": "chain",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "PANCAKESWAP",
+    "quotes": false,
+    "suspensions": [
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  },
+  {
+    "provider": "ALLBRIDGE",
+    "quotes": false,
+    "suspensions": [
+      {
+        "asset": "XMR.XMR",
+        "kind": "asset",
+        "side": "any"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
The app offers PancakeSwap as `pancake_v3` while `GET /providers` publishes it as `PANCAKESWAP`, so its suspension rules were indexed under an id nothing looked up. Since that provider is quoted client-side, its rules had no effect at all.

Adds a test that every provider the app offers resolves to a server provider id.

Follow-up to #9469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider ID matching for swap suspension checks, including correct PancakeSwap identification.
  * Standardized provider ID handling for PancakeSwap, Uniswap V3, and NEAR.

* **Tests**
  * Added coverage to verify application provider IDs map correctly to server identifiers.
  * Added test configurations covering quote availability and provider-specific suspension scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->