### PR TITLE
Drop the passcode prompt from WalletConnect approvals

### DIFF
--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/WcRequestEvmScreen.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/WcRequestEvmScreen.kt
@@ -341,7 +341,7 @@ fun WCNewSignRequestScreen(
                     title = stringResource(R.string.Button_Confirm),
                     variant = ButtonVariant.Primary,
                     modifier = Modifier.weight(1f),
-                    onClick = navigation.authorizedAction {
+                    onClick = {
                         logger.info("allow request")
                         scope.launch {
                             try {

--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/WcRequestEvmScreen.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/WcRequestEvmScreen.kt
@@ -167,8 +167,12 @@ fun WCNewSignRequestScreen(
         onDismissRequest = {
             // Discard synchronously (avoids the reEmit race), then animate out before popping —
             // same reason as hideAndPop above; popping outright can leave the sheet card on screen.
-            WCDelegate.discardActiveSessionRequest()
-            hideAndPop()
+            // A confirmed sign is already responding (NonCancellable); discarding now would race
+            // the pending response, so ignore dismissal until it completes.
+            if (!confirmAction.inProgress) {
+                WCDelegate.discardActiveSessionRequest()
+                hideAndPop()
+            }
         },
         sheetState = sheetState
     ) { snackbarActions ->
@@ -334,6 +338,7 @@ fun WCNewSignRequestScreen(
                     variant = ButtonVariant.Secondary,
                     size = ButtonSize.Medium,
                     modifier = Modifier.weight(1f),
+                    enabled = !confirmAction.inProgress,
                     onClick = {
                         logger.info("decline request")
                         onDecline()

--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/WcRequestEvmScreen.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/WcRequestEvmScreen.kt
@@ -43,6 +43,7 @@ import io.horizontalsystems.walletkit.modules.walletconnect.request.signtransact
 import io.horizontalsystems.walletkit.modules.walletconnect.session.TitleValueCell
 import io.horizontalsystems.walletkit.ui.compose.ComposeAppTheme
 import io.horizontalsystems.walletkit.ui.compose.components.MessageToSign
+import io.horizontalsystems.walletkit.ui.compose.components.rememberAsyncAction
 import io.horizontalsystems.walletkit.ui.compose.components.VSpacer
 import io.horizontalsystems.walletkit.ui.compose.components.headline1_leah
 import io.horizontalsystems.walletkit.ui.compose.components.subhead_grey
@@ -148,6 +149,7 @@ fun WCNewSignRequestScreen(
     val view = LocalView.current
     val messageBottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var messageBottomSheet by remember { mutableStateOf<String?>(null) }
+    val confirmAction = rememberAsyncAction()
 
     // Animate the bottom sheet out before popping. Removing the entry directly disposes the
     // ModalBottomSheet's window abruptly, which intermittently leaves the sheet content on screen
@@ -341,9 +343,10 @@ fun WCNewSignRequestScreen(
                     title = stringResource(R.string.Button_Confirm),
                     variant = ButtonVariant.Primary,
                     modifier = Modifier.weight(1f),
+                    enabled = !confirmAction.inProgress,
                     onClick = {
                         logger.info("allow request")
-                        scope.launch {
+                        confirmAction.run {
                             try {
                                 // Offload the signing (CPU-bound crypto) off the Main thread, but
                                 // keep hide()/removeLastOrNull() on Main — they mutate UI state.

--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/WcRequestEvmScreen.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/WcRequestEvmScreen.kt
@@ -64,6 +64,7 @@ import io.horizontalsystems.walletkit.uiv3.components.controls.ButtonSize
 import io.horizontalsystems.walletkit.uiv3.components.controls.ButtonVariant
 import io.horizontalsystems.walletkit.uiv3.components.controls.HSButton
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -350,7 +351,10 @@ fun WCNewSignRequestScreen(
                             try {
                                 // Offload the signing (CPU-bound crypto) off the Main thread, but
                                 // keep hide()/removeLastOrNull() on Main — they mutate UI state.
-                                withContext(Dispatchers.Default) { onAllow() }
+                                // NonCancellable: this scope dies with the composition (locking the
+                                // app tears the sheet down), and a confirmed sign-and-respond must
+                                // not be dropped halfway.
+                                withContext(Dispatchers.Default + NonCancellable) { onAllow() }
                                 sheetState.hide()
                                 navigation.removeLastOrNull()
                             } catch (e: Throwable) {

--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/sendtransaction/WCSendEthScreen.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/sendtransaction/WCSendEthScreen.kt
@@ -74,7 +74,9 @@ fun WCSendEthRequestScreen(
         factory = WCSendEthereumTransactionRequestViewModel.Factory(
             blockchainType = blockchainType,
             transaction = transaction,
-            peerName = sessionRequestUI.peerUI.peerName
+            peerName = sessionRequestUI.peerUI.peerName,
+            requestId = sessionRequestUI.requestId,
+            topic = sessionRequestUI.topic
         )
     )
     val uiState = viewModel.uiState
@@ -87,8 +89,12 @@ fun WCSendEthRequestScreen(
 
     BottomSheetContent(
         onDismissRequest = {
-            WCDelegate.discardActiveSessionRequest(sessionRequestUI.requestId)
-            navigation.removeLastOrNull()
+            // A confirmed send is already broadcasting (NonCancellable); discarding or rejecting
+            // now would race the pending response, so ignore dismissal until it completes.
+            if (!confirmAction.inProgress) {
+                WCDelegate.discardActiveSessionRequest(sessionRequestUI.requestId)
+                navigation.removeLastOrNull()
+            }
         },
         sheetState = sheetState,
     ) { snackbarActions ->
@@ -190,6 +196,7 @@ fun WCSendEthRequestScreen(
                     variant = ButtonVariant.Secondary,
                     size = ButtonSize.Medium,
                     modifier = Modifier.weight(1f),
+                    enabled = !confirmAction.inProgress,
                     onClick = {
                         viewModel.reject(sessionRequestUI.topic, sessionRequestUI.requestId)
                         navigation.removeLastOrNull()

--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/sendtransaction/WCSendEthScreen.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/sendtransaction/WCSendEthScreen.kt
@@ -200,7 +200,7 @@ fun WCSendEthRequestScreen(
                     variant = ButtonVariant.Primary,
                     modifier = Modifier.weight(1f),
                     enabled = !confirmAction.inProgress && uiState.sendEnabled,
-                    onClick = navigation.authorizedAction {
+                    onClick = {
                         confirmAction.run {
                             Toast.makeText(view.context, sendingMessage, Toast.LENGTH_SHORT).show()
                             try {

--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/sendtransaction/WCSendEthereumTransactionRequestViewModel.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/sendtransaction/WCSendEthereumTransactionRequestViewModel.kt
@@ -27,7 +27,11 @@ import io.horizontalsystems.walletkit.modules.multiswap.sendtransaction.toEvmTra
 class WCSendEthereumTransactionRequestViewModel(
     private val sendEvmTransactionViewItemFactory: SendEvmTransactionViewItemFactory,
     transaction: WalletConnectTransaction,
-    blockchainType: BlockchainType
+    blockchainType: BlockchainType,
+    // Captured at construction: WCDelegate.sessionRequestEvent is mutable and can be replaced by
+    // a newer request while this sheet is open, so the response must target the displayed request.
+    private val requestId: Long,
+    private val topic: String,
 ) : ViewModelUiState<WCSendEthereumTransactionRequestUiState>() {
     val sendTransactionService: SendTransactionServiceEvm
 
@@ -87,9 +91,7 @@ class WCSendEthereumTransactionRequestViewModel(
         val sendResult = sendTransactionService.sendTransaction()
         val transactionHash = sendResult.transactionHash ?: throw Exception("No transaction hash")
 
-        WCDelegate.sessionRequestEvent?.let { sessionRequest ->
-            WCDelegate.respondPendingRequest(sessionRequest.requestId, sessionRequest.topic, transactionHash)
-        }
+        WCDelegate.respondPendingRequest(requestId, topic, transactionHash)
     }
 
     fun reject(topic: String, requestId: Long) {
@@ -104,7 +106,9 @@ class WCSendEthereumTransactionRequestViewModel(
     class Factory(
         private val blockchainType: BlockchainType,
         private val transaction: WalletConnectTransaction,
-        private val peerName: String
+        private val peerName: String,
+        private val requestId: Long,
+        private val topic: String,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -126,7 +130,9 @@ class WCSendEthereumTransactionRequestViewModel(
             return WCSendEthereumTransactionRequestViewModel(
                 sendEvmTransactionViewItemFactory,
                 transaction,
-                blockchainType
+                blockchainType,
+                requestId,
+                topic
             ) as T
         }
     }

--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/sendtransaction/WCSendEthereumTransactionRequestViewModel.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/sendtransaction/WCSendEthereumTransactionRequestViewModel.kt
@@ -19,6 +19,7 @@ import io.horizontalsystems.walletkit.modules.walletconnect.WCDelegate
 import io.horizontalsystems.ethereumkit.models.TransactionData
 import io.horizontalsystems.marketkit.models.BlockchainType
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import io.horizontalsystems.walletkit.modules.multiswap.sendtransaction.toEvmTransactionData
@@ -77,7 +78,12 @@ class WCSendEthereumTransactionRequestViewModel(
             sendTransactionService.decorate(transactionData)
         )
 
-    suspend fun confirm() = withContext(Dispatchers.Default) {
+    // NonCancellable: the caller is a UI-scoped coroutine that dies with the composition (locking
+    // the app tears the sheet down mid-flight). sendTransaction() suspends on the network, so a
+    // plain cancellation could land after the transaction broadcast but before the dApp response —
+    // leaving the request pending and inviting a second send. Once the user has confirmed, run the
+    // broadcast-and-respond block to completion.
+    suspend fun confirm() = withContext(Dispatchers.Default + NonCancellable) {
         val sendResult = sendTransactionService.sendTransaction()
         val transactionHash = sendResult.transactionHash ?: throw Exception("No transaction hash")
 

--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/signtransaction/WCSignEthereumTransactionRequestScreen.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/signtransaction/WCSignEthereumTransactionRequestScreen.kt
@@ -199,7 +199,7 @@ fun WCSignEthereumTransactionRequestScreen(
                     title = stringResource(R.string.Button_Approve),
                     variant = ButtonVariant.Primary,
                     modifier = Modifier.weight(1f),
-                    onClick = navigation.authorizedAction {
+                    onClick = {
                         coroutineScope.launch {
                             try {
                                 logger.info("click sign button")
@@ -229,7 +229,7 @@ fun WCSignEthereumTransactionRequestScreen(
             ButtonPrimaryYellow(
                 modifier = Modifier.fillMaxWidth(),
                 title = stringResource(R.string.Button_Sign),
-                onClick = navigation.authorizedAction {
+                onClick = {
                     coroutineScope.launch {
                         try {
                             logger.info("click sign button")

--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/signtransaction/WCSignEthereumTransactionRequestScreen.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/signtransaction/WCSignEthereumTransactionRequestScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -44,6 +43,7 @@ import io.horizontalsystems.walletkit.ui.compose.ComposeAppTheme
 import io.horizontalsystems.walletkit.ui.compose.components.ButtonPrimaryDefault
 import io.horizontalsystems.walletkit.ui.compose.components.ButtonPrimaryYellow
 import io.horizontalsystems.walletkit.ui.compose.components.VSpacer
+import io.horizontalsystems.walletkit.ui.compose.components.rememberAsyncAction
 import io.horizontalsystems.walletkit.ui.compose.components.headline1_leah
 import io.horizontalsystems.walletkit.ui.compose.components.subhead_grey
 import io.horizontalsystems.walletkit.modules.walletconnect.VerificationAlert
@@ -56,7 +56,6 @@ import io.horizontalsystems.walletkit.uiv3.components.controls.HSButton
 import io.horizontalsystems.walletkit.uiv3.components.info.TextBlock
 import io.horizontalsystems.marketkit.models.BlockchainType
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -76,8 +75,10 @@ fun WCSignEthereumTransactionRequestScreen(
     )
     val uiState = viewModel.uiState
     val view = LocalView.current
-    val coroutineScope = rememberCoroutineScope()
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    // Shared by the sheet's Approve and the confirmation screen's Sign button: both respond to
+    // the same request, so a click on either must lock out both.
+    val signAction = rememberAsyncAction()
 
     val feeText = stringResource(id = R.string.Send_Fee)
     val feeInfoText = stringResource(id = R.string.FeeSettings_NetworkFee_Info)
@@ -199,8 +200,9 @@ fun WCSignEthereumTransactionRequestScreen(
                     title = stringResource(R.string.Button_Approve),
                     variant = ButtonVariant.Primary,
                     modifier = Modifier.weight(1f),
+                    enabled = !signAction.inProgress,
                     onClick = {
-                        coroutineScope.launch {
+                        signAction.run {
                             try {
                                 logger.info("click sign button")
                                 viewModel.sign()
@@ -229,8 +231,9 @@ fun WCSignEthereumTransactionRequestScreen(
             ButtonPrimaryYellow(
                 modifier = Modifier.fillMaxWidth(),
                 title = stringResource(R.string.Button_Sign),
+                enabled = !signAction.inProgress,
                 onClick = {
-                    coroutineScope.launch {
+                    signAction.run {
                         try {
                             logger.info("click sign button")
                             viewModel.sign()

--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/signtransaction/WCSignEthereumTransactionRequestScreen.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/signtransaction/WCSignEthereumTransactionRequestScreen.kt
@@ -70,7 +70,9 @@ fun WCSignEthereumTransactionRequestScreen(
         factory = WCSignEthereumTransactionRequestViewModel.Factory(
             blockchainType = blockchainType,
             transaction = transaction,
-            peerName = sessionRequestUI.peerUI.peerName
+            peerName = sessionRequestUI.peerUI.peerName,
+            requestId = sessionRequestUI.requestId,
+            topic = sessionRequestUI.topic
         )
     )
     val uiState = viewModel.uiState
@@ -86,8 +88,12 @@ fun WCSignEthereumTransactionRequestScreen(
 
     BottomSheetContent(
         onDismissRequest = {
-            WCDelegate.discardActiveSessionRequest(sessionRequestUI.requestId)
-            navigation.removeLastOrNull()
+            // A confirmed sign is already responding (NonCancellable); discarding or rejecting
+            // now would race the pending response, so ignore dismissal until it completes.
+            if (!signAction.inProgress) {
+                WCDelegate.discardActiveSessionRequest(sessionRequestUI.requestId)
+                navigation.removeLastOrNull()
+            }
         },
         sheetState = sheetState,
     ) { snackbarActions ->
@@ -191,6 +197,7 @@ fun WCSignEthereumTransactionRequestScreen(
                     variant = ButtonVariant.Secondary,
                     size = ButtonSize.Medium,
                     modifier = Modifier.weight(1f),
+                    enabled = !signAction.inProgress,
                     onClick = {
                         viewModel.reject(sessionRequestUI.topic, sessionRequestUI.requestId)
                         navigation.removeLastOrNull()

--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/signtransaction/WCSignEthereumTransactionRequestViewModel.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/signtransaction/WCSignEthereumTransactionRequestViewModel.kt
@@ -22,6 +22,7 @@ import io.horizontalsystems.walletkit.modules.walletconnect.request.sendtransact
 import io.horizontalsystems.ethereumkit.models.TransactionData
 import io.horizontalsystems.marketkit.models.BlockchainType
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
 
 class WCSignEthereumTransactionRequestViewModel(
@@ -86,7 +87,10 @@ class WCSignEthereumTransactionRequestViewModel(
         return items
     }
 
-    suspend fun sign() = withContext(Dispatchers.Default) {
+    // NonCancellable: the caller is a UI-scoped coroutine that dies with the composition (locking
+    // the app tears the sheet down mid-flight). The body has no suspension points today, but that
+    // atomicity is incidental — keep sign-and-respond explicitly uninterruptible once confirmed.
+    suspend fun sign() = withContext(Dispatchers.Default + NonCancellable) {
         val signer = evmKit.signer ?: throw WCSessionManager.RequestDataError.NoSigner
         val gasData = gasData ?: throw WCSessionManager.RequestDataError.InvalidGasPrice
         val nonce = nonce ?: throw WCSessionManager.RequestDataError.InvalidNonce

--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/signtransaction/WCSignEthereumTransactionRequestViewModel.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/signtransaction/WCSignEthereumTransactionRequestViewModel.kt
@@ -30,7 +30,11 @@ class WCSignEthereumTransactionRequestViewModel(
     baseCoinService: EvmCoinService,
     private val sendEvmTransactionViewItemFactory: SendEvmTransactionViewItemFactory,
     private val dAppName: String,
-    transaction: WalletConnectTransaction
+    transaction: WalletConnectTransaction,
+    // Captured at construction: WCDelegate.sessionRequestEvent is mutable and can be replaced by
+    // a newer request while this sheet is open, so the response must target the displayed request.
+    private val requestId: Long,
+    private val topic: String,
 ) : ViewModelUiState<WCSignEthereumTransactionRequestUiState>() {
 
     private val transactionData = TransactionData(
@@ -104,9 +108,7 @@ class WCSignEthereumTransactionRequestViewModel(
             nonce = nonce
         )
 
-        WCDelegate.sessionRequestEvent?.let { sessionRequest ->
-            WCDelegate.respondPendingRequest(sessionRequest.requestId, sessionRequest.topic, signature.toHexString())
-        }
+        WCDelegate.respondPendingRequest(requestId, topic, signature.toHexString())
     }
 
     fun reject(topic: String, requestId: Long) {
@@ -121,7 +123,9 @@ class WCSignEthereumTransactionRequestViewModel(
     class Factory(
         private val blockchainType: BlockchainType,
         private val transaction: WalletConnectTransaction,
-        private val peerName: String
+        private val peerName: String,
+        private val requestId: Long,
+        private val topic: String,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -147,7 +151,9 @@ class WCSignEthereumTransactionRequestViewModel(
                 coinServiceFactory.baseCoinService,
                 sendEvmTransactionViewItemFactory,
                 peerName,
-                transaction
+                transaction,
+                requestId,
+                topic
             ) as T
         }
     }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/BottomSheetSceneStrategy.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/BottomSheetSceneStrategy.kt
@@ -5,8 +5,8 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.ModalBottomSheetProperties
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.scene.OverlayScene
 import androidx.navigation3.scene.Scene
@@ -36,7 +36,7 @@ internal class BottomSheetScene<T : Any>(
         // Default-dispatcher coroutine), so a sheet can slip onto the stack in the same frame the
         // app locks. Keep the entry on the stack but don't compose the sheet while locked: the
         // window is torn down for the whole lock, and the sheet re-enters intact on unlock.
-        val isLocked by App.pinComponent.isLockedFlow.collectAsState()
+        val isLocked by App.pinComponent.isLockedFlow.collectAsStateWithLifecycle()
         if (!isLocked) {
             ModalBottomSheet(
                 onDismissRequest = onBack,

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/BottomSheetSceneStrategy.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/BottomSheetSceneStrategy.kt
@@ -5,11 +5,14 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.ModalBottomSheetProperties
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.scene.OverlayScene
 import androidx.navigation3.scene.Scene
 import androidx.navigation3.scene.SceneStrategy
 import androidx.navigation3.scene.SceneStrategyScope
+import io.horizontalsystems.walletkit.core.App
 import io.horizontalsystems.walletkit.modules.nav3.BottomSheetSceneStrategy.Companion.bottomSheet
 
 /** An [OverlayScene] that renders an [entry] within a [ModalBottomSheet]. */
@@ -27,13 +30,22 @@ internal class BottomSheetScene<T : Any>(
     override val entries: List<NavEntry<T>> = listOf(entry)
 
     override val content: @Composable (() -> Unit) = {
-        ModalBottomSheet(
-            onDismissRequest = onBack,
-            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = skipPartiallyExpanded),
-            properties = modalBottomSheetProperties,
-            dragHandle = null
-        ) {
-            entry.Content()
+        // ModalBottomSheet opens its own window, composited above the activity window — and so
+        // above the PinUnlock overlay, which would leave the sheet interactable over the keypad.
+        // The lock also engages asynchronously (PinComponent collects background state on a
+        // Default-dispatcher coroutine), so a sheet can slip onto the stack in the same frame the
+        // app locks. Keep the entry on the stack but don't compose the sheet while locked: the
+        // window is torn down for the whole lock, and the sheet re-enters intact on unlock.
+        val isLocked by App.pinComponent.isLockedFlow.collectAsState()
+        if (!isLocked) {
+            ModalBottomSheet(
+                onDismissRequest = onBack,
+                sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = skipPartiallyExpanded),
+                properties = modalBottomSheetProperties,
+                dragHandle = null
+            ) {
+                entry.Content()
+            }
         }
     }
 }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/session/WCSessionSheet.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/session/WCSessionSheet.kt
@@ -110,6 +110,10 @@ fun WCSessionScreen(
         }
     }
 
+    // Latched off on click so a connect attempt can't be started twice; on success the sheet
+    // closes, so the only path that must re-enable it is a failure surfacing through showError.
+    var connectButtonEnabled by remember { mutableStateOf(true) }
+
     BottomSheetContent(
         onDismissRequest = {
             // Reject the proposal on dismiss so the dApp isn't left waiting, then animate out.
@@ -120,6 +124,7 @@ fun WCSessionScreen(
     ) { snackbarActions ->
         uiState.showError?.let {
             snackbarActions.showErrorMessage(it)
+            connectButtonEnabled = true
             viewModel.errorShown()
         }
         Column(
@@ -250,7 +255,11 @@ fun WCSessionScreen(
         ActionButtons(
             navigation = navigation,
             buttonsStates = buttonsStates,
-            onConnectClick = { viewModel.connect() },
+            connectEnabled = connectButtonEnabled,
+            onConnectClick = {
+                connectButtonEnabled = false
+                viewModel.connect()
+            },
             onDisconnectClick = { viewModel.disconnect() },
             onCancelClick = {
                 viewModel.rejectProposal()
@@ -266,11 +275,11 @@ fun WCSessionScreen(
 private fun ActionButtons(
     navigation: HSNavigation,
     buttonsStates: WCSessionButtonStates?,
+    connectEnabled: Boolean,
     onConnectClick: () -> Unit,
     onDisconnectClick: () -> Unit,
     onCancelClick: () -> Unit,
 ) {
-    var connectButtonEnabled by remember { mutableStateOf(true) }
     buttonsStates?.let { buttons ->
         ButtonsGroupHorizontal {
             if (buttons.cancel.visible) {
@@ -287,11 +296,8 @@ private fun ActionButtons(
                     title = stringResource(R.string.Button_Connect),
                     variant = ButtonVariant.Primary,
                     modifier = Modifier.weight(1f),
-                    enabled = connectButtonEnabled,
-                    onClick = {
-                        connectButtonEnabled = false
-                        onConnectClick()
-                    }
+                    enabled = connectEnabled,
+                    onClick = onConnectClick
                 )
             }
             if (buttons.disconnect.visible || buttons.remove.visible) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/session/WCSessionSheet.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/session/WCSessionSheet.kt
@@ -288,9 +288,7 @@ private fun ActionButtons(
                     variant = ButtonVariant.Primary,
                     modifier = Modifier.weight(1f),
                     enabled = connectButtonEnabled,
-                    // Guarded first, so cancelling the passcode prompt leaves the button usable
-                    // instead of latching it disabled.
-                    onClick = navigation.authorizedAction {
+                    onClick = {
                         connectButtonEnabled = false
                         onConnectClick()
                     }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/session/WCSessionViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/session/WCSessionViewModel.kt
@@ -32,6 +32,7 @@ import io.horizontalsystems.dapp.core.HSDAppVerification
 import io.horizontalsystems.marketkit.models.BlockchainType
 import io.horizontalsystems.subscriptions.core.ScamProtection
 import io.horizontalsystems.subscriptions.core.UserSubscriptionManager
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.net.URL
@@ -338,6 +339,8 @@ class WCSessionViewModel(
                 reject(proposal.proposerPublicKey) {
                     sessionServiceState = Killed
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (t: Throwable) {
                 // The proposal may already be gone (RequestNotFoundError) or the relay call may
                 // fail. The user asked to dismiss either way, so close instead of crashing the
@@ -369,6 +372,8 @@ class WCSessionViewModel(
                 connected = true
                 closeDialog = true
                 emitState()
+            } catch (e: CancellationException) {
+                throw e
             } catch (t: Throwable) {
                 WCDelegate.sessionProposalEvent = null
                 // showErrorLiveEvent has no observer in the Compose sheet; surface the failure
@@ -404,7 +409,7 @@ class WCSessionViewModel(
     suspend fun approve(proposalPublicKey: String) {
         val accountNonNull = account ?: return
         return suspendCoroutine { continuation ->
-            if (DAppManager.getSessionProposals().isNotEmpty()) {
+            if (DAppManager.getSessionProposals().any { it.proposerPublicKey == proposalPublicKey }) {
                 val namespaces = wcManager.getSupportedNamespaces(accountNonNull)
                 val sessionNamespaces = DAppManager.generateApprovedNamespaces(proposalPublicKey, namespaces)
 
@@ -431,7 +436,7 @@ class WCSessionViewModel(
 
     suspend fun reject(proposalPublicKey: String, onSuccess: () -> Unit) {
         return suspendCoroutine { continuation ->
-            if (DAppManager.getSessionProposals().isNotEmpty()) {
+            if (DAppManager.getSessionProposals().any { it.proposerPublicKey == proposalPublicKey }) {
                 DAppManager.rejectSession(
                     proposerPublicKey = proposalPublicKey,
                     onSuccess = {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/session/WCSessionViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/session/WCSessionViewModel.kt
@@ -334,10 +334,17 @@ class WCSessionViewModel(
         }
 
         viewModelScope.launch {
-            reject(proposal.proposerPublicKey) {
-                sessionServiceState = Killed
+            try {
+                reject(proposal.proposerPublicKey) {
+                    sessionServiceState = Killed
+                }
+            } catch (t: Throwable) {
+                // The proposal may already be gone (RequestNotFoundError) or the relay call may
+                // fail. The user asked to dismiss either way, so close instead of crashing the
+                // coroutine or stranding the sheet; the dApp side times out on its own.
             }
             closeDialog = true
+            emitState()
         }
     }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/session/WCSessionViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/session/WCSessionViewModel.kt
@@ -366,7 +366,7 @@ class WCSessionViewModel(
                 WCDelegate.sessionProposalEvent = null
                 // showErrorLiveEvent has no observer in the Compose sheet; surface the failure
                 // through uiState so the snackbar shows and the Connect button is re-enabled.
-                showError = t.message ?: t.javaClass.simpleName
+                showError = getErrorMessage(t) ?: t.message ?: t.javaClass.simpleName
                 emitState()
             }
         }
@@ -413,6 +413,11 @@ class WCSessionViewModel(
                         WCDelegate.sessionProposalEvent = null
                     }
                 )
+            } else {
+                // Resume with an error instead of suspending forever (which would also leave the
+                // Connect button latched disabled): the proposal is gone, e.g. already handled or
+                // expired.
+                continuation.resumeWithException(RequestNotFoundError)
             }
         }
     }
@@ -432,6 +437,9 @@ class WCSessionViewModel(
                         WCDelegate.sessionProposalEvent = null
                     }
                 )
+            } else {
+                // Same as approve(): never leave the continuation suspended forever.
+                continuation.resumeWithException(RequestNotFoundError)
             }
         }
     }
@@ -500,10 +508,13 @@ class WCSessionViewModel(
     }
 
     private fun setError(state: WCSessionServiceState) {
-        showError = when {
+        when {
             state is Invalid && (state.error !is ValidationError) ->
-                state.error.message ?: state.error::class.java.simpleName
-            else -> null
+                showError = state.error.message ?: state.error::class.java.simpleName
+            // Don't clear a pending error here: sync() runs on every connectionAvailableEvent
+            // emission and would wipe an approve() failure before the sheet renders it. The
+            // error is consumed by errorShown() once displayed.
+            else -> {}
         }
     }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/session/WCSessionViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/session/WCSessionViewModel.kt
@@ -364,7 +364,10 @@ class WCSessionViewModel(
                 emitState()
             } catch (t: Throwable) {
                 WCDelegate.sessionProposalEvent = null
-                showErrorLiveEvent.postValue(t.message)
+                // showErrorLiveEvent has no observer in the Compose sheet; surface the failure
+                // through uiState so the snackbar shows and the Connect button is re-enabled.
+                showError = t.message ?: t.javaClass.simpleName
+                emitState()
             }
         }
     }


### PR DESCRIPTION
Confirming a WalletConnect request is an action the user just initiated from the dApp, so the passcode guard added in 586eb649a and 510196ff8 was unwanted friction.

This removes `authorizedAction` from the WalletConnect confirm/approve buttons:

- request confirm (`WcRequestEvmScreen`)
- send transaction confirm (`WCSendEthScreen`)
- sign transaction — both the Approve sheet and Sign screen buttons (`WCSignEthereumTransactionRequestScreen`)
- session connect (`WCSessionSheet`)

TonConnect keeps its existing guard, and the typed-data parsing fixes from 510196ff8 are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WalletConnect connection, signing, and transaction approval reliability.
  * Prevented duplicate actions by disabling controls while requests are processing.
  * Ensured responses are sent to the correct WalletConnect request.
  * Improved error handling and visibility for failed connection and approval attempts.
  * Prevented requests from becoming stuck when no pending proposal is available.
  * WalletConnect sheets now close when the app is locked and reappear after unlocking.
  * Preserved progress, success, toast, and error feedback throughout request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->