### PR TITLE
Move the Tron send confirmation to its own page

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/SendConfirmationPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/SendConfirmationPage.kt
@@ -4,8 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.nav3.HSPage
-import io.horizontalsystems.walletkit.modules.send.tron.SendTronConfirmationScreen
-import io.horizontalsystems.walletkit.modules.send.tron.SendTronViewModel
 import io.horizontalsystems.walletkit.serializers.HSScreenKClassSerializer
 import kotlinx.serialization.Serializable
 import kotlin.reflect.KClass
@@ -32,14 +30,12 @@ data class SendConfirmationPage(val input: Input) : HSPage() {
                 }
             }
 
+            // Legacy: moved to SendTronConfirmationPage next to the Tron send screen.
+            // A back stack persisted before the split may still restore this entry - pop it.
             Type.Tron -> {
-                val sendTronViewModel = navigation.viewModelForScreen<SendTronViewModel>(SendPage::class)
-
-                SendTronConfirmationScreen(
-                    navigation,
-                    sendTronViewModel,
-                    input.sendEntryPointDestId
-                )
+                LaunchedEffect(Unit) {
+                    navigation.removeLastOrNull()
+                }
             }
 
             // Legacy: moved to SendSolanaConfirmationPage in the Solana chain module.

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/tron/SendTronConfirmationPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/tron/SendTronConfirmationPage.kt
@@ -1,0 +1,26 @@
+package io.horizontalsystems.walletkit.modules.send.tron
+
+import androidx.compose.runtime.Composable
+import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
+import io.horizontalsystems.walletkit.modules.nav3.HSPage
+import io.horizontalsystems.walletkit.modules.send.SendPage
+import io.horizontalsystems.walletkit.serializers.HSScreenKClassSerializer
+import kotlinx.serialization.Serializable
+import kotlin.reflect.KClass
+
+@Serializable
+data class SendTronConfirmationPage(
+    @Serializable(with = HSScreenKClassSerializer::class) val sendEntryPointDestId: KClass<out HSPage>,
+) : HSPage() {
+
+    @Composable
+    override fun GetContent(navigation: HSNavigation) {
+        val sendTronViewModel = navigation.viewModelForScreen<SendTronViewModel>(SendPage::class)
+
+        SendTronConfirmationScreen(
+            navigation,
+            sendTronViewModel,
+            sendEntryPointDestId
+        )
+    }
+}

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/tron/SendTronScreen.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/tron/SendTronScreen.kt
@@ -24,7 +24,6 @@ import io.horizontalsystems.walletkit.modules.availablebalance.AvailableBalance
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.nav3.HSPage
 import io.horizontalsystems.walletkit.modules.send.AddressRiskySheet
-import io.horizontalsystems.walletkit.modules.send.SendConfirmationPage
 import io.horizontalsystems.walletkit.modules.send.SendScreen
 import io.horizontalsystems.walletkit.ui.compose.components.ButtonPrimaryYellow
 import io.horizontalsystems.walletkit.ui.compose.components.VSpacer
@@ -148,10 +147,5 @@ private fun openConfirm(
 ) {
     viewModel.onNavigateToConfirmation()
 
-    navigation.slideFromRight(
-        SendConfirmationPage(SendConfirmationPage.Input(
-            SendConfirmationPage.Type.Tron,
-            sendEntryPointDestId
-        ))
-    )
+    navigation.slideFromRight(SendTronConfirmationPage(sendEntryPointDestId))
 }


### PR DESCRIPTION
Gives Tron the same dedicated confirmation page as the extracted chains, leaving the legacy SendConfirmationPage with shim branches only — deletable after one shipped release. Part of #9440.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Tron transaction confirmation page.
  * Tron send flows now open the dedicated confirmation screen directly.

* **Bug Fixes**
  * Improved navigation handling for restored Tron send flows by removing outdated confirmation entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->