### PR TITLE
Separate the deploy links from the notification body

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -96,6 +96,7 @@ jobs:
 
             Title: ${{ needs.build.outputs.commit_subject }}
             Author: @${{ github.actor }}
+
             <a href="${{ needs.build.outputs.ci_testing_uri }}">Standard</a> | <a href="${{ needs.build.outputs.fdroid_testing_uri }}">F-Droid</a>
 
       - name: Notify Telegram on failure
@@ -111,4 +112,5 @@ jobs:
 
             Title: ${{ needs.build.outputs.commit_subject }}
             Author: @${{ github.actor }}
+
             <a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}">Log</a>

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -80,6 +80,7 @@ jobs:
 
             Title: ${{ needs.build.outputs.commit_subject }}
             Author: @${{ github.actor }}
+
             <a href="${{ needs.build.outputs.ci_testing_uri }}">Open release</a>
 
       - name: Notify Telegram on failure
@@ -95,4 +96,5 @@ jobs:
 
             Title: ${{ needs.build.outputs.commit_subject }}
             Author: @${{ github.actor }}
+
             <a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}">Log</a>


### PR DESCRIPTION
Adds a blank line between the author line and the distribution links in the Telegram deploy notifications.