### PR TITLE
Stop offering AllBridge as a swap provider

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/MultiSwapProviderRegistry.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/MultiSwapProviderRegistry.kt
@@ -7,7 +7,6 @@ import io.horizontalsystems.marketkit.models.BlockchainType
 object MultiSwapProviderRegistry {
     val allProviders: List<IMultiSwapProvider> = listOf(
         // Cross-chain providers
-        AllBridgeProvider,
         USwapProvider(UProvider.Near),
         USwapProvider(UProvider.QuickEx),
         USwapProvider(UProvider.LetsExchange),
@@ -30,8 +29,16 @@ object MultiSwapProviderRegistry {
         ),
     ) + ChainRegistry.all.flatMap { it.swapProviders() }
 
+    /**
+     * Providers no longer offered for swapping. They stay reachable by id so swaps already made
+     * with them keep resolving their type and stage layout in history, but no quote is requested
+     * from them.
+     */
+    private val retiredProviders: List<IMultiSwapProvider>
+        get() = listOf(AllBridgeProvider)
+
     private val providersById: Map<String, IMultiSwapProvider> by lazy {
-        allProviders.associateBy { it.id }
+        (allProviders + retiredProviders).associateBy { it.id }
     }
 
     fun isSingleTransactionSwap(providerId: String, tokenInBlockchainTypeUid: String, tokenOutBlockchainTypeUid: String): Boolean {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/SwapSuspension.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/SwapSuspension.kt
@@ -12,7 +12,7 @@ import java.time.Instant
  * Two kinds of provider need this and for different reasons:
  *  - Providers uswap-server quotes: it already refuses a suspended request, so honouring the rule
  *    here is purely so the user never sees a card that is going to fail.
- *  - Providers the APP quotes itself (Uniswap, PancakeSwap, AllBridge, and 1inch/THORChain/Maya,
+ *  - Providers the APP quotes itself (Uniswap, PancakeSwap, and 1inch/THORChain/Maya,
  *    which have native implementations here): no server call happens at all, so this filter is the
  *    ONLY enforcement that exists. Dropping it would make those providers unsuspendable.
  *

--- a/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/multiswap/providers/SwapProviderIdMappingTest.kt
+++ b/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/multiswap/providers/SwapProviderIdMappingTest.kt
@@ -23,7 +23,6 @@ class SwapProviderIdMappingTest {
     // The registry cannot be built in a unit test — its providers reach for App at construction —
     // so the ids are listed from their declaration sites.
     private val appProviderIds = UProvider.entries.map { "u_${it.id}" } + listOf(
-        "allbridge",
         "u_STELLARBROKER",
         THORCHAIN_PROVIDER_ID,
         MAYA_PROVIDER_ID,


### PR DESCRIPTION
Closes #9497

AllBridge is no longer offered for quotes. The provider implementation is kept and stays reachable by id so existing swap history records still resolve correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Removed AllBridge from the list of currently available swap providers.
  * Preserved historical AllBridge references so previously recorded swaps can still be resolved.
  * Updated provider documentation and validation to reflect the current provider list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->