### PR TITLE
Allow manual runs of the dev deploy workflow

### DIFF
--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -3,6 +3,7 @@ name: Deploy Dev to Firebase
 on:
   push:
     branches: [ version/* ]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Adds a workflow_dispatch trigger so the Firebase dev deploy can be started manually from the Actions tab, in addition to running on version/* pushes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to manually trigger Dev deployments from the GitHub Actions interface.
  * Dev deployments continue to run automatically for changes pushed to `version/*` branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->