### PR TITLE
Update Zano kit to 4e55a34

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,7 +67,7 @@ unstoppableDomains = "v7.1.0"
 
 # Wallet Kits
 moneroKit = "ccd6dd8b"
-zanoKit = "d83a9a5"
+zanoKit = "4e55a34"
 stellarKit = "4ecccc5"
 tonKit = "947c48a"
 bitcoinKit = "dad7ed4"


### PR DESCRIPTION
Bumps `zanoKit` from `d83a9a5` to `4e55a34`, which rebuilds the native libs from Zano 2.2.1.506 (up from 2.2.1.502).

### What's in it

- **2.2.1.505** — HF6 consensus/security: reorg unwind order, gateway descriptor limits, asset ticker/name/meta limits enforced at consensus
- **2.2.1.506** — `submitblock2` range-proof validation, `object_in_json` serialization fix

The wallet-facing delta is small — one line each in `wallet2.cpp` and `wallet_rpc_server.cpp`, both in asset-deploy paths the kit doesn't call. No kit API changes, so nothing in `walletkit-chain-zano` needed touching.

The kit's ARM32 chacha patch is still applied: the fix is merged upstream (hyle-team/zano#727), but tag 2.2.1.506 was cut before the merge reached it, so the tag's `chacha.c` still has the unaligned pointer casts. See horizontalsystems/zano-kit-android#6.

### Testing

Sync and send verified on arm64 against the kit published to mavenLocal, then rebuilt against the JitPack artifact — the two AARs are identical. The APK embeds `2.2.1.506[3a18f65]` on both shipped ABIs (`armeabi-v7a`, `arm64-v8a`).

Note the ARM32 alignment fix itself can only be exercised on physical 32-bit ARM hardware, so it remains covered by code-level verification rather than an on-device test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Zano wallet kit dependency to a newer version for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->