### PR TITLE
Defer WalletConnect pairing and deeplinks while locked

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/App.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/App.kt
@@ -393,7 +393,7 @@ abstract class App : CoreApp(), WorkConfiguration.Provider, ImageLoaderFactory {
 
         rateAppManager = RateAppManager(walletManager, adapterManager, localStorage)
 
-        wcManager = WCManager(accountManager)
+        wcManager = WCManager(accountManager, pinComponent)
         ChainRegistry.all.forEach { plugin ->
             plugin.wcHandlers().forEach(wcManager::addWcHandler)
         }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/BalanceViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/BalanceViewModel.kt
@@ -418,8 +418,11 @@ class BalanceViewModel(
     }
 
     fun connectWC(uri: String) {
-        DAppManager.pair(
-            uri = uri.trim(),
+        // The QR scanner is its own activity, so it isn't covered by the unlock overlay and can
+        // still be scanning when the app locks. Deferring keeps a scanned `wc:` code from pairing
+        // behind the lock screen.
+        wCManager.pairOrDefer(
+            uri = uri,
             onSuccess = { connectionResult = null },
             onError = { connectionResult = WalletConnectListViewModel.ConnectionResult.Error }
         )

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainPage.kt
@@ -27,7 +27,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import io.horizontalsystems.walletkit.core.App
 import io.horizontalsystems.walletkit.core.managers.RateAppManager
 import io.horizontalsystems.walletkit.core.stats.StatEvent
 import io.horizontalsystems.walletkit.core.stats.StatPage
@@ -81,7 +83,14 @@ private fun MainScreen(
     viewModel: MainViewModel = viewModel(factory = MainModule.Factory())
 ) {
     val activityIntent by mainActivityViewModel.intentLiveData.observeAsState()
-    LaunchedEffect(activityIntent) {
+    val isLocked by App.pinComponent.isLockedFlow.collectAsStateWithLifecycle()
+    // MainScreen stays composed under the unlock overlay, so without this gate a deeplink opened
+    // while the app is locked would be acted on behind the lock screen — referral registration,
+    // TonConnect links, prefilled send flows, the WalletConnect list. The intent is deliberately
+    // left unconsumed (no intentHandled() call) so this effect re-runs when isLocked flips back.
+    LaunchedEffect(activityIntent, isLocked) {
+        if (isLocked) return@LaunchedEffect
+
         activityIntent?.data?.let {
             delay(1000)
             viewModel.handleDeepLink(it)

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/Nav3.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/Nav3.kt
@@ -69,7 +69,9 @@ fun Nav3(entryPage: HSPage) {
 
     LaunchedEffect(isLocked) {
         if (!isLocked) {
-            // Re-show any WC request/proposal that arrived while locked
+            // Pair with any `wc:` link that arrived while locked, then re-show any WC
+            // request/proposal that arrived while locked
+            App.wcManager.flushPendingPairing()
             mainActivityViewModel.reEmitPendingWcEventIfNeeded()
         }
     }
@@ -175,7 +177,8 @@ private fun handleWalletConnectDeepLink(intent: Intent, navigation: HSNavigation
 
     when (val supportState = App.wcManager.getWalletConnectSupportState()) {
         WCManager.SupportState.Supported -> {
-            DAppManager.pair(wcUri.trim())
+            // Held until unlock while the app is locked — see WCManager.pairOrDefer.
+            App.wcManager.pairOrDefer(wcUri)
         }
 
         WCManager.SupportState.NotSupportedDueToNoActiveAccount -> {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/qrscanner/QRScannerActivity.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/qrscanner/QRScannerActivity.kt
@@ -97,6 +97,10 @@ class QRScannerActivity : BaseActivity() {
             repeatOnLifecycle(Lifecycle.State.CREATED) {
                 App.pinComponent.isLockedFlow.collect { isLocked ->
                     if (isLocked) {
+                        // onScan() sets RESULT_OK a full second before it finishes, so overwrite
+                        // the result here: a code scanned just as the app locks must not reach the
+                        // launcher and be acted on behind the lock screen.
+                        setResult(RESULT_CANCELED)
                         finish()
                     }
                 }
@@ -116,6 +120,12 @@ class QRScannerActivity : BaseActivity() {
     }
 
     private fun onScan(address: String?) {
+        if (App.pinComponent.isLocked) {
+            setResult(RESULT_CANCELED)
+            finish()
+            return
+        }
+
         setResult(RESULT_OK, Intent().apply {
             putExtra(ModuleField.SCAN_ADDRESS, address)
         })

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/qrscanner/QRScannerActivity.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/qrscanner/QRScannerActivity.kt
@@ -50,7 +50,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleResumeEffect
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionStatus
 import com.google.accompanist.permissions.rememberPermissionState
@@ -62,6 +65,7 @@ import com.google.zxing.qrcode.QRCodeReader
 import com.journeyapps.barcodescanner.CompoundBarcodeView
 import com.journeyapps.barcodescanner.ScanOptions
 import io.horizontalsystems.walletkit.R
+import io.horizontalsystems.walletkit.core.App
 import io.horizontalsystems.walletkit.core.BaseActivity
 import io.horizontalsystems.walletkit.core.utils.ModuleField
 import io.horizontalsystems.walletkit.helpers.HudHelper
@@ -78,11 +82,26 @@ import io.horizontalsystems.walletkit.ui.compose.components.title3_leah
 import io.horizontalsystems.walletkit.ui.helpers.TextHelper
 import io.horizontalsystems.walletkit.uiv3.components.controls.ButtonVariant
 import io.horizontalsystems.walletkit.uiv3.components.controls.HSButton
+import kotlinx.coroutines.launch
 
 class QRScannerActivity : BaseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // The scanner is a separate activity, so the unlock overlay drawn inside MainActivity
+        // doesn't cover it: a scanner left open when the app auto-locks would keep accepting QR
+        // codes (WalletConnect pairing, addresses) behind the lock screen. Close it instead, which
+        // brings MainActivity and its unlock keypad back to the front.
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.CREATED) {
+                App.pinComponent.isLockedFlow.collect { isLocked ->
+                    if (isLocked) {
+                        finish()
+                    }
+                }
+            }
+        }
 
         setContent {
             ComposeAppTheme {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/WCManager.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/WCManager.kt
@@ -1,17 +1,20 @@
 package io.horizontalsystems.walletkit.modules.walletconnect
 
 import android.net.Uri
+import io.horizontalsystems.walletkit.IPinComponent
 import io.horizontalsystems.walletkit.core.IAccountManager
 import io.horizontalsystems.walletkit.entities.Account
 import io.horizontalsystems.walletkit.modules.walletconnect.handler.IWCHandler
 import io.horizontalsystems.walletkit.modules.walletconnect.handler.MethodData
 import io.horizontalsystems.walletkit.modules.walletconnect.request.AbstractWCAction
 import io.horizontalsystems.walletkit.modules.walletconnect.session.ValidationError
+import io.horizontalsystems.dapp.core.DAppManager
 import io.horizontalsystems.dapp.core.HSDAppNamespaceSession
 import io.horizontalsystems.dapp.core.HSDAppRequest
 
 class WCManager(
     private val accountManager: IAccountManager,
+    private val pinComponent: IPinComponent,
 ) {
     sealed class SupportState {
         object Supported : SupportState()
@@ -20,6 +23,38 @@ class WCManager(
     }
 
     private val handlersMap = mutableMapOf<String, IWCHandler>()
+
+    // A `wc:` URI that arrived (deeplink or QR scan) while the app was locked. Pairing is an
+    // active network handshake with a dApp, so it must not run behind the lock screen: it would
+    // let anyone holding an OS-unlocked device establish a session the owner never saw, and the
+    // proposal sheet then pops up on their next unlock looking self-inflicted. The URI is kept
+    // here and paired by flushPendingPairing() once unlocked.
+    private var pendingPairingUri: String? = null
+
+    /**
+     * Pairs with [uri], or holds it until the app is unlocked. Callbacks apply to the immediate
+     * path only — a deferred pairing reports through the usual WC event stream instead.
+     */
+    fun pairOrDefer(
+        uri: String,
+        onSuccess: () -> Unit = {},
+        onError: (Throwable) -> Unit = {},
+    ) {
+        val trimmed = uri.trim()
+        if (pinComponent.isLocked) {
+            pendingPairingUri = trimmed
+            return
+        }
+        DAppManager.pair(trimmed, onSuccess, onError)
+    }
+
+    /** Pairs with the URI held by [pairOrDefer] while locked, if any. Call after unlocking. */
+    fun flushPendingPairing() {
+        val uri = pendingPairingUri ?: return
+        pendingPairingUri = null
+        if (!DAppManager.isAvailable) return
+        DAppManager.pair(uri)
+    }
 
     fun addWcHandler(wcHandler: IWCHandler) {
         handlersMap[wcHandler.chainNamespace] = wcHandler

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/WCManager.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/WCManager.kt
@@ -1,6 +1,7 @@
 package io.horizontalsystems.walletkit.modules.walletconnect
 
 import android.net.Uri
+import android.util.Log
 import io.horizontalsystems.walletkit.IPinComponent
 import io.horizontalsystems.walletkit.core.IAccountManager
 import io.horizontalsystems.walletkit.entities.Account
@@ -11,7 +12,6 @@ import io.horizontalsystems.walletkit.modules.walletconnect.session.ValidationEr
 import io.horizontalsystems.dapp.core.DAppManager
 import io.horizontalsystems.dapp.core.HSDAppNamespaceSession
 import io.horizontalsystems.dapp.core.HSDAppRequest
-import timber.log.Timber
 
 class WCManager(
     private val accountManager: IAccountManager,
@@ -62,10 +62,10 @@ class WCManager(
         try {
             DAppManager.pair(
                 uri = uri,
-                onError = { Timber.e(it, "Deferred WalletConnect pairing failed") }
+                onError = { Log.e("WCManager", "Deferred WalletConnect pairing failed", it) }
             )
         } catch (e: Exception) {
-            Timber.e(e, "Deferred WalletConnect pairing failed")
+            Log.e("WCManager", "Deferred WalletConnect pairing failed", e)
         }
     }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/WCManager.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/WCManager.kt
@@ -11,6 +11,7 @@ import io.horizontalsystems.walletkit.modules.walletconnect.session.ValidationEr
 import io.horizontalsystems.dapp.core.DAppManager
 import io.horizontalsystems.dapp.core.HSDAppNamespaceSession
 import io.horizontalsystems.dapp.core.HSDAppRequest
+import timber.log.Timber
 
 class WCManager(
     private val accountManager: IAccountManager,
@@ -53,7 +54,19 @@ class WCManager(
         val uri = pendingPairingUri ?: return
         pendingPairingUri = null
         if (!DAppManager.isAvailable) return
-        DAppManager.pair(uri)
+
+        // Pairing reports asynchronously through the WC delegate (which surfaces errors as an
+        // HSDAppEvent.Error hud), but an unusable SDK throws straight away. This runs from a
+        // LaunchedEffect on the main dispatcher, where an escaping exception would take the
+        // process down and skip the pending-event replay that follows it — so it stops here.
+        try {
+            DAppManager.pair(
+                uri = uri,
+                onError = { Timber.e(it, "Deferred WalletConnect pairing failed") }
+            )
+        } catch (e: Exception) {
+            Timber.e(e, "Deferred WalletConnect pairing failed")
+        }
     }
 
     fun addWcHandler(wcHandler: IWCHandler) {


### PR DESCRIPTION
Defers WalletConnect pairing and deeplink handling until the app is unlocked, and stops the QR scanner from staying active across a lock.

## Changes

- `WCManager.pairOrDefer()` holds a `wc:` URI while the app is locked; `flushPendingPairing()` pairs it after unlock. Hooked into the existing `LaunchedEffect(isLocked)` in `Nav3`, next to `reEmitPendingWcEventIfNeeded()`, so the flow is deferred rather than dropped.
- `Nav3.handleWalletConnectDeepLink()` and `BalanceViewModel.connectWC()` route through it.
- `QRScannerActivity` closes itself when the app locks and returns a cancelled result in that window.
- `MainScreen`'s deeplink effect is gated on `isLocked` and keyed on it, leaving the intent unconsumed so it replays after unlock. That path also drives TonConnect links, referral registration, prefilled send flows and the cold-start WalletConnect list.

No `authorizedAction` / PIN prompt is added to any WalletConnect confirm or approve button — that behaviour is unchanged.

## Notes

- Behaviour change: a `wc:` link or QR arriving while locked starts pairing after unlock, so the connect sheet appears ~1s later in that case. A pending URI is dropped if the process dies before unlock; pairing URIs are short-lived, so that is the safe failure direction.
- Verified with `:walletkit:compileDebugKotlin` and `:app:compileBaseDebugKotlin`.

Part of #9452.
