### PR TITLE
Name WalletConnect requests by what confirming does

### DIFF
--- a/translation_snapshot.json
+++ b/translation_snapshot.json
@@ -1568,6 +1568,8 @@
     "WalletConnect_SendTransactionRequest_ButtonSend": "Send",
     "WalletConnect_SendTransactionRequest_Title": "Send Transaction",
     "WalletConnect_SignMessageRequest_Title": "Sign Request",
+    "WalletConnect_SignTransactionRequest_Description": "%s will receive the signed transaction and can broadcast it at any time.",
+    "WalletConnect_SignTransactionRequest_Title": "Sign Transaction",
     "WalletConnect_Status": "Status",
     "WalletConnect_Status_Connecting": "Connecting…",
     "WalletConnect_Status_Offline": "Offline",

--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/signtransaction/WCSignEthereumTransactionRequestScreen.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/signtransaction/WCSignEthereumTransactionRequestScreen.kt
@@ -239,7 +239,7 @@ fun WCSignEthereumTransactionRequestScreen(
     }
 
     ConfirmTransactionScreen(
-        title = stringResource(id = R.string.WalletConnect_SignMessageRequest_Title),
+        title = stringResource(id = R.string.WalletConnect_SignTransactionRequest_Title),
         onClickBack = navigation::removeLastOrNull,
         onClickFeeSettings = null,
         buttonsSlot = {

--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/signtransaction/WCSignEthereumTransactionRequestScreen.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/signtransaction/WCSignEthereumTransactionRequestScreen.kt
@@ -127,7 +127,10 @@ fun WCSignEthereumTransactionRequestScreen(
             }
             VSpacer(16.dp)
             headline1_leah(
-                text = stringResource(R.string.WalletConnect_TokenAllowance),
+                // eth_signTransaction carries whatever the dApp put in it, so the screen can't
+                // claim it is an allowance. It names the request instead and leaves the contents
+                // to the decoded rows below.
+                text = stringResource(R.string.WalletConnect_SignTransactionRequest_Title),
                 textAlign = TextAlign.Center,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
@@ -147,7 +150,12 @@ fun WCSignEthereumTransactionRequestScreen(
             VerificationAlert(sessionRequestUI.verification, reportUnverified = false)
 
             TextBlock(
-                text = stringResource(R.string.WalletConnect_DappWillBeAbleToMoveToken, sessionRequestUI.peerUI.peerName),
+                // The signature goes back to the dApp rather than to the network: nothing is
+                // broadcast here, and the dApp decides when — or whether — it ever is.
+                text = stringResource(
+                    R.string.WalletConnect_SignTransactionRequest_Description,
+                    sessionRequestUI.peerUI.peerName
+                ),
             )
             VSpacer(16.dp)
             Column(
@@ -204,7 +212,7 @@ fun WCSignEthereumTransactionRequestScreen(
                     }
                 )
                 HSButton(
-                    title = stringResource(R.string.Button_Approve),
+                    title = stringResource(R.string.Button_Sign),
                     variant = ButtonVariant.Primary,
                     modifier = Modifier.weight(1f),
                     enabled = !signAction.inProgress,

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/WcRequestScreen.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/WcRequestScreen.kt
@@ -112,7 +112,9 @@ fun WcRequestScreen(
             }
             VSpacer(16.dp)
             headline1_leah(
-                text = stringResource(R.string.WalletConnect_SignMessageRequest_Title),
+                // The action names itself: stellar_signAndSubmitXDR broadcasts as well as signs,
+                // and calling that a sign request understates what confirming does.
+                text = uiState.title.getString(),
                 textAlign = TextAlign.Center,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
@@ -161,7 +163,7 @@ fun WcRequestScreen(
                     onClick = viewModel::reject
                 )
                 HSButton(
-                    title = stringResource(R.string.Button_Confirm),
+                    title = uiState.approveButtonTitle.getString(),
                     variant = ButtonVariant.Primary,
                     modifier = Modifier.weight(1f),
                     enabled = uiState.runnable,

--- a/walletkit/src/main/res/values-de/strings.xml
+++ b/walletkit/src/main/res/values-de/strings.xml
@@ -1839,4 +1839,6 @@
     <string name="Transactions_Migrate_ToIronwood">zu Ironwood</string>
     <string name="Zcash_Migration_PubliclyVisible_Title">Öffentlich sichtbarer Betrag</string>
     <string name="Zcash_Migration_PubliclyVisible_Description">Das Verschieben von Gedern zwischen Pools erfordert, dass der migrierte Betrag öffentlich sichtbar auf der Blockchain ist. Absender, Empfänger und Ihre Adressen bleiben privat.</string>
+    <string name="WalletConnect_SignTransactionRequest_Title">Transaktion signieren</string>
+    <string name="WalletConnect_SignTransactionRequest_Description">%s erhält die signierte Transaktion und kann sie jederzeit übertragen.</string>
 </resources>

--- a/walletkit/src/main/res/values-es/strings.xml
+++ b/walletkit/src/main/res/values-es/strings.xml
@@ -1830,4 +1830,6 @@
     <string name="Transactions_Migrate_ToIronwood">a Ironwood</string>
     <string name="Zcash_Migration_PubliclyVisible_Title">Cantidad visible públicamente</string>
     <string name="Zcash_Migration_PubliclyVisible_Description">Mover fondos entre pools requiere que la cantidad migrada sea visible públicamente en la cadena de bloques. El remitente, destinatario y sus direcciones permanecen privados.</string>
+    <string name="WalletConnect_SignTransactionRequest_Title">Firmar Transacción</string>
+    <string name="WalletConnect_SignTransactionRequest_Description">%s recibirá la transacción firmada y podrá transmitirla en cualquier momento.</string>
 </resources>

--- a/walletkit/src/main/res/values-fa/strings.xml
+++ b/walletkit/src/main/res/values-fa/strings.xml
@@ -763,4 +763,6 @@
     <string name="Transactions_Migrate_ToIronwood">به Ironwood</string>
     <string name="Zcash_Migration_PubliclyVisible_Title">مبلغ عمومی قابل مشاهده</string>
     <string name="Zcash_Migration_PubliclyVisible_Description">انتقال صندوق‌ها بین استخرها نیاز دارد که مبلغ منتقل‌شده بر روی بلاکچین عمومی قابل مشاهده باشد. فرستنده، گیرنده و آدرس‌های شما خصوصی باقی می‌مانند.</string>
+    <string name="WalletConnect_SignTransactionRequest_Title">امضای تراکنش</string>
+    <string name="WalletConnect_SignTransactionRequest_Description">%s تراکنش امضا شده را دریافت می کند و می تواند آن را در هر زمانی پخش کند.</string>
 </resources>

--- a/walletkit/src/main/res/values-fr/strings.xml
+++ b/walletkit/src/main/res/values-fr/strings.xml
@@ -1832,4 +1832,6 @@
     <string name="Transactions_Migrate_ToIronwood">vers Ironwood</string>
     <string name="Zcash_Migration_PubliclyVisible_Title">Montant visibles publiquement</string>
     <string name="Zcash_Migration_PubliclyVisible_Description">Le déplacement de fonds entre les pools nécessite que le montant migré soit visible publiquement sur la blockchain. L\'expéditeur, le destinataire et vos adresses restent privés.</string>
+    <string name="WalletConnect_SignTransactionRequest_Title">Signer la Transaction</string>
+    <string name="WalletConnect_SignTransactionRequest_Description">%s recevra la transaction signée et pourra la diffuser à tout moment.</string>
 </resources>

--- a/walletkit/src/main/res/values-ko/strings.xml
+++ b/walletkit/src/main/res/values-ko/strings.xml
@@ -1831,4 +1831,6 @@
     <string name="Transactions_Migrate_ToIronwood">Ironwood로</string>
     <string name="Zcash_Migration_PubliclyVisible_Title">공개적으로 표시되는 금액</string>
     <string name="Zcash_Migration_PubliclyVisible_Description">풀 간 자금 이동을 위해서는 마이그레이션된 금액이 블록체인에 공개적으로 표시되어야 합니다. 발신자, 수신자 및 주소는 비공개 상태로 유지됩니다.</string>
+    <string name="WalletConnect_SignTransactionRequest_Title">트랜잭션 서명</string>
+    <string name="WalletConnect_SignTransactionRequest_Description">%s가 서명된 트랜잭션을 받고 언제든지 브로드캐스트할 수 있습니다.</string>
 </resources>

--- a/walletkit/src/main/res/values-pt-rBR/strings.xml
+++ b/walletkit/src/main/res/values-pt-rBR/strings.xml
@@ -1835,4 +1835,6 @@
     <string name="Transactions_Migrate_ToIronwood">para Ironwood</string>
     <string name="Zcash_Migration_PubliclyVisible_Title">Quantidade visível publicamente</string>
     <string name="Zcash_Migration_PubliclyVisible_Description">Mover fundos entre pools requer que o valor migrado seja visível publicamente na blockchain. O remetente, destinatário e seus endereços permanecem privados.</string>
+    <string name="WalletConnect_SignTransactionRequest_Title">Assinar Transação</string>
+    <string name="WalletConnect_SignTransactionRequest_Description">%s receberá a transação assinada e poderá transmiti-la a qualquer momento.</string>
 </resources>

--- a/walletkit/src/main/res/values-ru/strings.xml
+++ b/walletkit/src/main/res/values-ru/strings.xml
@@ -1837,4 +1837,6 @@
     <string name="Transactions_Migrate_ToIronwood">на Ironwood</string>
     <string name="Zcash_Migration_PubliclyVisible_Title">Публично видимое количество</string>
     <string name="Zcash_Migration_PubliclyVisible_Description">Перемещение средств между пулами требует, чтобы перенесённое количество было открыто видно в блокчейне. Отправитель, получатель и ваши адреса остаются приватными.</string>
+    <string name="WalletConnect_SignTransactionRequest_Title">Подписать транзакцию</string>
+    <string name="WalletConnect_SignTransactionRequest_Description">%s получит подписанную транзакцию и может транслировать её в любое время.</string>
 </resources>

--- a/walletkit/src/main/res/values-tr/strings.xml
+++ b/walletkit/src/main/res/values-tr/strings.xml
@@ -1831,4 +1831,6 @@
     <string name="Transactions_Migrate_ToIronwood">Ironwood\'a</string>
     <string name="Zcash_Migration_PubliclyVisible_Title">Herkese açık görünür tutar</string>
     <string name="Zcash_Migration_PubliclyVisible_Description">Havuzlar arasında para transferi, geçirilen tutarın blokzincirde herkese açık şekilde görünür olmasını gerektirir. Gönderici, alıcı ve adresleriniz özel kalır.</string>
+    <string name="WalletConnect_SignTransactionRequest_Title">İşlemi İmzala</string>
+    <string name="WalletConnect_SignTransactionRequest_Description">%s imzalanan işlemi alacak ve bunu istediği zaman yayınlayabilir.</string>
 </resources>

--- a/walletkit/src/main/res/values-zh/strings.xml
+++ b/walletkit/src/main/res/values-zh/strings.xml
@@ -1830,4 +1830,6 @@
     <string name="Transactions_Migrate_ToIronwood">至 Ironwood</string>
     <string name="Zcash_Migration_PubliclyVisible_Title">公开可见金额</string>
     <string name="Zcash_Migration_PubliclyVisible_Description">在池之间转移资金需要迁移金额在区块链上公开可见。发送人、接收人和您的地址保持隐私。</string>
+    <string name="WalletConnect_SignTransactionRequest_Title">签署交易</string>
+    <string name="WalletConnect_SignTransactionRequest_Description">%s 将接收已签署的交易，可以随时广播。</string>
 </resources>

--- a/walletkit/src/main/res/values/strings.xml
+++ b/walletkit/src/main/res/values/strings.xml
@@ -715,6 +715,8 @@
     <string name="WalletConnect_TokenAllowance">Token Allowance</string>
     <string name="WalletConnect_ConfirmTransaction">Confirm Transaction</string>
     <string name="WalletConnect_DappWillBeAbleToMoveToken">%s will be able to move these tokens on your behalf.</string>
+    <string name="WalletConnect_SignTransactionRequest_Title">Sign Transaction</string>
+    <string name="WalletConnect_SignTransactionRequest_Description">%s will receive the signed transaction and can broadcast it at any time.</string>
     <string name="WalletConnect_RequestFailedDescription">Something went wrong and the request couldn’t be completed</string>
     <string name="WalletConnect_DisconnectWarning">Are you sure you want to remove this connection?</string>
     <string name="WalletConnect_DefenseMessage_Warning">You may connect to a fake site and lose funds. Turn me on to stay protected.</string>


### PR DESCRIPTION
Two WalletConnect confirmation screens described the request as something other than what confirming it does.

## Changes

**Generic request screen (`WcRequestScreen`)** — `WCRequestViewModel` already computes `title` and `approveButtonTitle` from the action, but both had zero readers; the screen hardcoded `WalletConnect_SignMessageRequest_Title` ("Sign Request") and `Button_Confirm`. It now reads them. `WCActionStellarSignAndSubmitXdr` — which signs **and** broadcasts — already returns "Send Transaction"/"Send", so it stops presenting itself as a message signature. `WCActionStellarSignXdr` (signs only, hands the XDR back) keeps "Sign Request"/"Sign". Any future `AbstractWCAction` gets correct labels for free.

**`eth_signTransaction` screen** — the headline was a fixed "Token Allowance" and the body a fixed "%s will be able to move these tokens on your behalf", regardless of the transaction. The method carries whatever the dApp put in it, so the screen now names the request and leaves the contents to the decoded rows below, and the body says what actually happens: the signature goes back to the dApp, which can broadcast it at any time. Its primary button also said "Approve" for an action that only signs — now "Sign".

Two new strings: `WalletConnect_SignTransactionRequest_Title`, `WalletConnect_SignTransactionRequest_Description`. `WalletConnect_TokenAllowance` and `WalletConnect_DappWillBeAbleToMoveToken` no longer have callers.

## Notes

- Labels only — nothing about what is signed, sent, or broadcast changes.
- Verified with `:app:compileBaseDebugKotlin`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer WalletConnect transaction-signing messaging.
  * Signing requests now display a “Sign” action instead of “Approve.”
  * Added a description explaining that signed transactions are returned to the dApp and may be broadcast later.
  * Updated request titles and labels to reflect the specific action being performed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Part of #9452.
