### PR TITLE
Fix Solana scam transaction filtering

### DIFF
--- a/app/src/main/java/io/horizontalsystems/bankwallet/core/providers/AppConfigProvider.kt
+++ b/app/src/main/java/io/horizontalsystems/bankwallet/core/providers/AppConfigProvider.kt
@@ -142,7 +142,7 @@ class AppConfigProvider(localStorage: ILocalStorage) : IAppConfigProvider {
         "ETH" to BigDecimal("0.0005"),
         "POL" to BigDecimal("1"),
         "BNB" to BigDecimal("0.0002"),
-        "SOL" to BigDecimal("0.000001"),
+        "SOL" to BigDecimal("0.0001"),
     )
 
     override val chainalysisBaseUrl = BuildConfig.CHAINALYSIS_BASE_URL

--- a/app/src/test/java/io/horizontalsystems/bankwallet/core/managers/PoisoningScorerBehaviorTest.kt
+++ b/app/src/test/java/io/horizontalsystems/bankwallet/core/managers/PoisoningScorerBehaviorTest.kt
@@ -1,0 +1,295 @@
+package io.horizontalsystems.bankwallet.core.managers
+
+import io.horizontalsystems.marketkit.models.Blockchain
+import io.horizontalsystems.marketkit.models.BlockchainType
+import io.horizontalsystems.marketkit.models.Coin
+import io.horizontalsystems.marketkit.models.Token
+import io.horizontalsystems.marketkit.models.TokenType
+import io.horizontalsystems.walletkit.core.managers.PoisoningScorer
+import io.horizontalsystems.walletkit.entities.TransactionValue
+import io.horizontalsystems.walletkit.entities.nft.NftUid
+import io.horizontalsystems.walletkit.entities.transactionrecords.evm.TransferEvent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.math.BigDecimal
+import java.math.BigInteger
+
+/**
+ * Behavioral / end-to-end coverage of transaction spam (address-poisoning) filtering.
+ *
+ * Unlike PoisoningScorerTest (which mostly pins constants and the isMimicAddress helper), this
+ * suite drives the real classification through the scorer's public API — calculateValueScore and
+ * calculateCorrelationScore — and composes the two phases exactly as SpamManager.isSpam does, so a
+ * regression in the actual decision is caught here.
+ *
+ * Production dust limits (AppConfigProvider.spamCoinValueLimits): SOL 0.0001, USDT 1.
+ * Derived bands per coin: micro-dust < limit/10 (+7), dust < limit (+3), low < limit*5 (+2).
+ */
+class PoisoningScorerBehaviorTest {
+
+    private val scorer = PoisoningScorer()
+
+    private val limits = mapOf(
+        "SOL" to BigDecimal("0.0001"),
+        "USDT" to BigDecimal("1"),
+    )
+
+    // Real on-chain poisoning of watch address 3VHM…LH7Q (see investigation):
+    private val realPayer = "6pRr7fQbrfpYUXZERLmxoKCaqXrz3ix6LQJGHVxSibvF"  // sent 100 SOL
+    private val mimic = "6pRrcG2PQrFfUL4dmGQFfFoD6bUnBNFGQ6AyQS2wibvF"      // dust, mimics realPayer
+    private val unrelated = "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
+
+    // ---- helpers -----------------------------------------------------------------------------
+
+    private fun coin(code: String, amount: String, decimals: Int = 9): TransactionValue.CoinValue {
+        val token = Token(
+            coin = Coin(uid = code.lowercase(), name = code, code = code),
+            blockchain = Blockchain(BlockchainType.Solana, "Solana", null),
+            type = TokenType.Native,
+            decimals = decimals
+        )
+        return TransactionValue.CoinValue(token, BigDecimal(amount))
+    }
+
+    private fun valueScore(value: TransactionValue, address: String? = mimic): Int =
+        scorer.calculateValueScore(listOf(TransferEvent(address, value)), limits).score
+
+    /** Mirrors SpamManager.isSpam's composition of the two scoring phases. */
+    private fun isSpam(
+        value: TransactionValue,
+        senderAddress: String = mimic,
+        incomingTimestamp: Long = 1_000L,
+        incomingBlockHeight: Int? = null,
+        context: List<PoisoningScorer.OutgoingTxInfo> = emptyList()
+    ): Boolean {
+        val events = listOf(TransferEvent(senderAddress, value))
+        val valueResult = scorer.calculateValueScore(events, limits)
+        if (valueResult.score >= PoisoningScorer.SPAM_THRESHOLD) return true
+        if (valueResult.score == 0) return false
+        val correlation = scorer.calculateCorrelationScore(
+            events, incomingTimestamp, incomingBlockHeight, context
+        )
+        return valueResult.score + correlation.points >= PoisoningScorer.SPAM_THRESHOLD
+    }
+
+    // ==================== Value scoring: auto-spam classes ====================
+
+    @Test
+    fun `unknown token (RawValue) is auto-spam`() {
+        assertEquals(PoisoningScorer.POINTS_AUTO_SPAM, valueScore(TransactionValue.RawValue(BigInteger.TEN)))
+        assertTrue(isSpam(TransactionValue.RawValue(BigInteger.TEN)))
+    }
+
+    @Test
+    fun `unrecognized token metadata (TokenValue) is auto-spam`() {
+        val v = TransactionValue.TokenValue("Free USDT", "USDT", 6, BigDecimal("1000"))
+        assertEquals(PoisoningScorer.POINTS_AUTO_SPAM, valueScore(v))
+        assertTrue(isSpam(v))
+    }
+
+    @Test
+    fun `zero-value native coin transfer is auto-spam`() {
+        val v = coin("SOL", "0")
+        assertEquals(PoisoningScorer.POINTS_AUTO_SPAM, valueScore(v))
+        assertTrue(isSpam(v))
+    }
+
+    // ==================== Value scoring: SOL dust bands (limit 0.0001) ====================
+
+    @Test
+    fun `micro-dust SOL below limit over ten is auto-spam by value alone`() {
+        // 0.000005 < 0.00001 (limit/10)
+        assertEquals(PoisoningScorer.POINTS_MICRO_DUST, valueScore(coin("SOL", "0.000005")))
+        assertTrue(isSpam(coin("SOL", "0.000005"), context = emptyList()))
+    }
+
+    @Test
+    fun `dust SOL below limit scores gray-zone three`() {
+        // 0.00001 <= 0.00005 < 0.0001
+        assertEquals(PoisoningScorer.POINTS_DUST_BELOW_LIMIT, valueScore(coin("SOL", "0.00005")))
+    }
+
+    @Test
+    fun `low-value SOL below five times limit scores two`() {
+        // 0.0001 <= 0.0003 < 0.0005
+        assertEquals(PoisoningScorer.POINTS_DUST_BELOW_5X_LIMIT, valueScore(coin("SOL", "0.0003")))
+    }
+
+    @Test
+    fun `normal SOL amount scores zero`() {
+        assertEquals(0, valueScore(coin("SOL", "0.01")))
+        assertEquals(0, valueScore(coin("SOL", "100")))
+    }
+
+    @Test
+    fun `SOL dust band boundaries`() {
+        assertEquals(PoisoningScorer.POINTS_DUST_BELOW_LIMIT, valueScore(coin("SOL", "0.00001"))) // == limit/10
+        assertEquals(PoisoningScorer.POINTS_DUST_BELOW_5X_LIMIT, valueScore(coin("SOL", "0.0001"))) // == limit
+        assertEquals(0, valueScore(coin("SOL", "0.0005"))) // == limit*5
+    }
+
+    @Test
+    fun `dust SOL alone is not spam without correlation context`() {
+        // The exact watch-only gap: dust scores 3, no outgoing/incoming context -> stays below 7.
+        assertFalse(isSpam(coin("SOL", "0.00005"), context = emptyList()))
+    }
+
+    // ==================== Value scoring: token not in limits map ====================
+
+    @Test
+    fun `known token absent from limits map gets no dust score`() {
+        // BONK is a real (known) SPL token but not in spamCoinValueLimits -> dust scoring skipped.
+        // Documents the current limitation: tiny known-token airdrops rely on correlation only.
+        assertEquals(0, valueScore(coin("BONK", "0.00000001", decimals = 5)))
+        assertFalse(isSpam(coin("BONK", "0.00000001", decimals = 5), context = emptyList()))
+    }
+
+    @Test
+    fun `USDT dust below limit scores gray-zone three`() {
+        assertEquals(PoisoningScorer.POINTS_DUST_BELOW_LIMIT, valueScore(coin("USDT", "0.5", decimals = 6)))
+    }
+
+    // ==================== Value scoring: NFTs ====================
+
+    @Test
+    fun `zero-value NFT scores three`() {
+        val v = TransactionValue.NftValue(NftUid.Solana("mintAddr"), BigDecimal.ZERO, "Scam", "SCAM")
+        assertEquals(PoisoningScorer.POINTS_ZERO_NFT, valueScore(v))
+    }
+
+    @Test
+    fun `non-zero NFT scores zero`() {
+        val v = TransactionValue.NftValue(NftUid.Solana("mintAddr"), BigDecimal.ONE, "Real", "REAL")
+        assertEquals(0, valueScore(v))
+    }
+
+    // ==================== Value scoring: aggregation ====================
+
+    @Test
+    fun `value score takes the max across multiple events`() {
+        val events = listOf(
+            TransferEvent(unrelated, coin("SOL", "100")),            // 0
+            TransferEvent(mimic, TransactionValue.RawValue(BigInteger.ONE)) // 7
+        )
+        assertEquals(PoisoningScorer.POINTS_AUTO_SPAM, scorer.calculateValueScore(events, limits).score)
+    }
+
+    @Test
+    fun `event with null address contributes nothing`() {
+        val events = listOf(TransferEvent(null, TransactionValue.RawValue(BigInteger.ONE)))
+        assertEquals(0, scorer.calculateValueScore(events, limits).score)
+    }
+
+    @Test
+    fun `empty events score zero`() {
+        assertEquals(0, scorer.calculateValueScore(emptyList(), limits).score)
+    }
+
+    // ==================== Correlation scoring ====================
+
+    private fun context(addr: String, ts: Long = 900L, block: Int? = null) =
+        listOf(PoisoningScorer.OutgoingTxInfo(addr, ts, block))
+
+    private fun correlation(
+        sender: String,
+        incomingTs: Long = 1_000L,
+        incomingBlock: Int? = null,
+        ctx: List<PoisoningScorer.OutgoingTxInfo>
+    ) = scorer.calculateCorrelationScore(
+        listOf(TransferEvent(sender, TransactionValue.RawValue(BigInteger.ONE))),
+        incomingTs, incomingBlock, ctx
+    ).points
+
+    @Test
+    fun `prefix and suffix match of a counterparty scores eight`() {
+        // realPayer as counterparty; mimic shares first-3 and last-3. Far-apart timestamps so no time bonus.
+        val points = correlation(mimic, incomingTs = 10_000_000L, ctx = context(realPayer, ts = 1L))
+        assertEquals(PoisoningScorer.POINTS_ADDRESS_PREFIX_MATCH + PoisoningScorer.POINTS_ADDRESS_SUFFIX_MATCH, points)
+    }
+
+    @Test
+    fun `time correlation within twenty minutes scores three`() {
+        // Unrelated address (no prefix/suffix match), within 20 minutes.
+        val points = correlation(unrelated, incomingTs = 1_000L, ctx = context(realPayer, ts = 900L))
+        assertEquals(PoisoningScorer.POINTS_TIME_WITHIN_20_MINUTES, points)
+    }
+
+    @Test
+    fun `block correlation within five blocks scores four and suppresses time`() {
+        // Same block window AND same time window, but the two are mutually exclusive: block wins.
+        val points = correlation(
+            unrelated, incomingTs = 1_000L, incomingBlock = 100,
+            ctx = context(realPayer, ts = 900L, block = 103)
+        )
+        assertEquals(PoisoningScorer.POINTS_TIME_WITHIN_5_BLOCKS, points)
+    }
+
+    @Test
+    fun `no correlation when context is empty`() {
+        assertEquals(0, correlation(mimic, ctx = emptyList()))
+    }
+
+    @Test
+    fun `identical address is not treated as a mimic`() {
+        // Address equal to a counterparty: prefix/suffix helper rejects equal addresses; only time may apply.
+        val points = correlation(realPayer, incomingTs = 10_000_000L, ctx = context(realPayer, ts = 1L))
+        assertEquals(0, points)
+    }
+
+    @Test
+    fun `unrelated dust far in time yields no correlation`() {
+        val points = correlation(unrelated, incomingTs = 10_000_000L, ctx = context(realPayer, ts = 1L))
+        assertEquals(0, points)
+    }
+
+    // ==================== End-to-end: the real poisoning scenario ====================
+
+    @Test
+    fun `dust mimic of a counterparty is spam when context is present`() {
+        // 100 SOL received from realPayer, then 0.00005 SOL dust from the look-alike, seconds later.
+        // dust(3) + prefix(4) + suffix(4) + time(3) = 14 >= 7.
+        val caught = isSpam(
+            value = coin("SOL", "0.00005"),
+            senderAddress = mimic,
+            incomingTimestamp = 1_000L,
+            context = context(realPayer, ts = 985L)
+        )
+        assertTrue(caught)
+    }
+
+    @Test
+    fun `same dust mimic is missed without any counterparty context`() {
+        // Regression guard for the watch-only / outgoing-only gap that originally hid this scam.
+        val caught = isSpam(
+            value = coin("SOL", "0.00005"),
+            senderAddress = mimic,
+            context = emptyList()
+        )
+        assertFalse(caught)
+    }
+
+    @Test
+    fun `low-value transfer that merely correlates in time is not spam`() {
+        // low-value(2) + time(3) = 5 < 7. Time proximity alone must not over-flag near-normal amounts.
+        val caught = isSpam(
+            value = coin("SOL", "0.0003"),
+            senderAddress = unrelated,
+            incomingTimestamp = 1_000L,
+            context = context(realPayer, ts = 950L)
+        )
+        assertFalse(caught)
+    }
+
+    @Test
+    fun `normal-value transfer never reaches correlation and is not spam`() {
+        // A mimic address that sends a NORMAL amount scores 0 in phase 1 and is never correlated.
+        val caught = isSpam(
+            value = coin("SOL", "5"),
+            senderAddress = mimic,
+            context = context(realPayer, ts = 985L)
+        )
+        assertFalse(caught)
+    }
+}

--- a/app/src/test/java/io/horizontalsystems/bankwallet/core/managers/PoisoningScorerTest.kt
+++ b/app/src/test/java/io/horizontalsystems/bankwallet/core/managers/PoisoningScorerTest.kt
@@ -1,10 +1,13 @@
 package io.horizontalsystems.bankwallet.core.managers
 
 import io.horizontalsystems.walletkit.core.managers.PoisoningScorer
+import io.horizontalsystems.walletkit.entities.TransactionValue
+import io.horizontalsystems.walletkit.entities.transactionrecords.evm.TransferEvent
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.math.BigInteger
 
 /**
  * Tests for PoisoningScorer - Address Poisoning Detection.
@@ -266,5 +269,60 @@ class PoisoningScorerTest {
 
         // But single factor can trigger suspicious
         assertTrue(PoisoningScorer.POINTS_ADDRESS_PREFIX_MATCH >= PoisoningScorer.SUSPICIOUS_THRESHOLD)
+    }
+
+    // ==================== Solana Address-Poisoning Regression ====================
+    //
+    // Regression coverage for a real on-chain poisoning of watch address
+    // 3VHMKeyoKzJDAaUXibFWuyyqFaNuNCJjKDS675z9LH7Q, which the filter missed. The wallet received
+    // 100 SOL from 6pRr7f…SibvF, then seconds later received 0.00001 SOL dust from 6pRrcG…wibvF —
+    // an address that mimics the *sender of the incoming payment* (prefix "6pR", suffix "bvF"),
+    // NOT the user's own address.
+    //
+    // Two things had to be true to catch it, both now fixed:
+    //  1. SolanaTransactionsAdapter must supply correlation context at all (it supplied none).
+    //  2. That context must include INCOMING counterparties, not just addresses the user sent to —
+    //     the mimicked address here only ever appeared as an incoming sender, and the wallet is
+    //     receive-only (no outgoing history).
+    // The scorer itself is direction-agnostic; these tests pin the scoring outcome, and
+    // SolanaTransactionEventExtractor.extractCounterpartyInfo feeds it the incoming sender.
+
+    private val realSender = "6pRr7fQbrfpYUXZERLmxoKCaqXrz3ix6LQJGHVxSibvF"   // sent 100 SOL
+    private val dustMimic = "6pRrcG2PQrFfUL4dmGQFfFoD6bUnBNFGQ6AyQS2wibvF"     // sent 0.00001 SOL dust
+
+    @Test
+    fun `solana dust mimic yields no correlation without counterparty context`() {
+        // Old broken behavior: empty context (no outgoing history for a receive-only wallet).
+        val events = listOf(TransferEvent(dustMimic, TransactionValue.RawValue(BigInteger.ONE)))
+
+        val result = scorer.calculateCorrelationScore(
+            events = events,
+            incomingTimestamp = 1_000L,
+            incomingBlockHeight = null,
+            recentOutgoingTxs = emptyList()
+        )
+
+        assertEquals(0, result.points)
+    }
+
+    @Test
+    fun `solana dust mimic of incoming sender reaches spam threshold`() {
+        // Fixed behavior: the incoming payer is now part of the correlation context.
+        val events = listOf(TransferEvent(dustMimic, TransactionValue.RawValue(BigInteger.ONE)))
+
+        val result = scorer.calculateCorrelationScore(
+            events = events,
+            incomingTimestamp = 1_000L,
+            incomingBlockHeight = null,
+            recentOutgoingTxs = listOf(
+                PoisoningScorer.OutgoingTxInfo(realSender, timestamp = 900L, blockHeight = null)
+            )
+        )
+
+        // prefix(4) + suffix(4) + time(3) well over threshold
+        assertTrue(
+            "mimic of incoming sender should reach spam threshold, was ${result.points}",
+            result.points >= PoisoningScorer.SPAM_THRESHOLD
+        )
     }
 }

--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/core/adapters/EvmTransactionsAdapter.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/core/adapters/EvmTransactionsAdapter.kt
@@ -41,7 +41,7 @@ class EvmTransactionsAdapter(
         val userAddress = evmKitWrapper.evmKit.receiveAddress
         return getFullTransactionsBefore(transactionHash, limit)
             .sortedByDescending { it.transaction.timestamp }
-            .mapNotNull { spamContextExtractor.extractOutgoingInfo(it, userAddress) }
+            .mapNotNull { spamContextExtractor.extractCounterpartyInfo(it, userAddress) }
     }
 
 

--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/core/managers/EvmTransactionEventExtractor.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/core/managers/EvmTransactionEventExtractor.kt
@@ -24,28 +24,38 @@ import java.math.BigInteger
 class EvmTransactionEventExtractor {
 
     /**
-     * Extract outgoing transaction info from EVM FullTransaction.
+     * Extract counterparty context from an EVM FullTransaction for address-poisoning correlation.
+     *
+     * The counterparty is taken direction-agnostically: the recipient of a send OR the sender of a
+     * receive. Correlating against incoming senders (not just addresses the user sent to) is what
+     * catches the common poisoning that mimics whoever just paid the user, and it is the only
+     * context a watch/receive-only wallet has at all.
      */
-    fun extractOutgoingInfo(
+    fun extractCounterpartyInfo(
         fullTx: FullTransaction,
         userAddress: Address
     ): PoisoningScorer.OutgoingTxInfo? {
         val tx = fullTx.transaction
+        val blockHeight = tx.blockNumber?.toInt()
         return when (val decoration = fullTx.decoration) {
             is OutgoingDecoration -> {
-                PoisoningScorer.OutgoingTxInfo(decoration.to.eip55, tx.timestamp, tx.blockNumber?.toInt())
+                PoisoningScorer.OutgoingTxInfo(decoration.to.eip55, tx.timestamp, blockHeight)
             }
             is OutgoingEip20Decoration -> {
-                PoisoningScorer.OutgoingTxInfo(decoration.to.eip55, tx.timestamp, tx.blockNumber?.toInt())
+                PoisoningScorer.OutgoingTxInfo(decoration.to.eip55, tx.timestamp, blockHeight)
+            }
+            is IncomingDecoration -> {
+                PoisoningScorer.OutgoingTxInfo(decoration.from.eip55, tx.timestamp, blockHeight)
             }
             is UnknownTransactionDecoration -> {
-                if (tx.from == userAddress) {
-                    decoration.eventInstances
-                        .mapNotNull { it as? TransferEventInstance }
-                        .firstOrNull { it.from == userAddress }?.let { transfer ->
-                            PoisoningScorer.OutgoingTxInfo(transfer.to.eip55, tx.timestamp, tx.blockNumber?.toInt())
-                        }
-                } else null
+                val transfers = decoration.eventInstances.mapNotNull { it as? TransferEventInstance }
+                val sentLeg = transfers.firstOrNull { it.from == userAddress }
+                val receivedLeg = transfers.firstOrNull { it.to == userAddress }
+                when {
+                    sentLeg != null -> PoisoningScorer.OutgoingTxInfo(sentLeg.to.eip55, tx.timestamp, blockHeight)
+                    receivedLeg != null -> PoisoningScorer.OutgoingTxInfo(receivedLeg.from.eip55, tx.timestamp, blockHeight)
+                    else -> null
+                }
             }
             else -> null
         }

--- a/walletkit-chain-solana/src/main/java/io/horizontalsystems/walletkit/core/adapters/SolanaTransactionsAdapter.kt
+++ b/walletkit-chain-solana/src/main/java/io/horizontalsystems/walletkit/core/adapters/SolanaTransactionsAdapter.kt
@@ -3,7 +3,10 @@ package io.horizontalsystems.walletkit.core.adapters
 import io.horizontalsystems.walletkit.core.AdapterState
 import io.horizontalsystems.walletkit.core.App
 import io.horizontalsystems.walletkit.core.ITransactionsAdapter
+import io.horizontalsystems.walletkit.core.managers.ISpamOutgoingContextSource
+import io.horizontalsystems.walletkit.core.managers.PoisoningScorer
 import io.horizontalsystems.walletkit.core.managers.SolanaKitWrapper
+import io.horizontalsystems.walletkit.core.managers.SolanaTransactionEventExtractor
 import io.horizontalsystems.walletkit.entities.LastBlockInfo
 import io.horizontalsystems.walletkit.entities.transactionrecords.TransactionRecord
 import io.horizontalsystems.walletkit.modules.transactions.FilterTransactionType
@@ -19,9 +22,33 @@ import kotlinx.coroutines.rx2.asFlowable
 class SolanaTransactionsAdapter(
         solanaKitWrapper: SolanaKitWrapper,
         private val solanaTransactionConverter: SolanaTransactionConverter
-) : ITransactionsAdapter {
+) : ITransactionsAdapter, ISpamOutgoingContextSource {
 
     private val kit = solanaKitWrapper.solanaKit
+    private val spamContextExtractor = SolanaTransactionEventExtractor()
+
+    // Supplies the recent counterparties that SpamManager correlates incoming dust senders against
+    // for address-poisoning detection. Without this, Solana gray-zone transactions (dust, zero-value
+    // NFTs) could never accrue the prefix/suffix/time points needed to cross the spam threshold.
+    //
+    // We pull BOTH directions (incoming = null): Solana poisoning most often mimics the sender of an
+    // INCOMING payment, not an address the user sent to — and a watch/receive-only wallet has no
+    // outgoing history at all, so an outgoing-only context would always be empty. `transactionHash`
+    // is the UTF-8 encoding of the incoming tx's base58 signature (see SolanaTransactionConverter),
+    // and `getAllTransactions(fromHash = ...)` returns strictly older transactions — the correct
+    // context window. Solana carries no confirmed slot, so block correlation is unavailable; the
+    // extractor leaves blockHeight null.
+    override suspend fun getOutgoingContext(
+        transactionHash: ByteArray,
+        operationId: Long?,
+        limit: Int
+    ): List<PoisoningScorer.OutgoingTxInfo> {
+        val userAddress = kit.receiveAddress
+        val fromHash = String(transactionHash, Charsets.UTF_8)
+        return kit.getAllTransactions(incoming = null, fromHash = fromHash, limit = limit)
+            .sortedByDescending { it.transaction.timestamp }
+            .mapNotNull { spamContextExtractor.extractCounterpartyInfo(it, userAddress) }
+    }
 
     override val explorerTitle: String
         get() = "Solscan.io"

--- a/walletkit-chain-solana/src/main/java/io/horizontalsystems/walletkit/core/managers/SolanaTransactionEventExtractor.kt
+++ b/walletkit-chain-solana/src/main/java/io/horizontalsystems/walletkit/core/managers/SolanaTransactionEventExtractor.kt
@@ -1,0 +1,50 @@
+package io.horizontalsystems.walletkit.core.managers
+
+import io.horizontalsystems.solanakit.models.FullTransaction
+
+/**
+ * Extracts counterparty context from Solana transactions for address-poisoning correlation
+ * (see [PoisoningScorer] / [SpamManager]).
+ *
+ * Correlation must run against every address the user has legitimately transacted with — in
+ * BOTH directions. Real Solana poisoning routinely mimics the sender of an INCOMING payment
+ * (e.g. whoever just sent you a large amount of SOL) so that, when you later scroll your history
+ * and copy "the address that paid me", you copy the look-alike instead. An outgoing-only context
+ * can never catch that — and a watch/receive-only wallet has no outgoing history at all.
+ *
+ * The counterparty is therefore taken direction-agnostically: the sender (`transaction.from`) of a
+ * received transfer, or the recipient (`transaction.to`) of a sent one. Both are wallet-owner
+ * addresses in the Solana kit's model (native SOL and SPL alike), which is what the attacker
+ * vanity-generates and what prefix/suffix matching compares.
+ *
+ * The Solana kit stores no confirmed slot, so block correlation can never contribute for Solana;
+ * only timestamp and address are available (blockHeight left null).
+ */
+class SolanaTransactionEventExtractor {
+
+    /**
+     * Map any user transaction to the counterparty the scorer compares incoming senders against,
+     * regardless of direction. Returns null when there is no usable counterparty (missing address
+     * or a self-transfer).
+     */
+    fun extractCounterpartyInfo(
+        fullTransaction: FullTransaction,
+        userAddress: String
+    ): PoisoningScorer.OutgoingTxInfo? {
+        val tx = fullTransaction.transaction
+
+        val counterparty = when {
+            // Received: the counterparty is the sender.
+            tx.from != null && tx.from != userAddress -> tx.from
+            // Sent: the counterparty is the recipient.
+            tx.to != null && tx.to != userAddress -> tx.to
+            else -> null
+        }?.takeIf { it.isNotBlank() } ?: return null
+
+        return PoisoningScorer.OutgoingTxInfo(
+            recipientAddress = counterparty,
+            timestamp = tx.timestamp,
+            blockHeight = null
+        )
+    }
+}

--- a/walletkit-chain-solana/src/main/java/io/horizontalsystems/walletkit/core/managers/SolanaTransactionEventExtractor.kt
+++ b/walletkit-chain-solana/src/main/java/io/horizontalsystems/walletkit/core/managers/SolanaTransactionEventExtractor.kt
@@ -35,11 +35,11 @@ class SolanaTransactionEventExtractor {
 
         val counterparty = when {
             // Received: the counterparty is the sender.
-            tx.from != null && tx.from != userAddress -> tx.from
+            !tx.from.isNullOrBlank() && tx.from != userAddress -> tx.from
             // Sent: the counterparty is the recipient.
-            tx.to != null && tx.to != userAddress -> tx.to
+            !tx.to.isNullOrBlank() && tx.to != userAddress -> tx.to
             else -> null
-        }?.takeIf { it.isNotBlank() } ?: return null
+        } ?: return null
 
         return PoisoningScorer.OutgoingTxInfo(
             recipientAddress = counterparty,

--- a/walletkit-chain-stellar/src/main/java/io/horizontalsystems/walletkit/core/adapters/StellarTransactionsAdapter.kt
+++ b/walletkit-chain-stellar/src/main/java/io/horizontalsystems/walletkit/core/adapters/StellarTransactionsAdapter.kt
@@ -125,6 +125,6 @@ class StellarTransactionsAdapter(
         val selfAddress = stellarKit.receiveAddress
         return stellarKit.operationsBefore(TagQuery(null, null, null), fromId = operationId, limit = limit)
             .sortedByDescending { it.timestamp }
-            .mapNotNull { spamContextExtractor.extractOutgoingInfo(it, selfAddress) }
+            .mapNotNull { spamContextExtractor.extractCounterpartyInfo(it, selfAddress) }
     }
 }

--- a/walletkit-chain-stellar/src/main/java/io/horizontalsystems/walletkit/core/managers/StellarTransactionEventExtractor.kt
+++ b/walletkit-chain-stellar/src/main/java/io/horizontalsystems/walletkit/core/managers/StellarTransactionEventExtractor.kt
@@ -16,23 +16,30 @@ import io.horizontalsystems.stellarkit.room.StellarAsset
 class StellarTransactionEventExtractor {
 
     /**
-     * Extract outgoing transaction info from Stellar Operation.
+     * Extract counterparty context from a Stellar Operation for address-poisoning correlation.
+     *
+     * The counterparty is taken direction-agnostically: the recipient of a send OR the sender of a
+     * receive. Correlating against incoming senders (not just addresses the user sent to) is what
+     * catches the common poisoning that mimics whoever just paid the user, and it is the only
+     * context a watch/receive-only wallet has at all.
      */
-    fun extractOutgoingInfo(
+    fun extractCounterpartyInfo(
         operation: Operation,
         selfAddress: String
     ): PoisoningScorer.OutgoingTxInfo? {
         // Check payment operations
         operation.payment?.let { payment ->
-            if (payment.from == selfAddress) {
-                return PoisoningScorer.OutgoingTxInfo(payment.to, operation.timestamp, null)
+            when (selfAddress) {
+                payment.from -> return PoisoningScorer.OutgoingTxInfo(payment.to, operation.timestamp, null)
+                payment.to -> return PoisoningScorer.OutgoingTxInfo(payment.from, operation.timestamp, null)
             }
         }
 
         // Check account creation operations
         operation.accountCreated?.let { accountCreated ->
-            if (accountCreated.funder == selfAddress) {
-                return PoisoningScorer.OutgoingTxInfo(accountCreated.account, operation.timestamp, null)
+            when (selfAddress) {
+                accountCreated.funder -> return PoisoningScorer.OutgoingTxInfo(accountCreated.account, operation.timestamp, null)
+                accountCreated.account -> return PoisoningScorer.OutgoingTxInfo(accountCreated.funder, operation.timestamp, null)
             }
         }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/address/AddressChecker.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/address/AddressChecker.kt
@@ -15,7 +15,7 @@ class PhishingAddressChecker(
     private val spamManager: SpamManager
 ) : AddressChecker {
 
-    private val supportedBlockchainTypes =  EvmBlockchainManager.blockchainTypes + listOf(BlockchainType.Tron, BlockchainType.Stellar)
+    private val supportedBlockchainTypes =  EvmBlockchainManager.blockchainTypes + listOf(BlockchainType.Tron, BlockchainType.Stellar, BlockchainType.Solana)
 
     override suspend fun isClear(address: Address, token: Token): Boolean {
         val spamTransaction = spamManager.findSpamByAddress(address.hex)

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/managers/SpamManager.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/managers/SpamManager.kt
@@ -172,7 +172,7 @@ class SpamManager(
                     val userAddress = adapter.tronKitWrapper.tronKit.address
                     adapter.getTronFullTransactionsBefore(transactionHash, OUTGOING_CONTEXT_SIZE)
                         .sortedByDescending { it.transaction.timestamp }
-                        .mapNotNull { tronExtractor.extractOutgoingInfo(it, userAddress) }
+                        .mapNotNull { tronExtractor.extractCounterpartyInfo(it, userAddress) }
                 }
                 is ISpamOutgoingContextSource -> {
                     adapter.getOutgoingContext(transactionHash, operationId, OUTGOING_CONTEXT_SIZE)

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/managers/TronTransactionEventExtractor.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/managers/TronTransactionEventExtractor.kt
@@ -17,9 +17,14 @@ import io.horizontalsystems.tronkit.models.TransferContract
 class TronTransactionEventExtractor {
 
     /**
-     * Extract outgoing transaction info from Tron FullTransaction.
+     * Extract counterparty context from a Tron FullTransaction for address-poisoning correlation.
+     *
+     * The counterparty is taken direction-agnostically: the recipient of a send OR the sender of a
+     * receive. Correlating against incoming senders (not just addresses the user sent to) is what
+     * catches the common poisoning that mimics whoever just paid the user, and it is the only
+     * context a watch/receive-only wallet has at all.
      */
-    fun extractOutgoingInfo(
+    fun extractCounterpartyInfo(
         fullTx: FullTransaction,
         userAddress: Address
     ): PoisoningScorer.OutgoingTxInfo? {
@@ -30,21 +35,24 @@ class TronTransactionEventExtractor {
         return when (val decoration = fullTx.decoration) {
             is NativeTransactionDecoration -> {
                 val contract = decoration.contract as? TransferContract ?: return null
-                if (contract.ownerAddress == userAddress) {
-                    PoisoningScorer.OutgoingTxInfo(contract.toAddress.base58, timestamp, blockHeight)
-                } else null
+                when (userAddress) {
+                    contract.ownerAddress -> PoisoningScorer.OutgoingTxInfo(contract.toAddress.base58, timestamp, blockHeight)
+                    contract.toAddress -> PoisoningScorer.OutgoingTxInfo(contract.ownerAddress.base58, timestamp, blockHeight)
+                    else -> null
+                }
             }
             is OutgoingTrc20Decoration -> {
                 PoisoningScorer.OutgoingTxInfo(decoration.to.base58, timestamp, blockHeight)
             }
             is UnknownTransactionDecoration -> {
-                if (decoration.fromAddress == userAddress) {
-                    decoration.events
-                        .mapNotNull { it as? Trc20TransferEvent }
-                        .firstOrNull { it.from == userAddress }?.let { transfer ->
-                            PoisoningScorer.OutgoingTxInfo(transfer.to.base58, timestamp, blockHeight)
-                        }
-                } else null
+                val transfers = decoration.events.mapNotNull { it as? Trc20TransferEvent }
+                val sentLeg = transfers.firstOrNull { it.from == userAddress }
+                val receivedLeg = transfers.firstOrNull { it.to == userAddress }
+                when {
+                    sentLeg != null -> PoisoningScorer.OutgoingTxInfo(sentLeg.to.base58, timestamp, blockHeight)
+                    receivedLeg != null -> PoisoningScorer.OutgoingTxInfo(receivedLeg.from.base58, timestamp, blockHeight)
+                    else -> null
+                }
             }
             else -> null
         }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/watchaddress/WatchAddressModule.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/watchaddress/WatchAddressModule.kt
@@ -19,6 +19,7 @@ object WatchAddressModule {
         add(BlockchainType.ECash)
         add(BlockchainType.Stellar)
         add(BlockchainType.Monero)
+        add(BlockchainType.Solana)
     }
 
     class Factory : ViewModelProvider.Factory {


### PR DESCRIPTION
#9487

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Solana support for watched addresses and phishing-address checks.
  - Improved transaction analysis across Solana, EVM, Tron, and Stellar networks by identifying counterparties in both incoming and outgoing transfers.
- **Bug Fixes**
  - Improved detection of address-poisoning and spam transactions, including Solana dust transfers and mimic-address activity.
  - Adjusted the Solana spam-value threshold to better classify unwanted small-value transactions.
  - Improved handling of transaction context when assessing suspicious activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->