### PR TITLE
Guard the send confirmation button against double taps

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -264,6 +264,8 @@ dependencies {
 
     // UI Tests
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+    // Supplies the ComponentActivity that Compose UI tests are hosted in
+    debugImplementation(libs.androidx.compose.ui.test.manifest)
     androidTestImplementation(libs.test.runner)
     androidTestImplementation(libs.espresso.core)
 

--- a/app/src/androidTest/java/io/horizontalsystems/bankwallet/SendButtonDoubleTapTest.kt
+++ b/app/src/androidTest/java/io/horizontalsystems/bankwallet/SendButtonDoubleTapTest.kt
@@ -1,0 +1,87 @@
+package io.horizontalsystems.bankwallet
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.horizontalsystems.walletkit.modules.send.SendButton
+import io.horizontalsystems.walletkit.modules.send.SendResult
+import io.horizontalsystems.walletkit.ui.compose.ComposeAppTheme
+import io.horizontalsystems.walletkit.ui.compose.TranslatableString
+import io.horizontalsystems.walletkit.core.HSCaution
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * The send button is disabled through [SendResult], which the view models assign on an IO
+ * dispatcher after the click handler returns. These cover the window in between, where the button
+ * is still live and a second tap would start a second transaction.
+ */
+@RunWith(AndroidJUnit4::class)
+class SendButtonDoubleTapTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private val sendTitle = "Send"
+
+    @Test
+    fun twoTapsBeforeRecompositionSendOnce() {
+        var sends = 0
+
+        composeRule.setContent {
+            ComposeAppTheme {
+                SendButton(
+                    modifier = Modifier,
+                    sendResult = null,
+                    onClickSend = { sends++ },
+                    enabled = true
+                )
+            }
+        }
+
+        // Hold the clock so neither tap can be rescued by a recomposition disabling the button —
+        // this is the same frame, which is exactly the case the view model state cannot cover.
+        composeRule.mainClock.autoAdvance = false
+        composeRule.onNodeWithText(sendTitle).performClick()
+        composeRule.onNodeWithText(sendTitle).performClick()
+        composeRule.mainClock.autoAdvance = true
+        composeRule.waitForIdle()
+
+        assertEquals(1, sends)
+    }
+
+    @Test
+    fun failedSendCanBeRetried() {
+        var sends = 0
+        var result by mutableStateOf<SendResult?>(null)
+
+        composeRule.setContent {
+            ComposeAppTheme {
+                SendButton(
+                    modifier = Modifier,
+                    sendResult = result,
+                    onClickSend = { sends++ },
+                    enabled = true
+                )
+            }
+        }
+
+        composeRule.onNodeWithText(sendTitle).performClick()
+        composeRule.waitForIdle()
+
+        result = SendResult.Failed(HSCaution(TranslatableString.PlainString("nope")))
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(sendTitle).performClick()
+        composeRule.waitForIdle()
+
+        assertEquals(2, sends)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -181,6 +181,7 @@ androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", versi
 androidx-compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata", version.ref = "compose" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "composeMaterial3" }
 androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
+androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose" }
 
 # Google Material
 google-material = { module = "com.google.android.material:material", version.ref = "material" }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/SendConfirmationScreen.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/SendConfirmationScreen.kt
@@ -301,6 +301,19 @@ fun SendButton(
     onClickSend: () -> Unit,
     enabled: Boolean
 ) {
+    // The Sending/Sent branches below disable the button, but they are driven by sendResult, which
+    // the view models assign on an IO dispatcher after onClickSend() returns. Between the tap and
+    // that state arriving in composition the button is still live, so a same-frame double tap
+    // launches two sends — two valid transactions on account-based chains. Latch synchronously
+    // here, in the same frame as the tap, and let a failure hand the button back.
+    var sent by remember { mutableStateOf(false) }
+
+    LaunchedEffect(sendResult) {
+        if (sendResult is SendResult.Failed) {
+            sent = false
+        }
+    }
+
     when (sendResult) {
         SendResult.Sending -> {
             ButtonPrimaryYellow(
@@ -324,8 +337,13 @@ fun SendButton(
             ButtonPrimaryYellow(
                 modifier = modifier,
                 title = stringResource(R.string.Send_Confirmation_Send_Button),
-                onClick = onClickSend,
-                enabled = enabled
+                onClick = {
+                    if (!sent) {
+                        sent = true
+                        onClickSend()
+                    }
+                },
+                enabled = enabled && !sent
             )
         }
     }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/tron/SendTronConfirmationScreen.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/tron/SendTronConfirmationScreen.kt
@@ -206,6 +206,17 @@ private fun SendButton(
     onClickSend: () -> Unit,
     enabled: Boolean
 ) {
+    // Same single-flight guard as the shared send confirmation button: sendResult only disables
+    // this button once the view model has assigned it on an IO dispatcher, which leaves the tap
+    // live for a frame or two.
+    var sent by remember { mutableStateOf(false) }
+
+    LaunchedEffect(sendResult) {
+        if (sendResult is SendResult.Failed) {
+            sent = false
+        }
+    }
+
     when (sendResult) {
         SendResult.Sending -> {
             ButtonPrimaryYellow(
@@ -229,8 +240,13 @@ private fun SendButton(
             ButtonPrimaryYellow(
                 modifier = modifier,
                 title = stringResource(R.string.Send_Confirmation_Send_Button),
-                onClick = onClickSend,
-                enabled = enabled
+                onClick = {
+                    if (!sent) {
+                        sent = true
+                        onClickSend()
+                    }
+                },
+                enabled = enabled && !sent
             )
         }
     }


### PR DESCRIPTION
The send confirmation button disables itself through `sendResult`, but the view models assign that on an IO dispatcher *after* `onClickSend()` returns:

```
onClickSend() → viewModelScope.launch { send() } → withContext(Dispatchers.IO) { sendResult = Sending }
```

Between the tap and that state reaching composition the button is still live, so a same-frame double tap starts two sends. On account-based chains both transactions are valid.

The EVM path already handles this with `rememberAsyncAction`, and `CLAUDE.md` documents the pattern under "Preventing Double Clicks in Compose" — but the shared confirmation screen never got it. It covers Bitcoin, Monero, Solana, Stellar, Thorchain, Ton, Zano, Zcash and the Zcash shield flow, plus Tron's own copy of the button.

## Changes

- Latch synchronously in the same frame as the tap, so the second tap never reaches `onClickSend()`. The existing `Sending`/`Sent` branches are unchanged — they still drive the title and the disabled state once the view model catches up.
- Release the latch when `sendResult` becomes `Failed`, so a genuinely failed send stays retryable.
- Same guard applied to the private `SendButton` in `SendTronConfirmationScreen`.
- View models are untouched: `onClickSend()` stays `() -> Unit`, so no signature churn across nine chains.

## Tests

`SendButtonDoubleTapTest` (instrumented, `app/src/androidTest`):

| Test | Purpose |
|---|---|
| `twoTapsBeforeRecompositionSendOnce` | holds the test clock so no recomposition can intervene, taps twice, asserts one send |
| `failedSendCanBeRetried` | a failed send re-enables the button, so the latch can't strand the user |

Both pass with the guard. **Reverting the guard fails the first with `expected:<1> but was:<2>`** — the defect reproduced deterministically, without needing a funded account (which is what blocked empirical verification in the original report).

This is the first instrumented test in the module, so it needs `androidx.compose.ui:ui-test-manifest` to supply the `ComponentActivity` that hosts the composable under test.

Run with:

```bash
ANDROID_SERIAL=<device> ./gradlew :app:connectedBaseDebugAndroidTest
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate transactions when the send button is tapped repeatedly.
  * Applied duplicate-tap protection to standard and Tron send confirmations.
  * Re-enabled sending after a failed transaction so users can retry.

* **Tests**
  * Added coverage for rapid double-taps and retry behavior after failed sends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Part of #9452.
