### PR TITLE
Guard the swap Proceed button against double taps

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapPage.kt
@@ -1,6 +1,7 @@
 package io.horizontalsystems.walletkit.modules.multiswap
 
 import android.annotation.SuppressLint
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -112,6 +113,7 @@ import io.horizontalsystems.walletkit.uiv3.components.controls.HSIconButton
 import io.horizontalsystems.marketkit.models.BlockchainType
 import io.horizontalsystems.marketkit.models.Token
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.Serializable
@@ -226,23 +228,32 @@ fun SwapScreen(
         viewModel.amlCheckEventFlow.collect { event ->
             proceeding = false
 
-            when (event) {
-                AmlCheckEvent.Proceed -> {
-                    if (viewModel.uiState.needToAcceptTerms) {
-                        forResultSwapTerms()
-                    } else {
-                        navigateToSwapConfirm()
+            // A throw here would end the collect and take the whole flow down with it: no later
+            // AML result would be handled, and since the latch is only released here, the next tap
+            // would disable Proceed for good. Keep the collector alive instead.
+            try {
+                when (event) {
+                    AmlCheckEvent.Proceed -> {
+                        if (viewModel.uiState.needToAcceptTerms) {
+                            forResultSwapTerms()
+                        } else {
+                            navigateToSwapConfirm()
+                        }
+                    }
+                    AmlCheckEvent.RiskDetected -> {
+                        showAmlRiskSheet = true
+                    }
+                    is AmlCheckEvent.Error -> {
+                        showAmlErrorSheet = true
+                    }
+                    AmlCheckEvent.RiskUnknown -> {
+                        showAmlUnknownSheet = true
                     }
                 }
-                AmlCheckEvent.RiskDetected -> {
-                    showAmlRiskSheet = true
-                }
-                is AmlCheckEvent.Error -> {
-                    showAmlErrorSheet = true
-                }
-                AmlCheckEvent.RiskUnknown -> {
-                    showAmlUnknownSheet = true
-                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                Log.e("SwapPage", "Handling AML check event failed", e)
             }
         }
     }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapPage.kt
@@ -207,8 +207,25 @@ fun SwapScreen(
     ) {
         if (it.accepted) navigateToSwapConfirm()
     }
+    // startProceed() is asynchronous on both of its paths — the no-precheck path only emits on the
+    // view model scope and sets no state at all — so the Proceed button stays live after the first
+    // tap. A second tap emits a second Proceed and pushes a second confirmation page. Latch in the
+    // same frame as the tap and hand the button back on whatever outcome comes back.
+    var proceeding by remember { mutableStateOf(false) }
+
+    val startProceed = {
+        if (!proceeding) {
+            // Latch on whether the flow actually started: startProceed() bails out when there is
+            // no quote yet, and that path emits no event, so latching unconditionally would leave
+            // the button disabled with nothing to release it.
+            proceeding = viewModel.startProceed()
+        }
+    }
+
     LaunchedEffect(Unit) {
         viewModel.amlCheckEventFlow.collect { event ->
+            proceeding = false
+
             when (event) {
                 AmlCheckEvent.Proceed -> {
                     if (viewModel.uiState.needToAcceptTerms) {
@@ -258,7 +275,7 @@ fun SwapScreen(
             onDismiss = { showAmlErrorSheet = false },
             onRetry = {
                 showAmlErrorSheet = false
-                viewModel.startProceed()
+                startProceed()
             },
         )
     }
@@ -307,7 +324,8 @@ fun SwapScreen(
 
             stat(page = StatPage.Swap, event = StatEvent.Open(StatPage.SwapProvider))
         },
-        onClickNext = viewModel::startProceed,
+        onClickNext = startProceed,
+        proceedEnabled = !proceeding,
         onActionStarted = {
             viewModel.onActionStarted(uiState.quote)
         },
@@ -334,6 +352,7 @@ private fun SwapScreenInner(
     onEnterAmountPercentage: (Int) -> Unit,
     onClickProvider: () -> Unit,
     onClickNext: () -> Unit,
+    proceedEnabled: Boolean,
     onActionStarted: () -> Unit,
     onActionCompleted: () -> Unit,
     navigation: HSNavigation,
@@ -577,6 +596,7 @@ private fun SwapScreenInner(
                                     .padding(horizontal = 16.dp)
                                     .fillMaxWidth(),
                                 title = stringResource(R.string.Swap_Proceed),
+                                enabled = proceedEnabled,
                                 onClick = onClickNext
                             )
                         }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapViewModel.kt
@@ -402,14 +402,19 @@ class SwapViewModel(
     fun onActionStarted(quote: SwapProviderQuote?) = quoteService.onActionStarted(quote)
     fun onActionCompleted() = quoteService.onActionCompleted()
 
-    fun startProceed() {
-        val provider = quoteState.quote?.provider ?: return
-        val tokenIn = quoteState.tokenIn ?: return
-        val amountIn = quoteState.amountIn ?: return
+    /**
+     * Returns whether the proceed flow actually started. The caller latches its button on the
+     * result, so a call that bails out early — no quote yet, no amount — must not leave the button
+     * disabled with no event ever coming back to release it.
+     */
+    fun startProceed(): Boolean {
+        val provider = quoteState.quote?.provider ?: return false
+        val tokenIn = quoteState.tokenIn ?: return false
+        val amountIn = quoteState.amountIn ?: return false
 
         if (!provider.amlPrecheck) {
             viewModelScope.launch { amlCheckEventFlow.emit(AmlCheckEvent.Proceed) }
-            return
+            return true
         }
 
         viewModelScope.launch(Dispatchers.IO) {
@@ -434,6 +439,8 @@ class SwapViewModel(
                 emitState()
             }
         }
+
+        return true
     }
 
     fun getCurrentQuote() = quoteState.quote


### PR DESCRIPTION
Same defect class as #9521, one step earlier in the flow.

`SwapPage.kt` renders the `SwapStep.Proceed` button with `onClick = onClickNext` and **no `enabled` gate at all** — unlike the `ActionRequired` branch directly above it, which correctly uses `enabled = !action.inProgress`. And `startProceed()` is asynchronous on both paths:

- no AML precheck → `viewModelScope.launch { emit(Proceed) }`, setting no state whatsoever;
- AML precheck → `amlChecking = true` assigned inside `launch(Dispatchers.IO)`.

So the button stays live after the first tap. A second tap emits a second `Proceed`, and both reach the collector, which calls `navigateToSwapConfirm()` twice — two confirmation pages stacked. `amlCheckEventFlow` is declared with `extraBufferCapacity = 1`, so the second event can also arrive later rather than immediately.

The final Swap/Approve buttons are properly guarded, so this doesn't silently double-swap — it needs the user to confirm twice, on what looks like the same screen appearing again.

## Changes

- Latch `proceeding` in the same frame as the tap, so the second tap never reaches the view model; release it in the AML event collector on every outcome (Proceed, RiskDetected, RiskUnknown, Error).
- Route the AML error sheet's Retry through the same latch.
- Gate the button with `enabled = proceedEnabled`.
- **`startProceed()` now returns whether it actually started.** It bails out early when there is no quote, token or amount yet, and that path emits no event — so latching unconditionally would have left the button permanently disabled with nothing to release it. That would have been a worse failure than the bug, and the Proceed step *is* reachable with a null quote.

## Testing

Compile-verified only. Unlike #9521 I could not put this under test: the button lives in a private composable driven by a real `SwapViewModel`, and reaching the Proceed step needs a live quote, so neither a Compose test nor the emulator gets there without a funded account.

The latch pattern itself is the one proven under test in #9521 (`SendButtonDoubleTapTest`, which fails with `expected:<1> but was:<2>` when the guard is reverted).

Worth considering as a follow-up: extracting a shared `rememberSingleFlight()` used by both this button and `SendButton`, which would make this call site testable and remove the duplication. Left out here to keep the change contained.

## Not changed

`amlCheckEventFlow`'s `extraBufferCapacity = 1` is untouched. With the latch in place a duplicate event can no longer originate from a double tap, and changing the buffer alters emission semantics for every producer — worth its own look rather than riding along here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate submissions when proceeding with a swap.
  * Disabled the Proceed button while a request is in progress.
  * Re-enabled proceeding after AML updates and supported guarded AML retries.
  * Improved AML event handling so later events continue processing after recoverable errors.
  * Added validation to prevent proceeding when required swap details are missing.
  * Correctly reports whether the proceed flow started, including when AML checks are disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Part of #9452.
