### PR TITLE
Recover instead of crashing on a restored send confirmation

### DIFF
--- a/app/src/androidTest/java/io/horizontalsystems/bankwallet/ConfirmationDataRecoveryTest.kt
+++ b/app/src/androidTest/java/io/horizontalsystems/bankwallet/ConfirmationDataRecoveryTest.kt
@@ -1,0 +1,84 @@
+package io.horizontalsystems.bankwallet
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation3.runtime.NavBackStack
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
+import io.horizontalsystems.walletkit.modules.nav3.HSPage
+import io.horizontalsystems.walletkit.modules.roi.RoiSelectCoinsPage
+import io.horizontalsystems.walletkit.modules.send.SendConfirmationData
+import io.horizontalsystems.walletkit.modules.send.rememberConfirmationData
+import io.horizontalsystems.walletkit.modules.usersubscription.BuySubscriptionHavHostPage
+import io.horizontalsystems.marketkit.models.Blockchain
+import io.horizontalsystems.marketkit.models.BlockchainType
+import io.horizontalsystems.marketkit.models.Coin
+import io.horizontalsystems.marketkit.models.Token
+import io.horizontalsystems.marketkit.models.TokenType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Send view models build their confirmation data from state that is filled in asynchronously and
+ * never persisted, while the back stack itself is persisted — so after process death the user is
+ * restored onto a confirmation screen whose view model came back empty. These cover what the screen
+ * does with that.
+ */
+@RunWith(AndroidJUnit4::class)
+class ConfirmationDataRecoveryTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private fun navigation(): Pair<HSNavigation, NavBackStack<HSPage>> {
+        val backStack = NavBackStack<HSPage>(RoiSelectCoinsPage, BuySubscriptionHavHostPage)
+        return HSNavigation(backStack) to backStack
+    }
+
+    @Test
+    fun missingDataPopsInsteadOfCrashing() {
+        val (navigation, backStack) = navigation()
+        var seen: SendConfirmationData? = null
+
+        composeRule.setContent {
+            seen = rememberConfirmationData(navigation) { null }
+        }
+        composeRule.waitForIdle()
+
+        assertNull(seen)
+        // The confirmation entry is gone, so the user lands back on the send form.
+        assertEquals(1, backStack.size)
+    }
+
+    @Test
+    fun availableDataIsKept() {
+        val (navigation, backStack) = navigation()
+        val coin = Coin("uid", "Name", "CODE")
+        val token = Token(
+            coin = coin,
+            blockchain = Blockchain(BlockchainType.Bitcoin, "Bitcoin", null),
+            type = TokenType.Native,
+            decimals = 8,
+        )
+        val data = SendConfirmationData(
+            amount = java.math.BigDecimal.ONE,
+            fee = null,
+            address = null,
+            contact = null,
+            token = token,
+            feeCoin = coin,
+            memo = null
+        )
+        var seen: SendConfirmationData? = null
+
+        composeRule.setContent {
+            seen = rememberConfirmationData(navigation) { data }
+        }
+        composeRule.waitForIdle()
+
+        assertEquals(data, seen)
+        assertEquals(2, backStack.size)
+    }
+}

--- a/walletkit-chain-bitcoin/src/main/java/io/horizontalsystems/walletkit/modules/send/bitcoin/SendBitcoinConfirmationScreen.kt
+++ b/walletkit-chain-bitcoin/src/main/java/io/horizontalsystems/walletkit/modules/send/bitcoin/SendBitcoinConfirmationScreen.kt
@@ -1,17 +1,13 @@
 package io.horizontalsystems.walletkit.modules.send.bitcoin
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.res.stringResource
-import androidx.lifecycle.compose.LifecycleResumeEffect
 import io.horizontalsystems.walletkit.R
 import io.horizontalsystems.walletkit.core.stringResId
 import io.horizontalsystems.walletkit.modules.multiswap.QuoteInfoRow
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.nav3.HSPage
+import io.horizontalsystems.walletkit.modules.send.rememberConfirmationData
 import io.horizontalsystems.walletkit.modules.send.SendConfirmationScreen
 import io.horizontalsystems.walletkit.ui.compose.ComposeAppTheme
 import io.horizontalsystems.walletkit.uiv3.components.cell.hs
@@ -23,18 +19,8 @@ fun SendBitcoinConfirmationScreen(
     sendViewModel: SendBitcoinViewModel,
     sendEntryPointDestId: KClass<out HSPage>
 ) {
-    var confirmationData by remember { mutableStateOf(sendViewModel.getConfirmationData()) }
-    var refresh by remember { mutableStateOf(false) }
-
-    LifecycleResumeEffect(Unit) {
-        if (refresh) {
-            confirmationData = sendViewModel.getConfirmationData()
-        }
-
-        onPauseOrDispose {
-            refresh = true
-        }
-    }
+    val confirmationData = rememberConfirmationData(navigation) { sendViewModel.getConfirmationData() }
+        ?: return
 
     SendConfirmationScreen(
         navigation = navigation,

--- a/walletkit-chain-bitcoin/src/main/java/io/horizontalsystems/walletkit/modules/send/bitcoin/SendBitcoinViewModel.kt
+++ b/walletkit-chain-bitcoin/src/main/java/io/horizontalsystems/walletkit/modules/send/bitcoin/SendBitcoinViewModel.kt
@@ -247,15 +247,22 @@ class SendBitcoinViewModel(
         emitState()
     }
 
-    fun getConfirmationData(): SendConfirmationData {
-        val address = addressState.validAddress!!
+    /**
+     * Confirmation data for the current input, or null when it isn't available.
+     *
+     * The pieces are filled in asynchronously and none of them survive process death, so a
+     * confirmation screen restored from the saved back stack sees empty state. Reporting that as
+     * null lets the caller send the user back to the form instead of crashing on composition.
+     */
+    fun getConfirmationData(): SendConfirmationData? {
+        val address = addressState.validAddress ?: return null
         val contact = contactsRepo.getContactsFiltered(
             blockchainType,
             addressQuery = address.hex
         ).firstOrNull()
         return SendConfirmationData(
-            amount = amountState.amount!!,
-            fee = fee!!,
+            amount = amountState.amount ?: return null,
+            fee = fee ?: return null,
             address = address,
             contact = contact,
             token = wallet.token,

--- a/walletkit-chain-monero/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroConfirmationScreen.kt
+++ b/walletkit-chain-monero/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroConfirmationScreen.kt
@@ -1,13 +1,9 @@
 package io.horizontalsystems.walletkit.modules.send.monero
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.lifecycle.compose.LifecycleResumeEffect
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.nav3.HSPage
+import io.horizontalsystems.walletkit.modules.send.rememberConfirmationData
 import io.horizontalsystems.walletkit.modules.send.SendConfirmationScreen
 import kotlin.reflect.KClass
 
@@ -17,18 +13,8 @@ fun SendMoneroConfirmationScreen(
     sendViewModel: SendMoneroViewModel,
     sendEntryPointDestId: KClass<out HSPage>
 ) {
-    var confirmationData by remember { mutableStateOf(sendViewModel.getConfirmationData()) }
-    var refresh by remember { mutableStateOf(false) }
-
-    LifecycleResumeEffect(Unit) {
-        if (refresh) {
-            confirmationData = sendViewModel.getConfirmationData()
-        }
-
-        onPauseOrDispose {
-            refresh = true
-        }
-    }
+    val confirmationData = rememberConfirmationData(navigation) { sendViewModel.getConfirmationData() }
+        ?: return
 
     SendConfirmationScreen(
         navigation = navigation,

--- a/walletkit-chain-monero/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroViewModel.kt
+++ b/walletkit-chain-monero/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroViewModel.kt
@@ -234,15 +234,22 @@ class SendMoneroViewModel(
         emitState()
     }
 
-    fun getConfirmationData(): SendConfirmationData {
-        val address = addressState.address!!
+    /**
+     * Confirmation data for the current input, or null when it isn't available.
+     *
+     * The pieces are filled in asynchronously and none of them survive process death, so a
+     * confirmation screen restored from the saved back stack sees empty state. Reporting that as
+     * null lets the caller send the user back to the form instead of crashing on composition.
+     */
+    fun getConfirmationData(): SendConfirmationData? {
+        val address = addressState.address ?: return null
         val contact = contactsRepo.getContactsFiltered(
             blockchainType,
             addressQuery = address.hex
         ).firstOrNull()
         return SendConfirmationData(
-            amount = amountState.amount!!,
-            fee = feeState.fee!!,
+            amount = amountState.amount ?: return null,
+            fee = feeState.fee ?: return null,
             address = address,
             contact = contact,
             token = wallet.token,

--- a/walletkit-chain-solana/src/main/java/io/horizontalsystems/walletkit/modules/send/solana/SendSolanaConfirmationScreen.kt
+++ b/walletkit-chain-solana/src/main/java/io/horizontalsystems/walletkit/modules/send/solana/SendSolanaConfirmationScreen.kt
@@ -1,13 +1,9 @@
 package io.horizontalsystems.walletkit.modules.send.solana
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.lifecycle.compose.LifecycleResumeEffect
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.nav3.HSPage
+import io.horizontalsystems.walletkit.modules.send.rememberConfirmationData
 import io.horizontalsystems.walletkit.modules.send.SendConfirmationScreen
 import kotlin.reflect.KClass
 
@@ -17,18 +13,8 @@ fun SendSolanaConfirmationScreen(
     sendViewModel: SendSolanaViewModel,
     sendEntryPointDestId: KClass<out HSPage>
 ) {
-    var confirmationData by remember { mutableStateOf(sendViewModel.getConfirmationData()) }
-    var refresh by remember { mutableStateOf(false) }
-
-    LifecycleResumeEffect(Unit) {
-        if (refresh) {
-            confirmationData = sendViewModel.getConfirmationData()
-        }
-
-        onPauseOrDispose {
-            refresh = true
-        }
-    }
+    val confirmationData = rememberConfirmationData(navigation) { sendViewModel.getConfirmationData() }
+        ?: return
 
     SendConfirmationScreen(
         navigation = navigation,

--- a/walletkit-chain-solana/src/main/java/io/horizontalsystems/walletkit/modules/send/solana/SendSolanaViewModel.kt
+++ b/walletkit-chain-solana/src/main/java/io/horizontalsystems/walletkit/modules/send/solana/SendSolanaViewModel.kt
@@ -108,8 +108,15 @@ class SendSolanaViewModel(
         addressService.setAddress(address)
     }
 
-    fun getConfirmationData(): SendConfirmationData {
-        val address = addressState.address!!
+    /**
+     * Confirmation data for the current input, or null when it isn't available.
+     *
+     * The pieces are filled in asynchronously and none of them survive process death, so a
+     * confirmation screen restored from the saved back stack sees empty state. Reporting that as
+     * null lets the caller send the user back to the form instead of crashing on composition.
+     */
+    fun getConfirmationData(): SendConfirmationData? {
+        val address = addressState.address ?: return null
         val contact = contactsRepo.getContactsFiltered(
             blockchainType,
             addressQuery = address.hex

--- a/walletkit-chain-solana/src/main/java/io/horizontalsystems/walletkit/modules/send/solana/SendSolanaViewModel.kt
+++ b/walletkit-chain-solana/src/main/java/io/horizontalsystems/walletkit/modules/send/solana/SendSolanaViewModel.kt
@@ -122,7 +122,8 @@ class SendSolanaViewModel(
             addressQuery = address.hex
         ).firstOrNull()
         return SendConfirmationData(
-            amount = decimalAmount,
+            // not decimalAmount: its getter asserts, which would defeat the null contract here
+            amount = amountState.amount ?: return null,
             fee = SolanaKit.fee,
             address = address,
             contact = contact,

--- a/walletkit-chain-stellar/src/main/java/io/horizontalsystems/walletkit/modules/send/stellar/SendStellarConfirmationScreen.kt
+++ b/walletkit-chain-stellar/src/main/java/io/horizontalsystems/walletkit/modules/send/stellar/SendStellarConfirmationScreen.kt
@@ -1,13 +1,9 @@
 package io.horizontalsystems.walletkit.modules.send.stellar
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.lifecycle.compose.LifecycleResumeEffect
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.nav3.HSPage
+import io.horizontalsystems.walletkit.modules.send.rememberConfirmationData
 import io.horizontalsystems.walletkit.modules.send.SendConfirmationScreen
 import kotlin.reflect.KClass
 
@@ -17,18 +13,8 @@ fun SendStellarConfirmationScreen(
     sendViewModel: SendStellarViewModel,
     sendEntryPointDestId: KClass<out HSPage>
 ) {
-    var confirmationData by remember { mutableStateOf(sendViewModel.getConfirmationData()) }
-    var refresh by remember { mutableStateOf(false) }
-
-    LifecycleResumeEffect(Unit) {
-        if (refresh) {
-            confirmationData = sendViewModel.getConfirmationData()
-        }
-
-        onPauseOrDispose {
-            refresh = true
-        }
-    }
+    val confirmationData = rememberConfirmationData(navigation) { sendViewModel.getConfirmationData() }
+        ?: return
 
     SendConfirmationScreen(
         navigation = navigation,

--- a/walletkit-chain-stellar/src/main/java/io/horizontalsystems/walletkit/modules/send/stellar/SendStellarViewModel.kt
+++ b/walletkit-chain-stellar/src/main/java/io/horizontalsystems/walletkit/modules/send/stellar/SendStellarViewModel.kt
@@ -136,14 +136,21 @@ class SendStellarViewModel(
         emitState()
     }
 
-    fun getConfirmationData(): SendConfirmationData {
-        val address = addressState.address!!
+    /**
+     * Confirmation data for the current input, or null when it isn't available.
+     *
+     * The pieces are filled in asynchronously and none of them survive process death, so a
+     * confirmation screen restored from the saved back stack sees empty state. Reporting that as
+     * null lets the caller send the user back to the form instead of crashing on composition.
+     */
+    fun getConfirmationData(): SendConfirmationData? {
+        val address = addressState.address ?: return null
         val contact = contactsRepo.getContactsFiltered(
             blockchainType,
             addressQuery = address.hex
         ).firstOrNull()
         return SendConfirmationData(
-            amount = amountState.amount!!,
+            amount = amountState.amount ?: return null,
             fee = fee,
             address = address,
             contact = contact,

--- a/walletkit-chain-thorchain/src/main/java/io/horizontalsystems/walletkit/modules/send/thorchain/SendThorchainConfirmationScreen.kt
+++ b/walletkit-chain-thorchain/src/main/java/io/horizontalsystems/walletkit/modules/send/thorchain/SendThorchainConfirmationScreen.kt
@@ -1,13 +1,9 @@
 package io.horizontalsystems.walletkit.modules.send.thorchain
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.lifecycle.compose.LifecycleResumeEffect
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.nav3.HSPage
+import io.horizontalsystems.walletkit.modules.send.rememberConfirmationData
 import io.horizontalsystems.walletkit.modules.send.SendConfirmationScreen
 import kotlin.reflect.KClass
 
@@ -17,18 +13,8 @@ fun SendThorchainConfirmationScreen(
     sendViewModel: SendThorchainViewModel,
     sendEntryPointDestId: KClass<out HSPage>
 ) {
-    var confirmationData by remember { mutableStateOf(sendViewModel.getConfirmationData()) }
-    var refresh by remember { mutableStateOf(false) }
-
-    LifecycleResumeEffect(Unit) {
-        if (refresh) {
-            confirmationData = sendViewModel.getConfirmationData()
-        }
-
-        onPauseOrDispose {
-            refresh = true
-        }
-    }
+    val confirmationData = rememberConfirmationData(navigation) { sendViewModel.getConfirmationData() }
+        ?: return
 
     SendConfirmationScreen(
         navigation = navigation,

--- a/walletkit-chain-thorchain/src/main/java/io/horizontalsystems/walletkit/modules/send/thorchain/SendThorchainViewModel.kt
+++ b/walletkit-chain-thorchain/src/main/java/io/horizontalsystems/walletkit/modules/send/thorchain/SendThorchainViewModel.kt
@@ -122,14 +122,21 @@ class SendThorchainViewModel(
         emitState()
     }
 
-    fun getConfirmationData(): SendConfirmationData {
-        val address = addressState.address!!
+    /**
+     * Confirmation data for the current input, or null when it isn't available.
+     *
+     * The pieces are filled in asynchronously and none of them survive process death, so a
+     * confirmation screen restored from the saved back stack sees empty state. Reporting that as
+     * null lets the caller send the user back to the form instead of crashing on composition.
+     */
+    fun getConfirmationData(): SendConfirmationData? {
+        val address = addressState.address ?: return null
         val contact = contactsRepo.getContactsFiltered(
             blockchainType,
             addressQuery = address.hex
         ).firstOrNull()
         return SendConfirmationData(
-            amount = amountState.amount!!,
+            amount = amountState.amount ?: return null,
             fee = fee,
             address = address,
             contact = contact,

--- a/walletkit-chain-ton/src/main/java/io/horizontalsystems/walletkit/modules/send/ton/SendTonConfirmationScreen.kt
+++ b/walletkit-chain-ton/src/main/java/io/horizontalsystems/walletkit/modules/send/ton/SendTonConfirmationScreen.kt
@@ -1,13 +1,9 @@
 package io.horizontalsystems.walletkit.modules.send.ton
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.lifecycle.compose.LifecycleResumeEffect
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.nav3.HSPage
+import io.horizontalsystems.walletkit.modules.send.rememberConfirmationData
 import io.horizontalsystems.walletkit.modules.send.SendConfirmationScreen
 import kotlin.reflect.KClass
 
@@ -17,18 +13,8 @@ fun SendTonConfirmationScreen(
     sendViewModel: SendTonViewModel,
     sendEntryPointDestId: KClass<out HSPage>
 ) {
-    var confirmationData by remember { mutableStateOf(sendViewModel.getConfirmationData()) }
-    var refresh by remember { mutableStateOf(false) }
-
-    LifecycleResumeEffect(Unit) {
-        if (refresh) {
-            confirmationData = sendViewModel.getConfirmationData()
-        }
-
-        onPauseOrDispose {
-            refresh = true
-        }
-    }
+    val confirmationData = rememberConfirmationData(navigation) { sendViewModel.getConfirmationData() }
+        ?: return
 
     SendConfirmationScreen(
         navigation = navigation,

--- a/walletkit-chain-ton/src/main/java/io/horizontalsystems/walletkit/modules/send/ton/SendTonViewModel.kt
+++ b/walletkit-chain-ton/src/main/java/io/horizontalsystems/walletkit/modules/send/ton/SendTonViewModel.kt
@@ -108,15 +108,22 @@ class SendTonViewModel(
         amountService.setAmount(amount)
     }
 
-    fun getConfirmationData(): SendConfirmationData {
-        val address = addressState.address!!
+    /**
+     * Confirmation data for the current input, or null when it isn't available.
+     *
+     * The pieces are filled in asynchronously and none of them survive process death, so a
+     * confirmation screen restored from the saved back stack sees empty state. Reporting that as
+     * null lets the caller send the user back to the form instead of crashing on composition.
+     */
+    fun getConfirmationData(): SendConfirmationData? {
+        val address = addressState.address ?: return null
         val contact = contactsRepo.getContactsFiltered(
             blockchainType,
             addressQuery = address.hex
         ).firstOrNull()
         return SendConfirmationData(
-            amount = amountState.amount!!,
-            fee = feeState.fee!!,
+            amount = amountState.amount ?: return null,
+            fee = feeState.fee ?: return null,
             address = address,
             contact = contact,
             token = wallet.token,

--- a/walletkit-chain-zano/src/main/java/io/horizontalsystems/walletkit/modules/send/zano/SendZanoConfirmationScreen.kt
+++ b/walletkit-chain-zano/src/main/java/io/horizontalsystems/walletkit/modules/send/zano/SendZanoConfirmationScreen.kt
@@ -1,13 +1,9 @@
 package io.horizontalsystems.walletkit.modules.send.zano
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.lifecycle.compose.LifecycleResumeEffect
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.nav3.HSPage
+import io.horizontalsystems.walletkit.modules.send.rememberConfirmationData
 import io.horizontalsystems.walletkit.modules.send.SendConfirmationScreen
 import kotlin.reflect.KClass
 
@@ -17,18 +13,8 @@ fun SendZanoConfirmationScreen(
     sendViewModel: SendZanoViewModel,
     sendEntryPointDestId: KClass<out HSPage>
 ) {
-    var confirmationData by remember { mutableStateOf(sendViewModel.getConfirmationData()) }
-    var refresh by remember { mutableStateOf(false) }
-
-    LifecycleResumeEffect(Unit) {
-        if (refresh) {
-            confirmationData = sendViewModel.getConfirmationData()
-        }
-
-        onPauseOrDispose {
-            refresh = true
-        }
-    }
+    val confirmationData = rememberConfirmationData(navigation) { sendViewModel.getConfirmationData() }
+        ?: return
 
     SendConfirmationScreen(
         navigation = navigation,

--- a/walletkit-chain-zano/src/main/java/io/horizontalsystems/walletkit/modules/send/zano/SendZanoViewModel.kt
+++ b/walletkit-chain-zano/src/main/java/io/horizontalsystems/walletkit/modules/send/zano/SendZanoViewModel.kt
@@ -163,15 +163,22 @@ class SendZanoViewModel(
         emitState()
     }
 
-    fun getConfirmationData(): SendConfirmationData {
-        val address = addressState.address!!
+    /**
+     * Confirmation data for the current input, or null when it isn't available.
+     *
+     * The pieces are filled in asynchronously and none of them survive process death, so a
+     * confirmation screen restored from the saved back stack sees empty state. Reporting that as
+     * null lets the caller send the user back to the form instead of crashing on composition.
+     */
+    fun getConfirmationData(): SendConfirmationData? {
+        val address = addressState.address ?: return null
         val contact = contactsRepo.getContactsFiltered(
             blockchainType,
             addressQuery = address.hex
         ).firstOrNull()
         return SendConfirmationData(
-            amount = amountState.amount!!,
-            fee = feeState.fee!!,
+            amount = amountState.amount ?: return null,
+            fee = feeState.fee ?: return null,
             address = address,
             contact = contact,
             token = wallet.token,

--- a/walletkit-chain-zcash/src/main/java/io/horizontalsystems/walletkit/modules/send/zcash/SendZCashConfirmationScreen.kt
+++ b/walletkit-chain-zcash/src/main/java/io/horizontalsystems/walletkit/modules/send/zcash/SendZCashConfirmationScreen.kt
@@ -1,13 +1,9 @@
 package io.horizontalsystems.walletkit.modules.send.zcash
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.lifecycle.compose.LifecycleResumeEffect
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.nav3.HSPage
+import io.horizontalsystems.walletkit.modules.send.rememberConfirmationData
 import io.horizontalsystems.walletkit.modules.send.SendConfirmationScreen
 import kotlin.reflect.KClass
 
@@ -17,18 +13,8 @@ fun SendZCashConfirmationScreen(
     sendViewModel: SendZCashViewModel,
     sendEntryPointDestId: KClass<out HSPage>
 ) {
-    var confirmationData by remember { mutableStateOf(sendViewModel.getConfirmationData()) }
-    var refresh by remember { mutableStateOf(false) }
-
-    LifecycleResumeEffect(Unit) {
-        if (refresh) {
-            confirmationData = sendViewModel.getConfirmationData()
-        }
-
-        onPauseOrDispose {
-            refresh = true
-        }
-    }
+    val confirmationData = rememberConfirmationData(navigation) { sendViewModel.getConfirmationData() }
+        ?: return
 
     SendConfirmationScreen(
         navigation = navigation,

--- a/walletkit-chain-zcash/src/main/java/io/horizontalsystems/walletkit/modules/send/zcash/SendZCashViewModel.kt
+++ b/walletkit-chain-zcash/src/main/java/io/horizontalsystems/walletkit/modules/send/zcash/SendZCashViewModel.kt
@@ -147,14 +147,21 @@ class SendZCashViewModel(
         emitState()
     }
 
-    fun getConfirmationData(): SendConfirmationData {
-        val address = addressState.address!!
+    /**
+     * Confirmation data for the current input, or null when it isn't available.
+     *
+     * The pieces are filled in asynchronously and none of them survive process death, so a
+     * confirmation screen restored from the saved back stack sees empty state. Reporting that as
+     * null lets the caller send the user back to the form instead of crashing on composition.
+     */
+    fun getConfirmationData(): SendConfirmationData? {
+        val address = addressState.address ?: return null
         val contact = contactsRepo.getContactsFiltered(
             blockchainType,
             addressQuery = address.hex
         ).firstOrNull()
         return SendConfirmationData(
-            amount = amountState.amount!!,
+            amount = amountState.amount ?: return null,
             fee = feeState.fee,
             address = address,
             contact = contact,

--- a/walletkit-chain-zcash/src/main/java/io/horizontalsystems/walletkit/modules/send/zcash/shield/ShieldZcashScreen.kt
+++ b/walletkit-chain-zcash/src/main/java/io/horizontalsystems/walletkit/modules/send/zcash/shield/ShieldZcashScreen.kt
@@ -1,15 +1,11 @@
 package io.horizontalsystems.walletkit.modules.send.zcash.shield
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.res.stringResource
-import androidx.lifecycle.compose.LifecycleResumeEffect
 import io.horizontalsystems.walletkit.R
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.nav3.HSPage
+import io.horizontalsystems.walletkit.modules.send.rememberConfirmationData
 import io.horizontalsystems.walletkit.modules.send.SendConfirmationScreen
 import kotlin.reflect.KClass
 
@@ -19,18 +15,8 @@ fun ShieldZcashScreen(
     viewModel: ShieldZcashViewModel,
     sendEntryPointDestId: KClass<out HSPage>
 ) {
-    var confirmationData by remember { mutableStateOf(viewModel.getConfirmationData()) }
-    var refresh by remember { mutableStateOf(false) }
-
-    LifecycleResumeEffect(Unit) {
-        if (refresh) {
-            confirmationData = viewModel.getConfirmationData()
-        }
-
-        onPauseOrDispose {
-            refresh = true
-        }
-    }
+    val confirmationData = rememberConfirmationData(navigation) { viewModel.getConfirmationData() }
+        ?: return
 
     SendConfirmationScreen(
         navigation = navigation,

--- a/walletkit-chain-zcash/src/main/java/io/horizontalsystems/walletkit/modules/send/zcash/shield/ShieldZcashViewModel.kt
+++ b/walletkit-chain-zcash/src/main/java/io/horizontalsystems/walletkit/modules/send/zcash/shield/ShieldZcashViewModel.kt
@@ -52,8 +52,15 @@ class ShieldZcashViewModel(
         }
     }
 
-    fun getConfirmationData(): SendConfirmationData {
-        val unshielded = adapter.balanceData?.unshielded ?: throw IllegalStateException()
+    /**
+     * Confirmation data for the current input, or null when it isn't available.
+     *
+     * The pieces are filled in asynchronously and none of them survive process death, so a
+     * confirmation screen restored from the saved back stack sees empty state. Reporting that as
+     * null lets the caller send the user back to the form instead of crashing on composition.
+     */
+    fun getConfirmationData(): SendConfirmationData? {
+        val unshielded = adapter.balanceData?.unshielded ?: return null
 
         return SendConfirmationData(
             amount = unshielded,

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/RememberConfirmationData.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/RememberConfirmationData.kt
@@ -1,0 +1,46 @@
+package io.horizontalsystems.walletkit.modules.send
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.compose.LifecycleResumeEffect
+import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
+
+/**
+ * Holds the confirmation data for a send screen, refreshing it when the screen resumes.
+ *
+ * The view models build it from amount, address and fee state that is filled in asynchronously and
+ * is not persisted anywhere. The back stack is persisted, though, so after process death the user
+ * is returned to a confirmation screen whose view model has been recreated empty. Rather than
+ * asserting its way to a crash on composition, [provider] reports null and the screen is popped so
+ * the user lands back on the send form.
+ */
+@Composable
+fun rememberConfirmationData(
+    navigation: HSNavigation,
+    provider: () -> SendConfirmationData?
+): SendConfirmationData? {
+    var confirmationData by remember { mutableStateOf(provider()) }
+    var refresh by remember { mutableStateOf(false) }
+
+    LifecycleResumeEffect(Unit) {
+        if (refresh) {
+            confirmationData = provider()
+        }
+
+        onPauseOrDispose {
+            refresh = true
+        }
+    }
+
+    LaunchedEffect(confirmationData) {
+        if (confirmationData == null) {
+            navigation.removeLastOrNull()
+        }
+    }
+
+    return confirmationData
+}


### PR DESCRIPTION
Switching away from the send confirmation screen and coming back after Android has killed the process crashes the app.

## Why it happens

- The confirmation screens are real `@Serializable HSPage`s on the back stack, and `Nav3` persists the whole stack through `rememberSerializable(NavBackStackSerializer(…))`. So the user is restored **onto the confirmation page**, not the form that validated it — the Next-button gate never runs again.
- The view model is obtained via `viewModelForScreen<…>(SendPage::class)` and no view model in the codebase uses `SavedStateHandle`, so it comes back with empty amount, address and fee.
- `getConfirmationData()` asserted through all of them (`amount!!`, `address!!`, `fee!!`) and is called from `remember { mutableStateOf(...) }` — during **composition**. Every candidate rescue (the pop-to-root in `HandleNavigateToMain`, the lock overlay) is a `LaunchedEffect`, which runs after composition, so the throw wins.

Reproduces on any low-memory device, and every time with Developer Options → *"Don't keep activities"*. No funds at risk — it throws long before `send()` — but the prepared transaction is lost and it presents as a crash while sending.

## Changes

- `getConfirmationData()` returns `SendConfirmationData?`, reporting null where it used to assert.
- New shared `rememberConfirmationData(navigation) { … }` keeps the refresh-on-resume behaviour the screens already had and pops back to the send form when the data isn't there, so all nine screens share one recovery path instead of nine copies.
- `send()` keeps its assertions — those run behind a filled-in confirmation and a user tap.

**This can only change behaviour where the old code crashed.** `getConfirmationData()` returned non-null exactly when every assertion held, so flows that work today are byte-for-byte unchanged; the only difference is that the path which used to kill the process now returns the user to the form.

## Scope note

The report names four view models (Ton, Monero, Zano, Bitcoin). The same pattern was in **all nine** — Solana, Stellar, Thorchain, Zcash and Zcash-shield included — so all nine are fixed rather than leaving five to be rediscovered. `ShieldZcashViewModel` was throwing `IllegalStateException` for the same reason and is folded in.

## Tests

`ConfirmationDataRecoveryTest` (instrumented):

| Test | Purpose |
|---|---|
| `missingDataPopsInsteadOfCrashing` | null data returns null and pops the entry, rather than throwing |
| `availableDataIsKept` | data present is returned untouched and nothing is popped |

Both pass; **removing the pop fails the first with `expected:<1> but was:<2>`**, so the test detects the regression rather than merely passing. Full app compiles; all 4 instrumented tests in the module are green.

Not covered on device: reaching a real confirmation screen needs a funded account, which is what blocked empirical verification in the original report too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved send confirmation recovery after app restoration or process recreation across supported networks.
  * Prevented crashes when confirmation details are temporarily unavailable.
  * Automatically removes invalid confirmation screens from navigation instead of displaying incomplete data.
  * Preserved confirmation details when they remain available.

* **Tests**
  * Added coverage for missing and available confirmation data, including navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Part of #9452.
