### PR TITLE
Hide blockchain label for native RUNE and CACAO

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/MarketKitExtensions.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/MarketKitExtensions.kt
@@ -553,7 +553,7 @@ val TokenType.AddressType.bitcoinCashCoinType: BitcoinCashCoinType
     }
 
 private val noBadgeCoinCodes by lazy {
-    listOf("AVAX", "XLM", "DASH", "ZEC", "XMR", "XEC", "POL", "SOL", "XDAI", "FTM")
+    listOf("AVAX", "XLM", "DASH", "ZEC", "XMR", "XEC", "POL", "SOL", "XDAI", "FTM", "RUNE", "CACAO")
 }
 
 val Token.coinCodeWithNetwork: String


### PR DESCRIPTION
## Summary

THORChain's native token RUNE and MayaChain's native token CACAO were displaying blockchain labels (`THORChain` / `MayaChain`), unlike other native chain tokens (ETH, BTC, AVAX, SOL, etc.) which show no label.

This adds `RUNE` and `CACAO` to `noBadgeCoinCodes` in `MarketKitExtensions.kt` so that `Token.badge` returns `null` for these native tokens, matching the behavior of other native chain tokens.

THORChain/MayaChain *assets* (non-native tokens) still display their badges as before.

## Test plan

- Verify native RUNE shows no blockchain label in coin lists / balance / send screens
- Verify native CACAO shows no blockchain label
- Verify THORChain assets (e.g. synths) still show labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated coin badge display behavior so RUNE and CACAO no longer show badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->