### PR TITLE
Guard the Zcash migration button against double taps

### DIFF
--- a/app/src/androidTest/java/io/horizontalsystems/bankwallet/SendButtonDoubleTapTest.kt
+++ b/app/src/androidTest/java/io/horizontalsystems/bankwallet/SendButtonDoubleTapTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.horizontalsystems.walletkit.modules.send.SendButton
+import io.horizontalsystems.walletkit.modules.zcashmigration.MigrateButton
 import io.horizontalsystems.walletkit.modules.send.SendResult
 import io.horizontalsystems.walletkit.ui.compose.ComposeAppTheme
 import io.horizontalsystems.walletkit.ui.compose.TranslatableString
@@ -30,6 +31,7 @@ class SendButtonDoubleTapTest {
     val composeRule = createComposeRule()
 
     private val sendTitle = "Send"
+    private val migrateTitle = "Migrate"
 
     @Test
     fun twoTapsBeforeRecompositionSendOnce() {
@@ -83,5 +85,57 @@ class SendButtonDoubleTapTest {
         composeRule.waitForIdle()
 
         assertEquals(2, sends)
+    }
+
+    @Test
+    fun migrateTwoTapsBeforeRecompositionMigratesOnce() {
+        var migrations = 0
+
+        composeRule.setContent {
+            ComposeAppTheme {
+                MigrateButton(
+                    modifier = Modifier,
+                    sendResult = null,
+                    onClick = { migrations++ },
+                    enabled = true
+                )
+            }
+        }
+
+        composeRule.mainClock.autoAdvance = false
+        composeRule.onNodeWithText(migrateTitle).performClick()
+        composeRule.onNodeWithText(migrateTitle).performClick()
+        composeRule.mainClock.autoAdvance = true
+        composeRule.waitForIdle()
+
+        assertEquals(1, migrations)
+    }
+
+    @Test
+    fun failedMigrationCanBeRetried() {
+        var migrations = 0
+        var result by mutableStateOf<SendResult?>(null)
+
+        composeRule.setContent {
+            ComposeAppTheme {
+                MigrateButton(
+                    modifier = Modifier,
+                    sendResult = result,
+                    onClick = { migrations++ },
+                    enabled = true
+                )
+            }
+        }
+
+        composeRule.onNodeWithText(migrateTitle).performClick()
+        composeRule.waitForIdle()
+
+        result = SendResult.Failed(HSCaution(TranslatableString.PlainString("nope")))
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(migrateTitle).performClick()
+        composeRule.waitForIdle()
+
+        assertEquals(2, migrations)
     }
 }

--- a/walletkit-chain-zcash/src/main/java/io/horizontalsystems/walletkit/modules/zcashmigration/ZcashMigrationScreen.kt
+++ b/walletkit-chain-zcash/src/main/java/io/horizontalsystems/walletkit/modules/zcashmigration/ZcashMigrationScreen.kt
@@ -7,6 +7,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
@@ -145,12 +149,23 @@ fun ZcashMigrationScreen(
 }
 
 @Composable
-private fun MigrateButton(
+fun MigrateButton(
     modifier: Modifier,
     sendResult: SendResult?,
     onClick: () -> Unit,
     enabled: Boolean
 ) {
+    // The Sending/Sent branches below disable the button, but sendResult is assigned on an IO
+    // dispatcher after onClick() returns, so the button stays live for a frame or two and a double
+    // tap starts a second migration. Latch in the tap frame; a failure hands the button back.
+    var migrating by remember { mutableStateOf(false) }
+
+    LaunchedEffect(sendResult) {
+        if (sendResult is SendResult.Failed) {
+            migrating = false
+        }
+    }
+
     when (sendResult) {
         SendResult.Sending -> {
             ButtonPrimaryYellow(
@@ -174,8 +189,13 @@ private fun MigrateButton(
             ButtonPrimaryYellow(
                 modifier = modifier,
                 title = stringResource(R.string.Balance_Zcash_Migration_Migrate),
-                onClick = onClick,
-                enabled = enabled
+                onClick = {
+                    if (!migrating) {
+                        migrating = true
+                        onClick()
+                    }
+                },
+                enabled = enabled && !migrating
             )
         }
     }


### PR DESCRIPTION
Third instance of the pattern fixed in #9521 (send) and #9524 (swap).

`MigrateButton` gates on `sendResult`, but `onClickMigrate()` is an unconditional `viewModelScope.launch { migrate() }` and `sendResult = SendResult.Sending` is assigned inside `withContext(Dispatchers.IO)`. The disable therefore arrives after a dispatcher hop plus a recomposition, and two taps in that window both reach `executeIronwoodMigration()`.

## Severity

Milder than the send case. This is a full-balance self-send, so a second attempt either repeats the same txid (deduped by the network) or fails on already-spent inputs — the realistic cost is a confusing error or a wasted fee, not a double spend. It's cheap to fix because the pattern is settled.

## Changes

- Latch synchronously in the tap frame; release on `SendResult.Failed` so a genuinely failed migration stays retryable.
- `enabled` keeps its existing precondition (`error == null && fee != null`) — there is no proposal to send before the fee resolves, so the latch composes with it rather than replacing it.
- `MigrateButton` becomes public so the test can drive it directly, matching `SendButton`.

## Tests

Two cases added to `SendButtonDoubleTapTest`, mirroring the send pair:

| Test | Purpose |
|---|---|
| `migrateTwoTapsBeforeRecompositionMigratesOnce` | clock held so no recomposition intervenes; two taps produce one migration |
| `failedMigrationCanBeRetried` | a failed migration re-enables the button |

All 6 instrumented tests pass. **Reverting the latch fails the first with `expected:<1> but was:<2>`**, so the test detects the regression rather than passing regardless.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate migration attempts when the migration button is tapped repeatedly.
  * Restored the migration button after a failed attempt so migration can be retried.
  * Improved button behavior while a migration is pending or unavailable.

* **Tests**
  * Added coverage for rapid repeated taps and successful retry after a failed migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Part of #9452.
