### PR TITLE
Stop trusting dusted jetton metadata on TON

### DIFF
--- a/walletkit-chain-ton/src/main/java/io/horizontalsystems/walletkit/core/managers/TonAccountManager.kt
+++ b/walletkit-chain-ton/src/main/java/io/horizontalsystems/walletkit/core/managers/TonAccountManager.kt
@@ -9,6 +9,7 @@ import io.horizontalsystems.marketkit.models.BlockchainType
 import io.horizontalsystems.marketkit.models.TokenQuery
 import io.horizontalsystems.tonkit.models.Event
 import io.horizontalsystems.tonkit.models.Jetton
+import io.horizontalsystems.tonkit.models.JettonVerificationType
 import io.horizontalsystems.tonkit.models.TagQuery
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -110,7 +111,14 @@ class TonAccountManager(
 
         val existingWallets = walletManager.activeWallets
         val existingTokenTypeIds = existingWallets.map { it.token.type.id }
-        val newJettons = jettons.filter { !existingTokenTypeIds.contains(it.tokenType.id) }
+        val newJettons = jettons
+            .filter { !existingTokenTypeIds.contains(it.tokenType.id) }
+            // Anyone can send dust to any address, and doing so is what puts a jetton in this
+            // list, so its metadata is attacker-chosen. Blacklisted ones are the cases the
+            // indexer has already judged, and adding them to the balance list under a name of
+            // their own choosing is how a fake "USDT" or a scam claim prompt gets in front of
+            // the user.
+            .filter { it.verification != JettonVerificationType.BLACKLIST }
 
         if (newJettons.isEmpty()) return
 
@@ -121,7 +129,11 @@ class TonAccountManager(
                 coinName = jetton.name,
                 coinCode = jetton.symbol,
                 coinDecimals = jetton.decimals,
-                coinImage = jetton.image
+                // Deliberately not jetton.image: it is a URL the sender controls, and the balance
+                // list would fetch it on every render, handing them the user's IP alongside the
+                // TON address they sent the dust to. The EVM path stores no image either;
+                // catalogued tokens still get theirs from marketKit.
+                coinImage = null
             )
         }
 


### PR DESCRIPTION
Receiving a jetton is what auto-enables it, and anyone can send dust to any address — so the name, symbol, decimals and image shown on the balance row are chosen by whoever sent it. ton-kit already reports the indexer's verdict in `Jetton.verification` (`WHITELIST` / `BLACKLIST` / `NONE` / `UNKNOWN`) and the app ignored it entirely — grep for `verification` across the TON module and core managers returns nothing.

TON is also the only chain that stores a remote image URL for auto-enabled tokens:

| Chain | Metadata source | Image |
|---|---|---|
| Solana | resolved via `marketKit.tokens(…)` | from catalogue |
| EVM | own `EnabledWallet` | **`null`** |
| TON | straight from the on-chain jetton | **sender-controlled URL** |

## Changes

- **Drop blacklisted jettons.** These are the ones the indexer has already judged; listing them under a name of their own choosing is how a fake "USDT" or a scam claim prompt reaches the balance list.
- **Stop storing `jetton.image`.** The balance list fetches it on every render through Coil, which hands the sender the user's IP alongside the TON address they dusted — a beacon that keeps firing for as long as the token sits in the list. Now `null`, matching EVM; catalogued tokens still get their image from marketKit.

## Deliberately not changed

`NONE` and `UNKNOWN` keep auto-enabling. Most uncatalogued-but-legitimate jettons land there, so filtering them is a product decision about whether a user sees a genuine airdrop, not a security one. If you want them hidden or badged as unverified later, the filter is now in one place.

Not retroactive: the filter applies to new auto-enables, so jettons already in someone's list stay as they are.

## Testing

Compile-verified. Not exercised on device: reproducing it needs a funded TON account and a dust transfer from a second party, which is the same funded precondition that blocked empirical verification in the original report.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blacklisted jettons are no longer automatically enabled in wallets.
  * Newly enabled wallets no longer retain sender-controlled jetton image URLs, improving image safety and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Part of #9452.
