### PR TITLE
Share the monitor with the kit stop paths

### DIFF
--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/core/managers/EvmKitManager.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/core/managers/EvmKitManager.kt
@@ -53,6 +53,11 @@ class EvmKitManager(
         }
     }
 
+    // Runs off the sync-source subscription while getEvmKitWrapper()/unlink() may be inside the
+    // monitor. Without it, the wrapper can be nulled between that getter's null check and its !!,
+    // and the blockchainType read below is a check-then-act on the same field. Callers already
+    // holding the monitor re-enter it — Zano's manager has had this since it was written.
+    @Synchronized
     private fun handleUpdateNetwork(blockchainType: BlockchainType) {
         if (blockchainType != evmKitWrapper?.blockchainType) return
 
@@ -231,6 +236,7 @@ class EvmKitManager(
         }
     }
 
+    @Synchronized
     private fun stopEvmKit() {
         job?.cancel()
         evmKitWrapper?.evmKit?.stop()

--- a/walletkit-chain-solana/src/main/java/io/horizontalsystems/walletkit/core/managers/SolanaKitManager.kt
+++ b/walletkit-chain-solana/src/main/java/io/horizontalsystems/walletkit/core/managers/SolanaKitManager.kt
@@ -43,6 +43,9 @@ class SolanaKitManager(
     val statusInfo: Map<String, Any>?
         get() = solanaKitWrapper?.solanaKit?.statusInfo()
 
+    // See EvmKitManager: stopping off the sync-source subscription has to share the monitor
+    // with the getter, or a caller can be handed a wrapper that is being torn down.
+    @Synchronized
     private fun handleUpdateNetwork() {
         try {
             stopKit()
@@ -125,6 +128,7 @@ class SolanaKitManager(
         }
     }
 
+    @Synchronized
     private fun stopKit() {
         try {
             solanaKitWrapper?.solanaKit?.stop()

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/managers/TronKitManager.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/managers/TronKitManager.kt
@@ -62,6 +62,9 @@ class TronKitManager(
         }
     }
 
+    // See EvmKitManager: stopping off the sync-source subscription has to share the monitor
+    // with the getter, or a caller can be handed a wrapper that is being torn down.
+    @Synchronized
     private fun handleUpdateNetwork() {
         stop()
         tronKitStoppedSubject.onNext(Unit)
@@ -189,6 +192,7 @@ class TronKitManager(
         }
     }
 
+    @Synchronized
     private fun stop() {
         tronKitWrapper?.tronKit?.stop()
         job?.cancel()


### PR DESCRIPTION
Changing the RPC source stops the kit from the sync-source subscription, outside the monitor that the getter and `unlink()` hold.

| Manager | Getter | Stop path | Sync-source handler |
|---|---|---|---|
| `EvmKitManager` | `@Synchronized` | `stopEvmKit()` — **unsynchronised** | `handleUpdateNetwork()` — **unsynchronised** |
| `SolanaKitManager` | `@Synchronized` | `stopKit()` — **unsynchronised** | `handleUpdateNetwork()` — **unsynchronised** |
| `TronKitManager` | `@Synchronized` | `stop()` — **unsynchronised** | `handleUpdateNetwork()` — **unsynchronised** |
| `ZanoKitManager` | — | — | already `@Synchronized` throughout |

Two consequences:

- **NPE.** `getEvmKitWrapper()` ends in `return this.evmKitWrapper!!` after a null check another thread can invalidate in between.
- **Stale kit, old RPC.** A caller can come away holding a wrapper that was just stopped and still points at the *previous* sync source — so after the user switches node the wallet may keep talking to the old one while the UI shows the new. That compounds with the hostile-backup case: an imported RPC could outlive the user switching away from it.

`EvmKitManager.handleUpdateNetwork()` also does a check-then-act on `evmKitWrapper?.blockchainType` before stopping, which is why the handler is synchronised too, not just the stop.

## Changes

`@Synchronized` on the three stop functions and the three sync-source handlers. The nested calls from the getter and from `unlink()` re-enter the same monitor, and none of these classes uses any other lock primitive — verified — so there is no lock ordering to get wrong. This matches what `ZanoKitManager` has always done, which is also the reason to read the gap as an oversight rather than a design choice.

## Testing

Compile-verified only, and deliberately no test: this is a race, so a passing test would say nothing about the interleaving. The argument is structural — stop and get now share a monitor where previously they did not.

Worth a reviewer's eye: `kit.stop()` now runs while holding the monitor, so a slow teardown briefly blocks the getter. `ZanoKitManager` has the same property, and the alternative — copying the reference out and stopping outside the lock — reintroduces the window this closes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when updating networks or stopping EVM, Solana, and Tron wallet connections.
  * Prevented overlapping shutdown and network-change operations from causing inconsistent wallet states.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Part of #9452.
