### PR TITLE
Clear EVM account data for every chain, not seven of them

### DIFF
--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/core/adapters/Eip20Adapter.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/core/adapters/Eip20Adapter.kt
@@ -5,6 +5,8 @@ import io.horizontalsystems.walletkit.core.IEip20ApproveAdapter
 import io.horizontalsystems.walletkit.modules.multiswap.sendtransaction.EvmTransactionData
 import io.horizontalsystems.walletkit.core.AdapterState
 import io.horizontalsystems.walletkit.core.App
+import io.horizontalsystems.walletkit.core.managers.EvmKitManagerRegistry
+import io.horizontalsystems.walletkit.core.managers.EvmBlockchainManager
 import io.horizontalsystems.walletkit.core.BalanceData
 import io.horizontalsystems.walletkit.core.ICoinManager
 import io.horizontalsystems.walletkit.core.managers.EvmKitWrapper
@@ -116,18 +118,9 @@ class Eip20Adapter(
 
     companion object {
         fun clear(walletId: String) {
-            val networkTypes = listOf(
-                Chain.Ethereum,
-                Chain.BinanceSmartChain,
-                Chain.Polygon,
-                Chain.Avalanche,
-                Chain.Optimism,
-                Chain.ArbitrumOne,
-                Chain.Gnosis,
-            )
-
-            networkTypes.forEach {
-                Erc20Kit.clear(App.instance, it, walletId)
+            // Same canonical list as EvmAdapter.clear — see the note there.
+            EvmBlockchainManager.blockchainTypes.forEach { blockchainType ->
+                Erc20Kit.clear(App.instance, EvmKitManagerRegistry.getChain(blockchainType), walletId)
             }
         }
     }

--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/core/adapters/EvmAdapter.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/core/adapters/EvmAdapter.kt
@@ -2,6 +2,8 @@ package io.horizontalsystems.walletkit.core.adapters
 
 import io.horizontalsystems.walletkit.core.AdapterState
 import io.horizontalsystems.walletkit.core.App
+import io.horizontalsystems.walletkit.core.managers.EvmKitManagerRegistry
+import io.horizontalsystems.walletkit.core.managers.EvmBlockchainManager
 import io.horizontalsystems.walletkit.core.BalanceData
 import io.horizontalsystems.walletkit.core.ICoinManager
 import io.horizontalsystems.walletkit.core.managers.EvmKitWrapper
@@ -61,17 +63,11 @@ class EvmAdapter(evmKitWrapper: EvmKitWrapper, coinManager: ICoinManager) :
         const val decimal = 18
 
         fun clear(walletId: String) {
-            val networkTypes = listOf(
-                Chain.Ethereum,
-                Chain.BinanceSmartChain,
-                Chain.Polygon,
-                Chain.Avalanche,
-                Chain.Optimism,
-                Chain.ArbitrumOne,
-                Chain.Gnosis,
-            )
-            networkTypes.forEach {
-                EthereumKit.clear(App.instance, it, walletId)
+            // Driven by the canonical list rather than a copy of it: the copy that used to live
+            // here was written when there were seven EVM chains and never grew, so deleting an
+            // account left the Base, ZkSync and Fantom databases behind forever.
+            EvmBlockchainManager.blockchainTypes.forEach { blockchainType ->
+                EthereumKit.clear(App.instance, EvmKitManagerRegistry.getChain(blockchainType), walletId)
             }
         }
     }


### PR DESCRIPTION
`EvmAdapter.clear()` and `Eip20Adapter.clear()` each carried a private copy of the EVM network list, written when there were seven chains:

| List | Contents |
|---|---|
| `EvmBlockchainManager.blockchainTypes` (canonical) | Ethereum, BSC, Polygon, Avalanche, Optimism, ArbitrumOne, Gnosis, Fantom, **Base**, **ZkSync** — 10 |
| `EvmAdapter.clear()` / `Eip20Adapter.clear()` | the first seven — **missing Base, ZkSync, Fantom** |

Deleting an account therefore left those three chains' transaction and address databases on disk indefinitely. The original report called this a latent mine for whenever an eleventh network is added — it had in fact already gone off, since Base, ZkSync and Fantom are exactly the networks added after those lists were written.

## Changes

Both clear paths now iterate `EvmBlockchainManager.blockchainTypes` and map through the existing `EvmKitManagerRegistry.getChain()`, which already covers all ten. An eleventh chain gets cleared by existing code instead of by remembering to edit two more lists.

Clearing a chain that has no data is a no-op, so this can only remove more than before, never less.

## Scope

The other half of the original finding — the two `unlinkAdapter` lists — no longer applies: the plugin refactor replaced them with `EvmChainPlugin.unlink(account)`, which is per-plugin and cannot disagree with itself.

Swept for other divergent lists as part of this:
- No hardcoded `Chain.*` lists remain anywhere.
- `AddressValidatorFactory` has all ten.
- `AddressParserFactory` is per-URI-scheme, and all EVM chains share `ethereum:`, so its single entry is correct rather than drift.

Not attempted here: the six orphaned-data cases in F7-01 (Stellar, TON, Zano, BCH Type0, MerkleIo). Those are separate stores with separate lifecycles, and the TON one involves a TonConnect session keypair stored in plaintext — that deserves its own change rather than riding along with a list unification.

## Nature of the issue

Data hygiene, not an attack path: what is left behind is transaction and address history, not keys, and reading it requires already having the device's storage. Compile-verified; exercising it would mean creating and deleting accounts across three chains on a device.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clearing of EVM and EIP-20 wallet data across all supported blockchain networks.
  * Updated cleanup behavior to automatically include newly supported EVM networks, reducing the risk of leftover data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Part of #9452.
