### PR TITLE
Hide synthetic coins from market search and discovery

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/MarketKitExtensions.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/MarketKitExtensions.kt
@@ -32,6 +32,16 @@ val Token.isCustom: Boolean
 val Coin.isCustom: Boolean
     get() = uid.startsWith(TokenQuery.customCoinPrefix)
 
+// Synthetic coins (e.g. thorchain-secured-* "Bitcoin (THORChain)", zano-bridged-*)
+// duplicate an original coin on another blockchain. The server marks them with a
+// coinGeckoId pointing at the original (coinGeckoId != uid). They must be hidden from
+// market lists but kept in Coin manager / Receive / Swap for enabling-disabling.
+val Coin.isSynthetic: Boolean
+    get() {
+        val coinGeckoId = coinGeckoId ?: return false
+        return coinGeckoId != uid
+    }
+
 val Token.isSupported: Boolean
     get() = tokenQuery.isSupported
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/search/MarketDiscoveryService.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/search/MarketDiscoveryService.kt
@@ -1,6 +1,7 @@
 package io.horizontalsystems.walletkit.modules.market.search
 
 import io.horizontalsystems.walletkit.core.ILocalStorage
+import io.horizontalsystems.walletkit.core.isSynthetic
 import io.horizontalsystems.walletkit.core.managers.MarketKitWrapper
 import io.horizontalsystems.marketkit.models.Coin
 import io.horizontalsystems.marketkit.models.FullCoin
@@ -31,7 +32,9 @@ class MarketDiscoveryService(
             .sortedBy {
                 localStorage.marketSearchRecentCoinUids.indexOf(it.coin.uid)
             }
-        popularCoins = marketKit.fullCoins("")
+        // Safety net: hide synthetic coins in case they ever get a market-cap rank.
+        // Recent list is intentionally left untouched.
+        popularCoins = marketKit.fullCoins("").filter { !it.coin.isSynthetic }
 
         emitState()
     }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/search/MarketSearchService.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/search/MarketSearchService.kt
@@ -1,5 +1,6 @@
 package io.horizontalsystems.walletkit.modules.market.search
 
+import io.horizontalsystems.walletkit.core.isSynthetic
 import io.horizontalsystems.walletkit.core.managers.MarketKitWrapper
 import io.horizontalsystems.marketkit.models.FullCoin
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -40,7 +41,7 @@ class MarketSearchService(private val marketKit: MarketKitWrapper) {
         results = if (query.isBlank()) {
             listOf()
         } else {
-            marketKit.fullCoins(query)
+            marketKit.fullCoins(query).filter { !it.coin.isSynthetic }
         }
     }
 


### PR DESCRIPTION
## Summary

Synthetic coins (e.g. `thorchain-secured-*` "Bitcoin (THORChain)", `zano-bridged-*`) duplicate an original coin on another blockchain. The server marks them with a `coinGeckoId` that points at the original coin (`coinGeckoId != uid`).

These coins should be hidden from market lists but remain available in Coin manager / Receive / Swap for enabling/disabling.

## Changes

- Add `Coin.isSynthetic` extension in `MarketKitExtensions.kt` — true when `coinGeckoId` is present and differs from `uid`.
- Filter synthetic coins out of `MarketSearchService` search results.
- Filter synthetic coins out of `MarketDiscoveryService` popular coins as a safety net (recent list left untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Synthetic coins are no longer shown in popular coin lists.
  * Search results now exclude synthetic coins, while recent coins remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->