### PR TITLE
Make account cleanup a decision every chain has to state

### DIFF
--- a/walletkit-chain-bitcoin/src/main/java/io/horizontalsystems/walletkit/core/adapters/BitcoinCashAdapter.kt
+++ b/walletkit-chain-bitcoin/src/main/java/io/horizontalsystems/walletkit/core/adapters/BitcoinCashAdapter.kt
@@ -134,7 +134,11 @@ class BitcoinCashAdapter(
         }
 
         fun clear(walletId: String) {
-            BitcoinCashKit.clear(App.instance, getNetworkType(), walletId)
+            // Both derivations, not just the default: a wallet on the Type0 derivation keeps its
+            // own database, and clearing with the default Type145 left it behind entirely.
+            MainNetBitcoinCash.CoinType.values().forEach { coinType ->
+                BitcoinCashKit.clear(App.instance, getNetworkType(coinType), walletId)
+            }
         }
 
         private fun getNetworkType(kitCoinType: MainNetBitcoinCash.CoinType = MainNetBitcoinCash.CoinType.Type145) =

--- a/walletkit-chain-stellar/src/main/java/io/horizontalsystems/walletkit/chain/stellar/StellarChainPlugin.kt
+++ b/walletkit-chain-stellar/src/main/java/io/horizontalsystems/walletkit/chain/stellar/StellarChainPlugin.kt
@@ -72,6 +72,13 @@ class StellarChainPlugin : ChainPlugin {
             else -> null
         }
 
+    // Not implemented: stellar-kit exposes no clear API, unlike bitcoin-kit and ethereum-kit which
+    // provide Kit.clear(context, network, walletId). Deleting the store from here would mean
+    // hardcoding the kit's internal database name, which silently stops working the moment the
+    // kit renames it. So Stellar account data currently outlives the account — history and
+    // addresses, not keys. Needs a clear() in stellar-kit; see #9452.
+    override fun clearAccountData(accountId: String) = Unit
+
     override fun createTransactionsAdapter(source: TransactionSource): ITransactionsAdapter? {
         val stellarKitWrapper = kitManager.getStellarKitWrapper(source.account)
         val baseToken = App.coinManager.getToken(TokenQuery(BlockchainType.Stellar, TokenType.Native)) ?: return null

--- a/walletkit-chain-thorchain/src/main/java/io/horizontalsystems/walletkit/chain/thorchain/MayachainChainPlugin.kt
+++ b/walletkit-chain-thorchain/src/main/java/io/horizontalsystems/walletkit/chain/thorchain/MayachainChainPlugin.kt
@@ -74,6 +74,10 @@ class MayachainChainPlugin : ChainPlugin {
             else -> null
         }
 
+    // Mayachain keeps no per-account store of its own — balances and history come from the API on
+    // demand — so there is nothing to delete when an account is removed.
+    override fun clearAccountData(accountId: String) = Unit
+
     override fun createTransactionsAdapter(source: TransactionSource): ITransactionsAdapter? {
         val baseToken = App.coinManager.getToken(TokenQuery(BlockchainType.Mayachain, TokenType.Native)) ?: return null
         val thorchainKitWrapper = kitManager.getThorchainKitWrapper(source.account)

--- a/walletkit-chain-thorchain/src/main/java/io/horizontalsystems/walletkit/chain/thorchain/ThorchainChainPlugin.kt
+++ b/walletkit-chain-thorchain/src/main/java/io/horizontalsystems/walletkit/chain/thorchain/ThorchainChainPlugin.kt
@@ -81,6 +81,10 @@ class ThorchainChainPlugin : ChainPlugin {
             else -> null
         }
 
+    // Thorchain keeps no per-account store of its own — balances and history come from the API on
+    // demand — so there is nothing to delete when an account is removed.
+    override fun clearAccountData(accountId: String) = Unit
+
     override fun createTransactionsAdapter(source: TransactionSource): ITransactionsAdapter? {
         val baseToken = App.coinManager.getToken(TokenQuery(BlockchainType.Thorchain, TokenType.Native)) ?: return null
         val thorchainKitWrapper = kitManager.getThorchainKitWrapper(source.account)

--- a/walletkit-chain-ton/src/main/java/io/horizontalsystems/walletkit/chain/ton/TonChainPlugin.kt
+++ b/walletkit-chain-ton/src/main/java/io/horizontalsystems/walletkit/chain/ton/TonChainPlugin.kt
@@ -87,6 +87,13 @@ class TonChainPlugin(
             else -> null
         }
 
+    // Not implemented: ton-kit exposes no clear API, unlike bitcoin-kit and ethereum-kit which
+    // provide Kit.clear(context, network, walletId). Deleting the store from here would mean
+    // hardcoding the kit's internal database name, which silently stops working the moment the
+    // kit renames it. So TON account data currently outlives the account — history and
+    // addresses, not keys. Needs a clear() in ton-kit; see #9452.
+    override fun clearAccountData(accountId: String) = Unit
+
     override fun createTransactionsAdapter(source: TransactionSource): ITransactionsAdapter? {
         val tonKitWrapper = kitManager.getTonKitWrapper(source.account)
         val baseToken = App.coinManager.getToken(TokenQuery(BlockchainType.Ton, TokenType.Native)) ?: return null

--- a/walletkit-chain-zano/src/main/java/io/horizontalsystems/walletkit/chain/zano/ZanoChainPlugin.kt
+++ b/walletkit-chain-zano/src/main/java/io/horizontalsystems/walletkit/chain/zano/ZanoChainPlugin.kt
@@ -78,6 +78,13 @@ class ZanoChainPlugin(
 
     override suspend fun estimateBlockHeightFromDate(date: Date): Long = ZanoKit.restoreHeightForDate(date)
 
+    // Not implemented: zano-kit exposes no clear API, unlike bitcoin-kit and ethereum-kit which
+    // provide Kit.clear(context, network, walletId). Deleting the store from here would mean
+    // hardcoding the kit's internal database name, which silently stops working the moment the
+    // kit renames it. So Zano account data currently outlives the account — history and
+    // addresses, not keys. Needs a clear() in zano-kit; see #9452.
+    override fun clearAccountData(accountId: String) = Unit
+
     override val walletReloadTrigger: Flow<*>
         get() = zanoNodeManager().currentNodeUpdatedFlow
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/chain/ChainPlugin.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/chain/ChainPlugin.kt
@@ -147,8 +147,14 @@ interface ChainPlugin {
     /** Startup work after core managers are ready (e.g. Monero fastest-node auto-select). */
     suspend fun onAppStart() = Unit
 
-    /** Deletes the chain's locally stored data for a removed account. */
-    fun clearAccountData(accountId: String) = Unit
+    /**
+     * Deletes the chain's locally stored data for a removed account.
+     *
+     * Deliberately without a default: this used to be a no-op that plugins inherited silently, and
+     * five of them did, so deleting an account left their databases behind. A chain with nothing
+     * to delete should say so with an empty body rather than by omission.
+     */
+    fun clearAccountData(accountId: String)
 
     /** Dedicated transactions adapter, or null when the balance adapter serves both roles. */
     fun createTransactionsAdapter(source: TransactionSource): ITransactionsAdapter? = null


### PR DESCRIPTION
`ChainPlugin.clearAccountData()` had a no-op default, so a plugin opted out of account cleanup by saying nothing at all. Five had:

| Plugin | Before | Now |
|---|---|---|
| Bitcoin family, EVM, Monero, Solana, Zcash | implemented | unchanged |
| Thorchain, Mayachain | silently inherited no-op | explicit empty body — **correct**, no per-account store |
| **Stellar, TON, Zano** | silently inherited no-op | explicit empty body **documenting a real gap** |

Removing the default turns the question into a compile error, which is how the three genuine gaps surfaced.

## What is fixed

**Bitcoin Cash.** `clear()` called `getNetworkType()`, whose parameter defaults to `Type145`, so a wallet on the **Type0** derivation kept its database forever. It now clears both coin types.

## What is not fixed, and why

**Stellar, TON and Zano still leave data behind on account removal.** Their kits expose no clear API, unlike bitcoin-kit and ethereum-kit which provide `Kit.clear(context, network, walletId)`. The only app-side option is to delete the Room databases by reconstructing the kit's internal naming — TON's, for instance, is `"${walletId}-${network.name}"` — which couples the app to kit internals and stops working silently the moment a kit renames it. There is no `deleteDatabase` precedent anywhere in the app, and I did not want to establish one in a cleanup PR.

Each of the three now carries a comment stating the gap and why it is not closed here, so the omission is visible in review rather than inherited in silence. Closing them properly needs a `clear()` added to stellar-kit, ton-kit and zano-kit, then a version bump — worth its own piece of work.

## Also checked

- **MerkleIo** (⑥ in the finding) no longer has a Room store in this codebase.
- **The TonConnect session keypair** (② in the finding) is deliberately out of scope. "Private session key in plaintext Room with no auto-disconnect" is a key-storage problem that merely also survives account deletion; deleting the row would close the orphan half and leave the at-rest half untouched, which would read as a fix that is not one. It needs tracing on its own.

What is left behind is transaction and address history, not keys.

Part of #9452.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bitcoin Cash account cleanup now removes data across all supported derivation networks.

* **Account Management**
  * Account-data clearing is now consistently handled across supported chains.
  * Chains without local account data or clearing support remain unaffected when cleanup is requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->