### PR TITLE
Survive malformed market API data on coin pages

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/CoinViewFactory.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/CoinViewFactory.kt
@@ -245,8 +245,7 @@ class CoinViewFactory(
         return when (linkType) {
             LinkType.Guide -> Translator.getString(R.string.CoinPage_Guide)
             LinkType.Website -> {
-                link?.let { URI(it).host.replaceFirst("www.", "") }
-                    ?: Translator.getString(R.string.CoinPage_Website)
+                link?.let { websiteHost(it) } ?: Translator.getString(R.string.CoinPage_Website)
             }
             LinkType.Whitepaper -> Translator.getString(R.string.CoinPage_Whitepaper)
             LinkType.Twitter -> {
@@ -265,3 +264,14 @@ class CoinViewFactory(
     }
 
 }
+
+/**
+ * Host of a website link as shown on the coin page, or null when there isn't one.
+ *
+ * The link is whatever the market API returned. URI.host is null for anything without an
+ * authority — a bare word, a mailto: — and URI itself throws on malformed input, so neither is
+ * allowed to reach the caller: an uncaught throw here takes the process down, since the coin page
+ * builds this off a coroutine and the project installs no CoroutineExceptionHandler.
+ */
+internal fun websiteHost(link: String): String? =
+    runCatching { URI(link).host }.getOrNull()?.replaceFirst("www.", "")

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/CoinViewFactory.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/CoinViewFactory.kt
@@ -274,4 +274,4 @@ class CoinViewFactory(
  * builds this off a coroutine and the project installs no CoroutineExceptionHandler.
  */
 internal fun websiteHost(link: String): String? =
-    runCatching { URI(link).host }.getOrNull()?.replaceFirst("www.", "")
+    runCatching { URI(link).host }.getOrNull()?.removePrefix("www.")

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/analytics/CoinAnalyticsViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/analytics/CoinAnalyticsViewModel.kt
@@ -193,7 +193,7 @@ class CoinAnalyticsViewModel(
                 BlockViewItem(
                     title = R.string.CoinAnalytics_ProjectTvl,
                     info = AnalyticInfo.TvlInfo,
-                    value = getFormattedValue(data.points.last().tvl, currency),
+                    value = getFormattedValue(data.points.lastOrNull()?.tvl ?: return@let, currency),
                     valuePeriod = getValuePeriod(true),
                     analyticChart = getChartViewItem(data.chartPoints(), ChartViewType.Line, ProChartModule.ChartType.Tvl),
                     footerItems = footerItems,
@@ -247,7 +247,7 @@ class CoinAnalyticsViewModel(
                 BlockViewItem(
                     title = R.string.CoinAnalytics_DexLiquidity,
                     info = AnalyticInfo.DexLiquidityInfo,
-                    value = getFormattedValue(data.points.last().volume, currency),
+                    value = getFormattedValue(data.points.lastOrNull()?.volume ?: return@let, currency),
                     valuePeriod = getValuePeriod(true),
                     analyticChart = getChartViewItem(data.chartPoints(), ChartViewType.Line, ProChartModule.ChartType.DexLiquidity),
                     footerItems = footerItems,
@@ -256,7 +256,9 @@ class CoinAnalyticsViewModel(
             )
         }
         analytics.addresses?.let { data ->
-            val chartValue = formatNumberShort(data.points.last().count.toBigDecimal())
+            val chartValue = formatNumberShort(
+                (data.points.lastOrNull()?.count ?: return@let).toBigDecimal()
+            )
             val footerItems = mutableListOf<FooterItem>()
             data.rating?.let { rating ->
                 getRatingFooterItem(rating, ScoreCategory.AddressesScoreCategory)?.let {
@@ -323,6 +325,9 @@ class CoinAnalyticsViewModel(
         analytics.holders?.let { data ->
             val blockchains = service.blockchains(data.map { it.blockchainUid })
             val total = data.sumOf { it.holdersCount }
+            // Every share is 0/0 when the API reports no holders anywhere; BigDecimal.divide
+            // throws on a zero divisor rather than yielding a meaningless percentage.
+            if (total <= BigDecimal.ZERO) return@let
             val footerItems = mutableListOf<FooterItem>()
             val chartSlices = mutableListOf<StackBarSlice>()
             analytics.holdersRating?.let { holdersRating ->

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/overview/ui/ChartHelper.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/overview/ui/ChartHelper.kt
@@ -57,15 +57,18 @@ class ChartHelper(private var target: ChartData, var hasVolumes: Boolean, privat
 
         if (hasVolumes) {
             val volumeByTimestamp = target.volumeByTimestamp()
-            val volumeMin = volumeByTimestamp.minOf { it.value }
-            val volumeMax = volumeByTimestamp.maxOf { it.value }
-            volumeBars = CurveAnimatorBars(
-                volumeByTimestamp,
-                minKey,
-                maxKey,
-                volumeMin,
-                volumeMax
-            )
+            // hasVolumes says the chart type has a volume track, not that this response carried
+            // any: every point can come back with a null volume, and minOf throws on an empty
+            // map. setValues() below already guards this — the initial build did not.
+            if (volumeByTimestamp.isNotEmpty()) {
+                volumeBars = CurveAnimatorBars(
+                    volumeByTimestamp,
+                    minKey,
+                    maxKey,
+                    volumeByTimestamp.minOf { it.value },
+                    volumeByTimestamp.maxOf { it.value }
+                )
+            }
         }
 
         defineColors()
@@ -155,6 +158,10 @@ class ChartHelper(private var target: ChartData, var hasVolumes: Boolean, privat
     private fun initRsiCurve() {
         rsiCurve = target.rsi?.let { chartIndicatorRsi ->
             val values = chartIndicatorRsi.points
+            // Too few points, or all of them filtered out, leaves this empty and minOf throws.
+            // The update path checks points.isNullOrEmpty() for the same reason.
+            if (values.isEmpty()) return@let null
+
             CurveAnimator2(
                 values,
                 minKey,

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/overview/ui/ChartHelper.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/overview/ui/ChartHelper.kt
@@ -345,19 +345,29 @@ class ChartHelper(private var target: ChartData, var hasVolumes: Boolean, privat
             }
         }
 
-        if (hasVolumes) {
-            val volumeByTimestamp = target.volumeByTimestamp()
-            if (volumeByTimestamp.isNotEmpty()) {
-                val volumeMin = volumeByTimestamp.minOf { it.value }
-                val volumeMax = volumeByTimestamp.maxOf { it.value }
-                volumeBars?.setValues(
-                    volumeByTimestamp,
-                    minKey,
-                    maxKey,
-                    volumeMin,
-                    volumeMax
-                )
-            }
+        val volumeByTimestamp = if (hasVolumes) target.volumeByTimestamp() else linkedMapOf()
+        when {
+            // Dropping the bars matters as much as creating them: a response without volumes must
+            // not leave the previous chart's bars on screen.
+            volumeByTimestamp.isEmpty() -> volumeBars = null
+
+            // The first response can legitimately carry no volumes, which leaves no animator to
+            // update, so a later populated response has to be able to create one.
+            volumeBars == null -> volumeBars = CurveAnimatorBars(
+                volumeByTimestamp,
+                minKey,
+                maxKey,
+                volumeByTimestamp.minOf { it.value },
+                volumeByTimestamp.maxOf { it.value }
+            )
+
+            else -> volumeBars?.setValues(
+                volumeByTimestamp,
+                minKey,
+                maxKey,
+                volumeByTimestamp.minOf { it.value },
+                volumeByTimestamp.maxOf { it.value }
+            )
         }
 
         defineColors()

--- a/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/coin/WebsiteHostTest.kt
+++ b/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/coin/WebsiteHostTest.kt
@@ -21,6 +21,12 @@ class WebsiteHostTest {
     }
 
     @Test
+    fun stripsOnlyLeadingWww() {
+        // "www." appearing later in the host is part of the name, not a prefix to drop.
+        assertEquals("docs.www.example.com", websiteHost("https://docs.www.example.com"))
+    }
+
+    @Test
     fun hostlessLinkIsNull() {
         // No authority, so URI.host is null — this is the NPE the crash came from.
         assertNull(websiteHost("not a url"))

--- a/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/coin/WebsiteHostTest.kt
+++ b/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/coin/WebsiteHostTest.kt
@@ -1,0 +1,34 @@
+package io.horizontalsystems.walletkit.modules.coin
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The coin page renders whatever the market API returns in its links map. A row that isn't a
+ * usable URL used to take the process down rather than the row.
+ */
+class WebsiteHostTest {
+
+    @Test
+    fun stripsWww() {
+        assertEquals("example.com", websiteHost("https://www.example.com/path"))
+    }
+
+    @Test
+    fun keepsHostWithoutWww() {
+        assertEquals("example.com", websiteHost("https://example.com"))
+    }
+
+    @Test
+    fun hostlessLinkIsNull() {
+        // No authority, so URI.host is null — this is the NPE the crash came from.
+        assertNull(websiteHost("not a url"))
+        assertNull(websiteHost("mailto:someone@example.com"))
+    }
+
+    @Test
+    fun malformedLinkIsNull() {
+        assertNull(websiteHost("http://[malformed"))
+    }
+}


### PR DESCRIPTION
Coin pages build their content from responses the app does not control, and an uncaught exception in a coroutine kills the process — the project installs no `CoroutineExceptionHandler`. So each of these is a full crash on opening a coin page, repeating every time until the API is fixed.

| # | Site | Failure |
|---|---|---|
| ① | `CoinViewFactory` website link | `URI.host` is null without an authority → NPE; malformed input throws `URISyntaxException` |
| ② | `CoinAnalyticsViewModel` ×3 | `points.last()` on an empty array → `NoSuchElementException` |
| ③ | `CoinAnalyticsViewModel` holders | `divide(total)` with `total == 0` → `ArithmeticException` |
| ④ | `ChartHelper` volumes | `minOf` on an empty map when every point has a null volume |
| ⑤ | `ChartHelper` RSI | `minOf` on an empty points list |

## Two corrections to the original finding

- **④⑤ are live, not fixed.** I initially reported them as gone because `ChartHelper` had moved to `coin/overview/ui/`. It hadn't gone anywhere. What makes them clearly oversights rather than trade-offs: the **update** path (`setValues`) already checks `isNotEmpty()` / `isNullOrEmpty()` for exactly these collections — only the **initial build** skipped the check.
- **① has two crash modes, not one.** The report describes the null-host NPE; a malformed link such as `http://[malformed` throws `URISyntaxException` before that. Both are covered.

⑥ (`SimpleDateFormat.parse` on a junk audit date) I could not locate — it appears to have moved or gone. Not claimed as fixed.

## Tests

`websiteHost()` extracted from the private `getTitle()` so the crash case is directly testable, and covered by `WebsiteHostTest`: strips `www.`, keeps a bare host, returns null for a hostless link and for a malformed one. **Reverting the guard fails 2 of the 4** with `URISyntaxException`, so the tests detect the regression rather than passing regardless.

②③④⑤ are guarded by inspection only — they sit inside a view model and a chart helper that need substantial market-kit fixtures to instantiate. I did not build those, and am not claiming coverage I don't have.

## Not done

The report floats a project-wide `CoroutineExceptionHandler` as a safety net. Deliberately skipped: a handler that swallows exceptions app-wide would hide real bugs, and the per-site guards are the honest fix.

Part of #9452.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved website link handling for malformed, incomplete, or hostless URLs without causing errors.
  * Prevented analytics issues when data is unavailable or holder counts are zero.
  * Prevented chart rendering errors when volume, RSI, or other data points are missing.
  * Website names now display cleanly without unnecessary “www” prefixes.

* **Tests**
  * Added coverage for valid, malformed, and hostless website links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->