### PR TITLE
Reset backup state when the file picker is missing

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/ActivityResultExtensions.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/ActivityResultExtensions.kt
@@ -8,10 +8,14 @@ import io.horizontalsystems.walletkit.helpers.HudHelper
 
 // The system file picker (DocumentsUI) can be disabled or missing on some devices;
 // launch() then throws ActivityNotFoundException straight out of the click handler.
-fun <I> ActivityResultLauncher<I>.launchSafe(input: I, view: View) {
-    try {
+// Returns false when the launch failed — the result callback will never fire, so
+// callers driven by state (rather than a click) must reset that state themselves.
+fun <I> ActivityResultLauncher<I>.launchSafe(input: I, view: View): Boolean {
+    return try {
         launch(input)
+        true
     } catch (e: ActivityNotFoundException) {
         HudHelper.showErrorMessage(view, R.string.Error_FilePickerNotFound)
+        false
     }
 }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/backuplocal/password/BackupLocalPassword.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/backuplocal/password/BackupLocalPassword.kt
@@ -103,7 +103,7 @@ fun LocalBackupPasswordScreen(
                 }
             } catch (e: CancellationException) {
                 throw e
-            } catch (e: Throwable) {
+            } catch (e: Exception) {
                 // Any failure before the picker opens means the result callback
                 // will never fire — reset, or the screen stays stuck.
                 viewModel.backupCanceled()

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/backuplocal/password/BackupLocalPassword.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/backuplocal/password/BackupLocalPassword.kt
@@ -27,6 +27,7 @@ import io.horizontalsystems.walletkit.SnackbarDuration
 import io.horizontalsystems.walletkit.core.App
 import io.horizontalsystems.walletkit.core.launchSafe
 import io.horizontalsystems.walletkit.helpers.HudHelper
+import kotlin.coroutines.cancellation.CancellationException
 import io.horizontalsystems.walletkit.modules.evmfee.ButtonsGroupWithShade
 import io.horizontalsystems.walletkit.ui.compose.ComposeAppTheme
 import io.horizontalsystems.walletkit.ui.compose.components.FormsInput
@@ -95,8 +96,16 @@ fun LocalBackupPasswordScreen(
     // the state must be reset here or the screen stays stuck.
     LaunchedEffect(uiState.backupJson) {
         if (uiState.backupJson != null) {
-            App.pinComponent.keepUnlocked()
-            if (!backupLauncher.launchSafe(viewModel.backupFileName, view)) {
+            try {
+                App.pinComponent.keepUnlocked()
+                if (!backupLauncher.launchSafe(viewModel.backupFileName, view)) {
+                    viewModel.backupCanceled()
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                // Any failure before the picker opens means the result callback
+                // will never fire — reset, or the screen stays stuck.
                 viewModel.backupCanceled()
             }
         }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/backuplocal/password/BackupLocalPassword.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/backuplocal/password/BackupLocalPassword.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -89,9 +90,16 @@ fun LocalBackupPasswordScreen(
         viewModel.accountErrorIsShown()
     }
 
-    if (uiState.backupJson != null) {
-        App.pinComponent.keepUnlocked()
-        backupLauncher.launchSafe(viewModel.backupFileName, view)
+    // One-shot per backup attempt: launching from composition would re-fire on
+    // recomposition, and a failed launch never invokes the result callback, so
+    // the state must be reset here or the screen stays stuck.
+    LaunchedEffect(uiState.backupJson) {
+        if (uiState.backupJson != null) {
+            App.pinComponent.keepUnlocked()
+            if (!backupLauncher.launchSafe(viewModel.backupFileName, view)) {
+                viewModel.backupCanceled()
+            }
+        }
     }
 
     if (uiState.closeScreen) {


### PR DESCRIPTION
Follow-up to #9530: when the system file picker is unavailable, the backup screen now resets instead of staying stuck waiting for a result that never arrives. Verified on an emulator with DocumentsUI disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved backup handling when the system cannot open the file-saving screen.
  - Backup operations now correctly reset after launch or PIN-unlock failures.
  - Canceled backup operations no longer leave the screen stuck.
  - Added clearer success and failure reporting when launching supported actions.
  - Prevented failed backup launches from leaving the interface in an incomplete state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->