### PR TITLE
Survive an empty guides or faq index

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/settings/faq/FaqViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/settings/faq/FaqViewModel.kt
@@ -52,7 +52,12 @@ class FaqViewModel(private val repository: FaqRepository) : ViewModel() {
 
     private fun didFetchFaqSections(faqSections: List<FaqSection>) {
         sections = faqSections
+
         // See GuidesViewModel: an empty but successful index used to crash the process here.
-        faqSections.firstOrNull()?.let { onSelectSection(it) }
+        // Assigned rather than skipped when empty, so a refetch that comes back empty clears the
+        // previous selection instead of leaving its items on a screen that has no sections.
+        val section = faqSections.firstOrNull()
+        selectedSection = section
+        faqItems = section?.faqItems.orEmpty()
     }
 }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/settings/faq/FaqViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/settings/faq/FaqViewModel.kt
@@ -52,6 +52,7 @@ class FaqViewModel(private val repository: FaqRepository) : ViewModel() {
 
     private fun didFetchFaqSections(faqSections: List<FaqSection>) {
         sections = faqSections
-        onSelectSection(faqSections.first())
+        // See GuidesViewModel: an empty but successful index used to crash the process here.
+        faqSections.firstOrNull()?.let { onSelectSection(it) }
     }
 }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/settings/guides/GuidesViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/settings/guides/GuidesViewModel.kt
@@ -59,7 +59,11 @@ class GuidesViewModel(private val repository: GuidesRepository) : ViewModelUiSta
 
     private fun didFetchGuideCategories(guideCategories: List<GuideCategory>) {
         categories = guideCategories
-        selectedCategory = guideCategories.first()
+        // A successful fetch can carry an empty index — the content is served, not built in — and
+        // first() on it threw out of a coroutine, taking the process down every time the screen
+        // was opened until the content was fixed. Nothing to select is a state the screen already
+        // handles.
+        selectedCategory = guideCategories.firstOrNull()
 
         emitState()
     }


### PR DESCRIPTION
`GuidesViewModel` and `FaqViewModel` both take the first entry of a successfully fetched index:

- `selectedCategory = guideCategories.first()`
- `onSelectSection(faqSections.first())`

The content is served rather than built into the app, so `DataState.Success(emptyList())` is an ordinary value — and `first()` on it throws `NoSuchElementException` out of `viewModelScope.launch`. With no `CoroutineExceptionHandler` anywhere in the project, that is process death, repeating on every open until the content is fixed.

## Changes

`firstOrNull()` at both sites. Both selections were already nullable and both screens already tolerate a null selection, so this needed no UI changes.

## Behaviour with an empty index

The screen renders **empty rather than crashing** — no tabs, no items. It does not say "no content available", because `ViewState` has only `Loading`, `Success` and `Error`; adding an `Empty` case to a sealed class used across the whole app is out of proportion to this fix. Worth a separate look if a blank screen is considered unacceptable.

## No test, deliberately

Covering this would mean adding `kotlinx-coroutines-test` (not in the version catalog) plus a mocking library to `walletkit` (which has only `junit`), and `Dispatchers.setMain` plumbing — because both view models subscribe in `init` through `viewModelScope`, and their repositories are concrete classes taking Android-backed managers. That is two new test dependencies and dispatcher scaffolding to exercise a change from `first()` to `firstOrNull()`, and there is no pure function worth extracting the way there was for the website-link crash in #9537.

Part of #9452.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability when FAQ sections or guide categories load with no available items.
  - Prevented errors caused by empty results during FAQ and guide navigation.
  - Ensured empty FAQ results clear the current selection appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->