### PR TITLE
Stop saving a non-Bundleable ROI dialog state

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/roi/RoiSelectCoinsPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/roi/RoiSelectCoinsPage.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -91,7 +92,11 @@ fun RoiSelectCoinsScreen(navigation: HSNavigation) {
         },
         backgroundColor = ComposeAppTheme.colors.tyler,
     ) {
-        var dialog: PeriodSelectorDialog? by rememberSaveable { mutableStateOf(null) }
+        // remember, not rememberSaveable: PeriodSelectorDialog is not Bundleable, so saving it
+        // threw IllegalStateException on every backgrounding while the picker was open. The state
+        // is a transient picker that is cleared on select or dismiss and read nowhere else, so
+        // letting it close when the process goes away is the behaviour we want anyway.
+        var dialog: PeriodSelectorDialog? by remember { mutableStateOf(null) }
 
         Column(
             modifier = Modifier.padding(it),


### PR DESCRIPTION
`RoiSelectCoinsPage` held its period-picker state in `rememberSaveable`:

```kotlin
var dialog: PeriodSelectorDialog? by rememberSaveable { mutableStateOf(null) }
```

`PeriodSelectorDialog` is a plain data class — no `@Parcelize`, no `Serializable` — and its `period` field (`HsTimePeriodTranslatable`) is not Bundleable either. `rememberSaveable` requires every value it holds to survive a `Bundle`, so with the picker open, `onSaveInstanceState` throws `IllegalStateException`.

Deterministic, not data-dependent and not a race: open the picker, press home. Trivially reachable for any user who reaches the ROI screen.

## Change

`remember` instead of `rememberSaveable`. The state is a transient picker — set by a tap, cleared on select or dismiss, read nowhere else in the file — so there is nothing to restore, and a period picker reopening itself after the user has left the app is not obviously desirable anyway.

Considered and not taken: keeping `rememberSaveable` and storing only the `index: Int`, deriving title and period from `uiState`. That preserves the open dialog across rotation, at the cost of more code for behaviour nobody asked for. Worth revisiting if rotation should reopen the picker.

## Sweep

The report calls this the only non-Bundleable point in the project, and that checks out. Every other `rememberSaveable` holds a primitive, a `String`, a `BigDecimal` (`Serializable`), or supplies an explicit `Saver` — `TextFieldValue.Saver`, `LazyListState.Saver`.

## Testing

Compile-verified. Not reproduced on device: it needs the ROI screen, which sits behind premium, and the failure is a documented `rememberSaveable` contract violation rather than something in doubt.

Part of #9452.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the ROI coin selection experience by preventing transient period-selector dialog state from being incorrectly restored after process recreation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->