### PR TITLE
Update the Zcash SDK to 2.7.0-rc.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -83,7 +83,7 @@ marketKit = "2134f02"
 solanaKit = "66cc82b"
 tronKit = "6fc27cf"
 thorchainKit = "9de6579"
-zcashSdk = "2.7.0-rc.2"
+zcashSdk = "2.7.0-rc.4"
 
 # Binance
 binanceConnector = "3.4.1"


### PR DESCRIPTION
Bumps `zcashSdk` from `2.7.0-rc.2` to `2.7.0-rc.4`, the latest version published to Maven Central (2026-07-30). One-line change in `gradle/libs.versions.toml`; both `zcash-android-sdk` and `zcash-android-backend` follow the same version ref.

## What rc.3 and rc.4 bring

librustzcash moves to `zcash_client_backend 0.24.0-rc.6` and `zcash_client_sqlite 0.22.0-rc.6`.

Fixes that affect ordinary post-NU6.3 receives and spends:

- Ironwood notes received on an account's internal address were classified as received rather than change when recorded before their transaction's spends could be linked to the wallet, so history counted the account's own change as a recipient. Balances were not affected.
- An address that had only ever received Ironwood notes was treated as never used: the transparent gap-limit search could hand the same address out again, and the receiving account was not reported as involved in the transaction that paid it.
- The funding account recorded for a transparent output ignored value spent from the Ironwood pool, so an output funded entirely from Ironwood was attributed to no account.

ZIP 318 changes:

- Revised migration timing — shorter transfer and preparation delays, anchor-age cap of 4 bucket boundaries instead of 16.
- A canonical crossing is now funded from the single oldest Orchard note that covers the payment and its fee when one exists, paying one fewer ZIP 317 marginal-fee action, falling back to ordinary multi-note funding otherwise.

## Upgrade notes

No source changes were needed — the update is API compatible with what we call.

rc.3 ships **database migrations that run on first launch after upgrade** to repair records affected by the three defects above. No rescan is required, but this is the thing to watch when testing against an existing Zcash wallet.

## Testing

`./gradlew :app:assembleDebug` succeeds; all four debug variants package. `debugRuntimeClasspath` resolves both artifacts to `2.7.0-rc.4`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Zcash Android SDK to release candidate version 2.7.0-rc.4.
  * Updated related backend dependency references to maintain compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Addresses #9520.
