### PR TITLE
Add a copy button to the transaction Memo field

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactionInfo/TransactionInfoPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactionInfo/TransactionInfoPage.kt
@@ -183,6 +183,7 @@ fun TransactionInfoSection(
                             TitleAndValueCell(
                                 title = viewItem.title,
                                 value = viewItem.value,
+                                copyable = viewItem.copyable,
                             )
                         }
                     }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactionInfo/TransactionInfoViewItem.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactionInfo/TransactionInfoViewItem.kt
@@ -31,7 +31,7 @@ sealed class TransactionInfoViewItem {
         val badge: String?,
     ) : TransactionInfoViewItem()
 
-    class Value(val title: String, val value: String) : TransactionInfoViewItem()
+    class Value(val title: String, val value: String, val copyable: Boolean = false) : TransactionInfoViewItem()
 
     class PriceWithToggle(val title: String, val valueOne: String, val valueTwo: String) : TransactionInfoViewItem()
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactionInfo/TransactionViewItemFactoryHelper.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactionInfo/TransactionViewItemFactoryHelper.kt
@@ -43,7 +43,7 @@ object TransactionViewItemFactoryHelper {
     private val evmLabelManager = App.evmLabelManager
 
     fun getMemoItem(memo: String) =
-        TransactionInfoViewItem.Value(Translator.getString(R.string.TransactionInfo_Memo), memo)
+        TransactionInfoViewItem.Value(Translator.getString(R.string.TransactionInfo_Memo), memo, copyable = true)
 
     private fun getFeeAmountString(
         rate: CurrencyValue?,

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/ui/compose/components/TransactionInfoCells.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/ui/compose/components/TransactionInfoCells.kt
@@ -203,13 +203,33 @@ fun TransactionAmountCell(
 fun TitleAndValueCell(
     title: String,
     value: String,
+    copyable: Boolean = false,
 ) {
+    val view = LocalView.current
     RowUniversal(
         modifier = Modifier.padding(horizontal = 16.dp),
     ) {
         subhead2_grey(text = title, modifier = Modifier.padding(end = 16.dp))
-        Spacer(Modifier.weight(1f))
-        subhead1_leah(text = value, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        if (!copyable) {
+            Spacer(Modifier.weight(1f))
+        }
+        subhead1_leah(
+            text = value,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.End,
+            modifier = if (copyable) Modifier.weight(1f) else Modifier,
+        )
+        if (copyable) {
+            HSpacer(16.dp)
+            ButtonSecondaryCircle(
+                icon = R.drawable.ic_copy_20,
+                onClick = {
+                    TextHelper.copyText(value)
+                    HudHelper.showSuccessMessage(view, R.string.Hud_Text_Copied)
+                }
+            )
+        }
     }
 }
 


### PR DESCRIPTION
#9550
## What

Adds a copy button to the Memo field on the transaction detail page so users can copy the memo text with one tap.

## Why

The memo value was previously display-only. Long memos are truncated in the cell, making them impossible to read or reuse in full without a copy affordance.

## How

- `TransactionInfoViewItem.Value` gains an opt-in `copyable` flag (defaults to `false`, so all other value cells are unchanged).
- `getMemoItem` sets `copyable = true`, scoping the button to the memo.
- `TitleAndValueCell` renders a `ButtonSecondaryCircle` copy icon when `copyable`, reusing the existing `TextHelper.copyText` + "Copied" hud pattern already used by the address cell.
- When copyable, the value takes the remaining row width with `weight(1f)` and ellipsizes, keeping the copy button pinned to the right edge even for long memos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copy controls for transaction values that support copying.
  * Transaction memos can now be copied directly from transaction details.
  * A confirmation message appears after a value is copied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->