### PR TITLE
Ignore transient WalletConnect connectivity errors

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/WCDelegate.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/WCDelegate.kt
@@ -1,5 +1,7 @@
 package io.horizontalsystems.walletkit.modules.walletconnect
 
+import android.util.Log
+import io.horizontalsystems.walletkit.BuildConfig
 import io.horizontalsystems.walletkit.core.App
 import io.horizontalsystems.dapp.core.DAppManager
 import io.horizontalsystems.dapp.core.DAppServiceCallback
@@ -53,6 +55,22 @@ object WCDelegate : DAppServiceCallback {
     }
 
     override fun onError(throwable: Throwable) {
+        // The WC/Reown relay reports transient reconnect failures (e.g. "Batch subscribe
+        // connectivity error. Check your internet connection") through this global delegate,
+        // typically when the WebSocket re-subscribes to session topics on app resume before the
+        // network is ready. These recover on their own, so swallow them here instead of surfacing
+        // an alarming red HUD. Errors from user-initiated actions are emitted elsewhere (see the
+        // per-action HSDAppEvent.Error emissions in this file) and are unaffected.
+        if (isTransientWcConnectivityError(throwable)) {
+            // Attach the throwable only in debug builds; release logs keep just the fixed message
+            // so no callback-provided details land in production logs.
+            if (BuildConfig.DEBUG) {
+                Log.w("WCDelegate", "Ignoring transient WC connectivity error", throwable)
+            } else {
+                Log.w("WCDelegate", "Ignoring transient WC connectivity error")
+            }
+            return
+        }
         scope.launch { _walletEvents.emit(HSDAppEvent.Error(throwable)) }
     }
 
@@ -204,4 +222,20 @@ object WCDelegate : DAppServiceCallback {
     }
 
     // endregion
+}
+
+// Best-effort classification of transient relay/connectivity errors delivered through the WC/Reown
+// global error delegate. The SDK exposes no typed error code — it wraps everything in a plain
+// Throwable(message) (see RelayJsonRpcInteractor) — so we match on specific, complete phrases rather
+// than the whole message, whose exact wording varies by SDK version. Matched errors recover on their
+// own via the SDK's backoff/resubscribe strategy, so surfacing them as a HUD is only noise:
+//   - "Batch subscribe error: ..." — resubscription is an SDK-internal op, never user-triggered
+//   - "No connection available"    — NoRelayConnectionException on reconnect
+//   - "...check your internet connection" — NoInternetConnectionException
+// Kept internal (not private) so it is unit-testable from the module's test source set.
+internal fun isTransientWcConnectivityError(throwable: Throwable): Boolean {
+    val message = throwable.message?.lowercase() ?: return false
+    return message.contains("batch subscribe") ||
+            message.contains("no connection available") ||
+            message.contains("check your internet connection")
 }

--- a/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/walletconnect/TransientWcConnectivityErrorTest.kt
+++ b/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/walletconnect/TransientWcConnectivityErrorTest.kt
@@ -1,0 +1,53 @@
+package io.horizontalsystems.walletkit.modules.walletconnect
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The WC/Reown relay reports transient reconnect failures through the global error delegate (e.g.
+ * on app resume, before the network is ready). Those recover on their own and shouldn't surface a
+ * HUD. These tests pin the classifier so it stays scoped to the known connectivity signatures and
+ * doesn't swallow genuine, actionable errors that merely mention a network word.
+ */
+class TransientWcConnectivityErrorTest {
+
+    @Test
+    fun batchSubscribeErrorIsTransient() {
+        // The reported symptom, plus the general "Batch subscribe error: ..." SDK form.
+        assertTrue(transient("Batch subscribe connectivity error. Check your internet connection"))
+        assertTrue(transient("Batch subscribe error: request timeout"))
+    }
+
+    @Test
+    fun noConnectionAvailableIsTransient() {
+        // NoRelayConnectionException delivered via the global delegate on reconnect.
+        assertTrue(transient("No connection available"))
+    }
+
+    @Test
+    fun noInternetConnectionIsTransient() {
+        assertTrue(transient("Connection error: Please check your Internet connection"))
+    }
+
+    @Test
+    fun classificationIsCaseInsensitive() {
+        assertTrue(transient("BATCH SUBSCRIBE ERROR: timeout"))
+    }
+
+    @Test
+    fun nullMessageIsNotTransient() {
+        assertFalse(isTransientWcConnectivityError(Throwable()))
+    }
+
+    @Test
+    fun genuineErrorsWithNetworkWordingAreNotTransient() {
+        // Near-matches that share a single loose word must remain actionable, not be suppressed.
+        assertFalse(transient("Failed to sign transaction: connectivity lost"))
+        assertFalse(transient("Session approve error: user rejected"))
+        assertFalse(transient("Publish error: invalid request"))
+        assertFalse(transient("Subscribe error: topic already subscribed"))
+    }
+
+    private fun transient(message: String) = isTransientWcConnectivityError(Throwable(message))
+}


### PR DESCRIPTION
## Problem

On app resume, users intermittently see a red toast: **"Batch subscribe connectivity error. Check your internet connection"**.

This string is **not** from our code — it comes verbatim from the Reown/WalletConnect relay SDK. When the app resumes, the relay WebSocket reconnects and batch-subscribes to active session topics. If the network isn't ready at that instant, the SDK emits a connectivity error through its **global** `onError` delegate.

Our code passes any such error straight to a HUD (`Nav3.kt:256`):

```kotlin
is HSDAppEvent.Error -> HudHelper.showErrorMessage(view, event.throwable.message ?: "Error")
```

The SDK recovers on its own (it has an exponential-backoff / resubscribe strategy), so the toast is alarming but not actionable.

## Fix

Filter transient relay/connectivity errors at the source — the global delegate `WCDelegate.onError` — and log them instead of surfacing a HUD. Errors from **user-initiated** actions are emitted on separate paths (per-action `HSDAppEvent.Error`) and are unaffected, so genuine dApp request/connection failures still show.

```kotlin
override fun onError(throwable: Throwable) {
    if (isTransientConnectivityError(throwable)) {
        Log.w("WCDelegate", "Ignoring transient WC connectivity error", throwable)
        return
    }
    scope.launch { _walletEvents.emit(HSDAppEvent.Error(throwable)) }
}
```

## Why this is safe

- `batchSubscribe` is an SDK-internal operation (relay resubscription) — never triggered by a user action — so it only ever arrives on the global delegate path.
- Verified against reown-kotlin source (`RelayJsonRpcInteractor.batchSubscribe`): the error text is `"Batch subscribe error: ${cause}"` and is guarded by `ConditionalExponentialBackoffStrategy` + `onResubscribe`, confirming it's transient and self-healing.
- Same transient-connectivity family as [WalletConnectKotlinV2#478](https://github.com/WalletConnect/WalletConnectKotlinV2/issues/478) (`NoRelayConnectionException`).
- Dropped errors are logged (`Log.w`, tag `WCDelegate`) so nothing disappears silently.

Message classification is string-based because the SDK hands us only a `Throwable.message` (no typed error code); the match is scoped to connectivity wording.

## Testing

Resume the app repeatedly with a live WalletConnect session on flaky/slow network — the toast no longer appears, while genuine dApp errors still surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary WalletConnect connectivity error notifications by filtering transient relay and reconnection issues.
  * Continued reporting genuine WalletConnect errors as usual.
  * Improved handling of connectivity messages regardless of letter casing, while avoiding suppression of unrelated errors.
* **Chores**
  * Added diagnostic logging to improve visibility into WalletConnect connection events and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->