### PR TITLE
Fix ViewModel resolution crash after process death

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/token/TokenBalancePage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/token/TokenBalancePage.kt
@@ -3,10 +3,8 @@ package io.horizontalsystems.walletkit.modules.balance.token
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.horizontalsystems.walletkit.entities.Wallet
-import io.horizontalsystems.walletkit.modules.nav3.EntryPage
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.nav3.HSPage
-import io.horizontalsystems.walletkit.modules.transactions.TransactionsViewModel
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -15,11 +13,9 @@ data class TokenBalancePage(val wallet: Wallet) : HSPage() {
     @Composable
     override fun GetContent(navigation: HSNavigation) {
         val viewModel = viewModel<TokenBalanceViewModel>(factory = TokenBalanceModule.Factory(wallet))
-        val transactionsViewModel = navigation.viewModelForScreen<TransactionsViewModel>(EntryPage::class)
 
         TokenBalanceScreen(
             viewModel,
-            transactionsViewModel,
             navigation
         )
     }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/token/TokenBalanceScreen.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/token/TokenBalanceScreen.kt
@@ -62,7 +62,7 @@ import io.horizontalsystems.walletkit.modules.send.address.EnterAddressPage
 import io.horizontalsystems.walletkit.modules.syncerror.SyncErrorSheet
 import io.horizontalsystems.walletkit.modules.transactionInfo.TransactionInfoPage
 import io.horizontalsystems.walletkit.modules.transactions.TransactionViewItem
-import io.horizontalsystems.walletkit.modules.transactions.TransactionsViewModel
+import io.horizontalsystems.walletkit.modules.transactionInfo.TransactionInfoPayload
 import io.horizontalsystems.walletkit.modules.transactions.transactionList
 import io.horizontalsystems.walletkit.ui.compose.ComposeAppTheme
 import io.horizontalsystems.walletkit.ui.compose.TranslatableString
@@ -99,7 +99,6 @@ import kotlinx.coroutines.launch
 @Composable
 fun TokenBalanceScreen(
     viewModel: TokenBalanceViewModel,
-    transactionsViewModel: TransactionsViewModel,
     navigation: HSNavigation
 ) {
     val uiState = viewModel.uiState
@@ -285,7 +284,6 @@ fun TokenBalanceScreen(
                         onTransactionClick(
                             it,
                             viewModel,
-                            transactionsViewModel,
                             navigation
                         )
                     },
@@ -447,11 +445,10 @@ private fun openSyncErrorDialog(
 private fun onTransactionClick(
     transactionViewItem: TransactionViewItem,
     tokenBalanceViewModel: TokenBalanceViewModel,
-    transactionsViewModel: TransactionsViewModel,
     navigation: HSNavigation
 ) {
     val transactionItem = tokenBalanceViewModel.getTransactionItem(transactionViewItem) ?: return
-    transactionsViewModel.tmpTransactionRecordToShow = transactionItem.record
+    TransactionInfoPayload.record = transactionItem.record
 
     navigation.slideFromBottom(TransactionInfoPage)
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/HSNavigation.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/HSNavigation.kt
@@ -3,6 +3,7 @@ package io.horizontalsystems.walletkit.modules.nav3
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation3.runtime.NavBackStack
 import io.horizontalsystems.walletkit.core.App
@@ -59,14 +60,24 @@ class HSNavigation(val backStack: NavBackStack<HSPage>) {
     }
 
     @Composable
-    inline fun <reified VM : ViewModel> viewModelForScreen(klass: KClass<out HSPage>) : VM {
-        return viewModelForScreen(klass.simpleName ?: "HSScreen")
+    inline fun <reified VM : ViewModel> viewModelForScreen(
+        klass: KClass<out HSPage>,
+        factory: ViewModelProvider.Factory? = null,
+    ) : VM {
+        return viewModelForScreen(klass.simpleName ?: "HSScreen", factory)
     }
 
     @Composable
-    inline fun <reified VM : ViewModel> viewModelForScreen(contentKey: String) : VM {
+    // The factory makes the lookup restore-safe: after process death the shared
+    // store is empty, and without a factory the default one instantiates the
+    // ViewModel reflectively and crashes on constructor parameters.
+    inline fun <reified VM : ViewModel> viewModelForScreen(
+        contentKey: String,
+        factory: ViewModelProvider.Factory? = null,
+    ) : VM {
         return viewModel(
             viewModelStoreOwner = rememberChildViewModelStoreOwner(contentKey),
+            factory = factory,
         )
     }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactionInfo/TransactionInfoPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactionInfo/TransactionInfoPage.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.compose.runtime.remember
 import io.horizontalsystems.walletkit.R
 import io.horizontalsystems.walletkit.core.stats.StatEntity
 import io.horizontalsystems.walletkit.core.stats.StatEvent
@@ -15,10 +16,8 @@ import io.horizontalsystems.walletkit.core.stats.StatPage
 import io.horizontalsystems.walletkit.core.stats.stat
 import io.horizontalsystems.walletkit.entities.transactionrecords.TransactionRecord
 import io.horizontalsystems.walletkit.modules.coin.CoinPage
-import io.horizontalsystems.walletkit.modules.nav3.EntryPage
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.nav3.HSPage
-import io.horizontalsystems.walletkit.modules.transactions.TransactionsViewModel
 import io.horizontalsystems.walletkit.ui.compose.TranslatableString
 import io.horizontalsystems.walletkit.ui.compose.components.CellUniversalLawrenceSection
 import io.horizontalsystems.walletkit.ui.compose.components.DescriptionCell
@@ -49,9 +48,7 @@ data object TransactionInfoPage : HSPage() {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {
-        val viewModelTxs = navigation.viewModelForScreen<TransactionsViewModel>(EntryPage::class)
-
-        val transactionRecord = viewModelTxs.tmpTransactionRecordToShow
+        val transactionRecord = remember { TransactionInfoPayload.record }
         if (transactionRecord == null) {
             navigation.removeLastUntil(TransactionInfoPage::class, true)
             return

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactionInfo/TransactionInfoPayload.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactionInfo/TransactionInfoPayload.kt
@@ -1,0 +1,12 @@
+package io.horizontalsystems.walletkit.modules.transactionInfo
+
+import io.horizontalsystems.walletkit.entities.transactionrecords.TransactionRecord
+
+// One-shot in-memory handoff of the tapped record to TransactionInfoPage.
+// TransactionRecord is not serializable and cannot be re-fetched by id, so it
+// cannot travel inside the nav page itself. After process death this is null
+// and the restored page pops itself instead of resolving a shared ViewModel
+// whose store no longer exists.
+object TransactionInfoPayload {
+    var record: TransactionRecord? = null
+}

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactions/FilterBlockchainPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactions/FilterBlockchainPage.kt
@@ -39,7 +39,7 @@ data object FilterBlockchainPage : HSPage() {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {
-        val viewModel = navigation.viewModelForScreen<TransactionsViewModel>(EntryPage::class)
+        val viewModel = navigation.viewModelForScreen<TransactionsViewModel>(EntryPage::class, TransactionsModule.Factory())
 
         FilterBlockchainScreen(navigation, viewModel)
     }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactions/FilterCoinPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactions/FilterCoinPage.kt
@@ -43,7 +43,7 @@ data object FilterCoinPage : HSPage() {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {
-        val viewModel = navigation.viewModelForScreen<TransactionsViewModel>(EntryPage::class)
+        val viewModel = navigation.viewModelForScreen<TransactionsViewModel>(EntryPage::class, TransactionsModule.Factory())
         FilterCoinScreen(navigation, viewModel)
     }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactions/TransactionsFilterPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactions/TransactionsFilterPage.kt
@@ -44,7 +44,7 @@ data object TransactionsFilterPage : HSPage() {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {
-        val viewModel = navigation.viewModelForScreen<TransactionsViewModel>(EntryPage::class)
+        val viewModel = navigation.viewModelForScreen<TransactionsViewModel>(EntryPage::class, TransactionsModule.Factory())
 
         FilterScreen(
             navigation,

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactions/TransactionsPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactions/TransactionsPage.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.Serializable
 data object TransactionsPage : HSPage() {
     @Composable
     override fun GetContent(navigation: HSNavigation) {
-        val viewModel = navigation.viewModelForScreen<TransactionsViewModel>(EntryPage::class)
+        val viewModel = navigation.viewModelForScreen<TransactionsViewModel>(EntryPage::class, TransactionsModule.Factory())
         TransactionsScreen(navigation, viewModel)
     }
 }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactions/TransactionsScreen.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactions/TransactionsScreen.kt
@@ -49,6 +49,7 @@ import io.horizontalsystems.walletkit.modules.balance.BalanceModule
 import io.horizontalsystems.walletkit.modules.balance.BalanceScreenState
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.transactionInfo.TransactionInfoPage
+import io.horizontalsystems.walletkit.modules.transactionInfo.TransactionInfoPayload
 import io.horizontalsystems.walletkit.ui.compose.ComposeAppTheme
 import io.horizontalsystems.walletkit.ui.compose.TranslatableString
 import io.horizontalsystems.walletkit.ui.compose.components.HSCircularProgressIndicator
@@ -196,7 +197,7 @@ private fun onTransactionClick(
 ) {
     val transactionItem = viewModel.getTransactionItem(transactionViewItem) ?: return
 
-    viewModel.tmpTransactionRecordToShow = transactionItem.record
+    TransactionInfoPayload.record = transactionItem.record
 
     navigation.slideFromBottom(TransactionInfoPage)
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactions/TransactionsViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/transactions/TransactionsViewModel.kt
@@ -41,7 +41,6 @@ class TransactionsViewModel(
     private val localStorage: ILocalStorage,
 ) : ViewModelUiState<TransactionsUiState>() {
 
-    var tmpTransactionRecordToShow: TransactionRecord? = null
 
     val filterResetEnabled = MutableLiveData<Boolean>()
     val filterTokensLiveData = MutableLiveData<List<Filter<FilterToken?>>>()


### PR DESCRIPTION
Restoring nav3 pages after the system killed the app could fail while resolving shared view models. Verified with a process-death repro on an emulator. Closes #9558.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation from transaction lists and token balances to transaction details.
  * Preserved the selected transaction when opening its details, reducing issues caused by shared screen state.
  * Improved restoration behavior so unavailable transaction details exit safely instead of displaying invalid content.

* **Improvements**
  * Enhanced screen setup to support more reliable creation and loading of transaction-related views.
  * Existing transaction filters and selection options continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->