### PR TITLE
Keep the nav3 backstack from draining to empty

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/HSNavigation.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/HSNavigation.kt
@@ -39,7 +39,12 @@ class HSNavigation(val backStack: NavBackStack<HSPage>) {
     }
 
     fun removeLastOrNull() {
-        backStack.removeLastOrNull()
+        // Never pop the root entry: NavDisplay requires a non-empty backstack,
+        // and rapid double back events (toolbar arrow double-tap or system back
+        // during the pop animation) can otherwise drain the stack and crash.
+        if (backStack.size > 1) {
+            backStack.removeLastOrNull()
+        }
     }
 
     fun navigateWithTermsAccepted(
@@ -92,7 +97,8 @@ class HSNavigation(val backStack: NavBackStack<HSPage>) {
             for (i in backStack.lastIndex downTo (index + 1)) {
                 backStack.removeAt(i)
             }
-            if (inclusive) {
+            // index 0 is the root entry; removing it would empty the backstack.
+            if (inclusive && index > 0) {
                 backStack.removeAt(index)
             }
         }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/Nav3.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/Nav3.kt
@@ -87,6 +87,9 @@ fun Nav3(entryPage: HSPage) {
                 eventBusNavEntryDecorator,
             ),
             backStack = backStack,
+            // Guarded pop: NavDisplay's default onBack removes entries without
+            // protecting the root, so a racing back event can empty the stack.
+            onBack = hsNavigation::removeLastOrNull,
             sceneStrategies = listOf(bottomSheetStrategy),
             entryProvider = { screen ->
                 eventBusNavEntryDecorator.setResultKey(screen.resultKey)


### PR DESCRIPTION
Rapid repeated back events could pop past the root entry, which NavDisplay rejects. Pops are now guarded so the root entry always remains; back at root still leaves the app. Verified with a double-back repro on an emulator. Closes #9560.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved back navigation to preserve the root screen.
  * Prevented rapid or repeated back actions from emptying the navigation stack.
  * Updated navigation stack removal to safely handle root and matched entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->