### PR TITLE
Fix crashes on backgrounding and restoring certain screens

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -269,6 +269,7 @@ dependencies {
 
     // Unit Tests
     testImplementation(libs.junit)
+    testImplementation(libs.classgraph)
     testImplementation(libs.arch.core.testing)
     testImplementation(libs.mockito)
     testImplementation(libs.mockito.kotlin)

--- a/app/src/test/java/io/horizontalsystems/bankwallet/nav3/NavPagesSerializableTest.kt
+++ b/app/src/test/java/io/horizontalsystems/bankwallet/nav3/NavPagesSerializableTest.kt
@@ -1,0 +1,57 @@
+package io.horizontalsystems.bankwallet.nav3
+
+import io.github.classgraph.ClassGraph
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.serializerOrNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The nav backstack is persisted in onSaveInstanceState, so every HSPage must
+ * resolve a kotlinx serializer at runtime — a page that doesn't crashes the app
+ * the moment it is backgrounded with that page on the stack. This scans all
+ * modules on the app classpath and verifies the exact lookup NavKeySerializer
+ * performs, which also catches serializable pages with unserializable
+ * property types.
+ */
+class NavPagesSerializableTest {
+
+    @OptIn(InternalSerializationApi::class)
+    @Test
+    fun allNavPagesHaveSerializers() {
+        val problems = mutableListOf<String>()
+
+        ClassGraph()
+            .enableClassInfo()
+            .acceptPackages("io.horizontalsystems")
+            .scan()
+            .use { scan ->
+                val subclasses = scan.getSubclasses("io.horizontalsystems.walletkit.modules.nav3.HSPage")
+                assertTrue("HSPage subclass scan found nothing — scan setup is broken", subclasses.isNotEmpty())
+
+                for (info in subclasses) {
+                    if (info.isAbstract) continue
+                    val problem = try {
+                        val serializer = info.loadClass().kotlin.serializerOrNull()
+                        if (serializer == null) {
+                            "missing @Serializable"
+                        } else {
+                            serializer.descriptor // force child serializer resolution
+                            null
+                        }
+                    } catch (e: Throwable) {
+                        e.message ?: e.javaClass.simpleName
+                    }
+                    if (problem != null) {
+                        problems.add("${info.name}: $problem")
+                    }
+                }
+            }
+
+        assertTrue(
+            "Nav pages that cannot be serialized (would crash on backgrounding):\n" +
+                problems.joinToString("\n"),
+            problems.isEmpty()
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -110,6 +110,7 @@ billing = "9.0.0"
 
 # Testing
 junit = "4.13.2"
+classgraph = "4.8.181"
 junitExt = "1.3.0"
 archCoreTesting = "2.2.0"
 mockito = "5.23.0"
@@ -282,6 +283,7 @@ androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", versio
 
 # Testing
 junit = { module = "junit:junit", version.ref = "junit" }
+classgraph = { module = "io.github.classgraph:classgraph", version.ref = "classgraph" }
 junit-ext = { module = "androidx.test.ext:junit", version.ref = "junitExt" }
 arch-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "archCoreTesting" }
 mockito = { module = "org.mockito:mockito-core", version.ref = "mockito" }

--- a/walletkit-chain-bitcoin/src/main/java/io/horizontalsystems/walletkit/modules/send/bitcoin/SendBitcoinScreen.kt
+++ b/walletkit-chain-bitcoin/src/main/java/io/horizontalsystems/walletkit/modules/send/bitcoin/SendBitcoinScreen.kt
@@ -72,6 +72,7 @@ data object SendBtcAdvancedSettingsPage : HSPage() {
     }
 }
 
+@Serializable
 data object TransactionInputsSortInfoPage : HSPage() {
     @Composable
     override fun GetContent(navigation: HSNavigation) {
@@ -79,6 +80,7 @@ data object TransactionInputsSortInfoPage : HSPage() {
     }
 }
 
+@Serializable
 data object UtxoExpertModePage : HSPage() {
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit-chain-monero/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroScreen.kt
+++ b/walletkit-chain-monero/src/main/java/io/horizontalsystems/walletkit/modules/send/monero/SendMoneroScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.horizontalsystems.walletkit.R
+import kotlinx.serialization.Serializable
 import io.horizontalsystems.walletkit.core.AdapterState
 import io.horizontalsystems.walletkit.core.providers.Translator
 import io.horizontalsystems.walletkit.modules.address.AddressParserModule
@@ -47,6 +48,7 @@ import io.horizontalsystems.walletkit.uiv3.components.HSScaffold
 import java.math.BigDecimal
 import kotlin.reflect.KClass
 
+@Serializable
 data object SendMoneroAdvancedSettingsPage : HSPage() {
     @Composable
     override fun GetContent(navigation: HSNavigation) {
@@ -56,6 +58,7 @@ data object SendMoneroAdvancedSettingsPage : HSPage() {
     }
 }
 
+@Serializable
 data object MoneroUtxoExpertModePage : HSPage() {
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/HSNavigation.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/HSNavigation.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation3.runtime.NavBackStack
+import io.horizontalsystems.walletkit.BuildConfig
 import io.horizontalsystems.walletkit.core.App
 import io.horizontalsystems.walletkit.core.NavigationType
 import io.horizontalsystems.walletkit.core.stats.StatEvent
@@ -17,6 +18,8 @@ import io.horizontalsystems.walletkit.modules.settings.terms.TermsPage
 import io.horizontalsystems.walletkit.modules.usersubscription.BuySubscriptionHavHostPage
 import io.horizontalsystems.subscriptions.core.IPaidAction
 import io.horizontalsystems.subscriptions.core.UserSubscriptionManager
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.serializerOrNull
 import java.util.UUID
 import kotlin.reflect.KClass
 
@@ -24,18 +27,18 @@ class HSNavigation(val backStack: NavBackStack<HSPage>) {
 
     fun slideFromRight(screen: HSPage) {
         screen.navType = NavigationType.SlideFromRight
-        backStack.add(screen)
+        push(screen)
     }
 
     fun slideFromRightForResult(screen: HSPage, resultKey: String) {
         screen.resultKey = resultKey
         screen.navType = NavigationType.SlideFromRight
-        backStack.add(screen)
+        push(screen)
     }
 
     fun slideFromBottom(screen: HSPage) {
         screen.navType = NavigationType.SlideFromBottom
-        backStack.add(screen)
+        push(screen)
     }
 
     fun removeLastOrNull() {
@@ -87,7 +90,24 @@ class HSNavigation(val backStack: NavBackStack<HSPage>) {
     }
 
     fun add(element: HSPage): Boolean {
-        return backStack.add(element)
+        return push(element)
+    }
+
+    private fun push(screen: HSPage): Boolean {
+        verifyPageSerializable(screen)
+        return backStack.add(screen)
+    }
+
+    // The backstack is persisted in onSaveInstanceState; a page whose class is
+    // not @Serializable crashes the app as soon as it goes to background. Fail
+    // fast in debug builds so the mistake is caught when the screen is opened.
+    @OptIn(InternalSerializationApi::class)
+    private fun verifyPageSerializable(screen: HSPage) {
+        if (!BuildConfig.DEBUG) return
+        checkNotNull(screen::class.serializerOrNull()) {
+            "${screen::class.qualifiedName} must be @Serializable — " +
+                "every HSPage is persisted with the nav backstack"
+        }
     }
 
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/receive/ReceiveChooseCoinPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/receive/ReceiveChooseCoinPage.kt
@@ -81,6 +81,7 @@ data object BchAddressFormatPage : HSPage() {
     }
 }
 
+@Serializable
 data object DerivationSelectPage : HSPage() {
     @Composable
     override fun GetContent(navigation: HSNavigation) {
@@ -105,6 +106,7 @@ data object DerivationSelectPage : HSPage() {
     }
 }
 
+@Serializable
 data object NetworkSelectPage : HSPage() {
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/SendPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/send/SendPage.kt
@@ -35,6 +35,15 @@ data class SendPage(val input: Input) : HSPage() {
         val amount = input.amount
         val memo = input.memo
 
+        // Every chain branch below builds a factory that throws when the wallet
+        // has no adapter. After process death this page can compose before
+        // AdapterManager has recreated adapters — leave the restored flow
+        // instead of crashing.
+        if (App.adapterManager.getAdapterForWallet<Any>(wallet) == null) {
+            navigation.removeLastOrNull()
+            return
+        }
+
         val amountInputModeViewModel = viewModel<AmountInputModeViewModel>(
             factory = AmountInputModeModule.Factory(wallet.coin.uid)
         )


### PR DESCRIPTION
Adds missing Serializable annotations to nav pages (with a debug-time check and a unit test that keep future pages covered), and makes a restored send screen leave gracefully when wallet adapters are not ready yet.

Closes #9562

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented send screens from crashing when wallet adapters are temporarily unavailable after process restoration.
  - Added debug-time validation to catch navigation pages missing serialization support.

- **Improvements**
  - Added serialization support for Monero send settings, Monero UTXO expert mode, and receive flow selection pages.
  - Added automated checks to verify navigation pages can be serialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->