### PR TITLE
Keep memo input enabled under Private Send

### DIFF
--- a/translation_snapshot.json
+++ b/translation_snapshot.json
@@ -980,7 +980,7 @@
     "PrivateSend_Fee": "Private send fee",
     "PrivateSend_Fee_Info": "This fee covers the cost of processing your transaction privately. It is charged in addition to the network fee and depends on the amount you send.",
     "PrivateSend_Info_Description": "Private Send routes your transaction through a confidential intermediary, hiding the public link between your address and the recipient. Both transactions remain visible on chain, but they are not directly connected to each other.",
-    "PrivateSend_NotAvailable": "Not available when Private Send is on.",
+    "PrivateSend_NotAvailable": "Memo is not available when Private Send is on.",
     "PrivateSend_ReservedAmount": "Reserved amount",
     "PrivateSend_ReservedAmount_Info": "An additional amount is temporarily reserved to cover possible price changes while your transaction is processed. Any unused part is returned to your wallet in a separate transaction after the send completes.",
     "PrivateSend_Toggle_Title": "Private Send",

--- a/walletkit-chain-bitcoin/src/main/java/io/horizontalsystems/walletkit/modules/send/bitcoin/SendBitcoinScreen.kt
+++ b/walletkit-chain-bitcoin/src/main/java/io/horizontalsystems/walletkit/modules/send/bitcoin/SendBitcoinScreen.kt
@@ -209,13 +209,16 @@ fun SendBitcoinScreen(
             }
 
             VSpacer(16.dp)
-            // Stays visible but refuses input under Private send: the deposit's memo slot
-            // belongs to the provider's crediting identifier, so a user memo cannot travel.
+            // Stays editable under Private send but warns that the memo cannot travel:
+            // the deposit's memo slot belongs to the provider's crediting identifier.
             HSMemoInput(
                 maxLength = 120,
                 visibility = MemoVisibility.Public,
-                enabled = !privateSendViewModel.isEnabled,
-                disabledCaution = stringResource(R.string.PrivateSend_NotAvailable),
+                warningCaution = if (privateSendViewModel.isEnabled) {
+                    stringResource(R.string.PrivateSend_NotAvailable)
+                } else {
+                    null
+                },
             ) {
                 viewModel.onEnterMemo(it)
             }

--- a/walletkit-chain-stellar/src/main/java/io/horizontalsystems/walletkit/modules/send/stellar/SendStellarScreen.kt
+++ b/walletkit-chain-stellar/src/main/java/io/horizontalsystems/walletkit/modules/send/stellar/SendStellarScreen.kt
@@ -119,13 +119,16 @@ fun SendStellarScreen(
         }
 
         VSpacer(16.dp)
-        // Stays visible but refuses input under Private send: the deposit's memo slot
-        // belongs to the provider's crediting identifier, so a user memo cannot travel.
+        // Stays editable under Private send but warns that the memo cannot travel:
+        // the deposit's memo slot belongs to the provider's crediting identifier.
         HSMemoInput(
             maxLength = 120,
             visibility = MemoVisibility.Public,
-            enabled = !privateSendViewModel.isEnabled,
-            disabledCaution = stringResource(R.string.PrivateSend_NotAvailable),
+            warningCaution = if (privateSendViewModel.isEnabled) {
+                stringResource(R.string.PrivateSend_NotAvailable)
+            } else {
+                null
+            },
         ) {
             viewModel.onEnterMemo(it)
         }

--- a/walletkit-chain-thorchain/src/main/java/io/horizontalsystems/walletkit/modules/send/thorchain/SendThorchainScreen.kt
+++ b/walletkit-chain-thorchain/src/main/java/io/horizontalsystems/walletkit/modules/send/thorchain/SendThorchainScreen.kt
@@ -120,14 +120,17 @@ fun SendThorchainScreen(
         }
 
         VSpacer(16.dp)
-        // Stays visible but refuses input under Private send: the deposit's memo slot
-        // belongs to the provider's crediting identifier, so a user memo cannot travel.
+        // Stays editable under Private send but warns that the memo cannot travel:
+        // the deposit's memo slot belongs to the provider's crediting identifier.
         HSMemoInput(
             maxLength = 250,
             memo = memo,
             visibility = MemoVisibility.Public,
-            enabled = !privateSendViewModel.isEnabled,
-            disabledCaution = stringResource(R.string.PrivateSend_NotAvailable),
+            warningCaution = if (privateSendViewModel.isEnabled) {
+                stringResource(R.string.PrivateSend_NotAvailable)
+            } else {
+                null
+            },
         ) {
             viewModel.onEnterMemo(it)
         }

--- a/walletkit-chain-ton/src/main/java/io/horizontalsystems/walletkit/modules/send/ton/SendTonScreen.kt
+++ b/walletkit-chain-ton/src/main/java/io/horizontalsystems/walletkit/modules/send/ton/SendTonScreen.kt
@@ -120,13 +120,16 @@ fun SendTonScreen(
         }
 
         VSpacer(16.dp)
-        // Stays visible but refuses input under Private send: the deposit's memo slot
-        // belongs to the provider's crediting identifier, so a user memo cannot travel.
+        // Stays editable under Private send but warns that the memo cannot travel:
+        // the deposit's memo slot belongs to the provider's crediting identifier.
         HSMemoInput(
             maxLength = 120,
             visibility = MemoVisibility.Public,
-            enabled = !privateSendViewModel.isEnabled,
-            disabledCaution = stringResource(R.string.PrivateSend_NotAvailable),
+            warningCaution = if (privateSendViewModel.isEnabled) {
+                stringResource(R.string.PrivateSend_NotAvailable)
+            } else {
+                null
+            },
         ) {
             viewModel.onEnterMemo(it)
         }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/memo/HSMemoInput.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/memo/HSMemoInput.kt
@@ -40,21 +40,17 @@ fun HSMemoInput(
     disabledCaution: String? = null,
     onValueChange: (String) -> Unit
 ) {
-    val state = when {
-        !enabled -> disabledCaution?.let { DataState.Error(Exception(it)) }
+    val state = if (!enabled) disabledCaution?.let { DataState.Error(Exception(it)) }
+    else null
 
-        visibility == MemoVisibility.Public -> DataState.Error(
-            FormsInputStateWarning(stringResource(R.string.Send_Memo_PublicWarning))
-        )
-
-        else -> null
-    }
-
-    val infoText = when {
-        !enabled -> null
-        visibility == MemoVisibility.Encrypted -> stringResource(R.string.Send_Memo_EncryptedInfo)
-        visibility == MemoVisibility.Offchain -> stringResource(R.string.Send_Memo_OffchainInfo)
-        else -> null
+    val infoText = if (enabled) {
+        when (visibility) {
+            MemoVisibility.Encrypted -> stringResource(R.string.Send_Memo_EncryptedInfo)
+            MemoVisibility.Offchain -> stringResource(R.string.Send_Memo_OffchainInfo)
+            MemoVisibility.Public -> stringResource(R.string.Send_Memo_PublicWarning)
+        }
+    } else {
+        null
     }
 
     Column(modifier = Modifier.padding(horizontal = 16.dp)) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/memo/HSMemoInput.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/memo/HSMemoInput.kt
@@ -3,6 +3,10 @@ package io.horizontalsystems.walletkit.modules.memo
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -33,17 +37,20 @@ fun HSMemoInput(
     maxLength: Int,
     memo: String? = null,
     visibility: MemoVisibility = MemoVisibility.Public,
-    enabled: Boolean = true,
-    // Rendered as the input's (red) caution while [enabled] is false — the flow's
-    // explanation of why a memo is not accepted right now. Any already-typed text stays
-    // visible, greyed, and comes back editable when the input is re-enabled.
-    disabledCaution: String? = null,
+    // Rendered as the input's (yellow) warning while there is typed text — the flow's
+    // explanation of why the memo will not be attached to the transaction right now.
+    warningCaution: String? = null,
     onValueChange: (String) -> Unit
 ) {
-    val state = if (!enabled) disabledCaution?.let { DataState.Error(Exception(it)) }
-    else null
+    var text by remember { mutableStateOf(memo ?: "") }
 
-    val infoText = if (enabled) {
+    val state = if (warningCaution != null && text.isNotEmpty()) {
+        DataState.Error(FormsInputStateWarning(warningCaution))
+    } else {
+        null
+    }
+
+    val infoText = if (state == null) {
         when (visibility) {
             MemoVisibility.Encrypted -> stringResource(R.string.Send_Memo_EncryptedInfo)
             MemoVisibility.Offchain -> stringResource(R.string.Send_Memo_OffchainInfo)
@@ -57,16 +64,18 @@ fun HSMemoInput(
         FormsInput(
             hint = stringResource(R.string.Send_DialogMemoHint),
             initial = memo,
-            enabled = enabled,
             hintColor = ComposeAppTheme.colors.andy,
             hintStyle = ComposeAppTheme.typography.bodyItalic,
-            textColor = if (enabled) ComposeAppTheme.colors.leah else ComposeAppTheme.colors.andy,
+            textColor = ComposeAppTheme.colors.leah,
             textStyle = ComposeAppTheme.typography.bodyItalic,
             pasteEnabled = false,
             singleLine = true,
             maxLength = maxLength,
             state = state,
-            onValueChange = onValueChange
+            onValueChange = {
+                text = it
+                onValueChange(it)
+            }
         )
 
         infoText?.let {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/ui/compose/components/Forms.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/ui/compose/components/Forms.kt
@@ -243,7 +243,7 @@ fun FormsInput(
 
         state?.errorOrNull?.localizedMessage?.let {
             Text(
-                modifier = Modifier.padding(start = 8.dp, top = 8.dp, end = 8.dp),
+                modifier = Modifier.padding(start = 16.dp, top = 8.dp, end = 16.dp),
                 text = it,
                 color = cautionColor,
                 style = ComposeAppTheme.typography.caption

--- a/walletkit/src/main/res/values-de/strings.xml
+++ b/walletkit/src/main/res/values-de/strings.xml
@@ -1869,7 +1869,7 @@
     <string name="PrivateSend_Caution_TokenUnsupported">Private Send ist für diesen Token nicht mehr verfügbar.</string>
     <string name="PrivateSend_Caution_AttachmentUnsupported">Diese private Route erfordert ein Transaktions-Tag, das dieses Wallet nicht anhängen kann. Private Send ist für diesen Token nicht verfügbar.</string>
     <string name="PrivateSend_Caution_BufferUnknown">Die angezeigte Gebühr ist eine Obergrenze; die endgültigen Kosten können niedriger sein.</string>
-    <string name="PrivateSend_NotAvailable">Notiz ist nicht verfügbar, wenn Private Send aktiviert ist.</string>
+    <string name="PrivateSend_NotAvailable">Memo ist nicht verfügbar, wenn Private Send aktiviert ist.</string>
     <string name="NetworkSettings_AutoSelect">Automatische Auswahl</string>
     <string name="NetworkSettings_Unreachable">Nicht erreichbar</string>
     <string name="NetworkSettings_Latency">%d ms</string>

--- a/walletkit/src/main/res/values-de/strings.xml
+++ b/walletkit/src/main/res/values-de/strings.xml
@@ -1869,7 +1869,7 @@
     <string name="PrivateSend_Caution_TokenUnsupported">Private Send ist für diesen Token nicht mehr verfügbar.</string>
     <string name="PrivateSend_Caution_AttachmentUnsupported">Diese private Route erfordert ein Transaktions-Tag, das dieses Wallet nicht anhängen kann. Private Send ist für diesen Token nicht verfügbar.</string>
     <string name="PrivateSend_Caution_BufferUnknown">Die angezeigte Gebühr ist eine Obergrenze; die endgültigen Kosten können niedriger sein.</string>
-    <string name="PrivateSend_NotAvailable">Nicht verfügbar, wenn Private Send aktiviert ist.</string>
+    <string name="PrivateSend_NotAvailable">Notiz ist nicht verfügbar, wenn Private Send aktiviert ist.</string>
     <string name="NetworkSettings_AutoSelect">Automatische Auswahl</string>
     <string name="NetworkSettings_Unreachable">Nicht erreichbar</string>
     <string name="NetworkSettings_Latency">%d ms</string>

--- a/walletkit/src/main/res/values-es/strings.xml
+++ b/walletkit/src/main/res/values-es/strings.xml
@@ -1860,7 +1860,7 @@
     <string name="PrivateSend_Caution_TokenUnsupported">El envío privado ya no está disponible para este token.</string>
     <string name="PrivateSend_Caution_AttachmentUnsupported">Esta ruta privada requiere una etiqueta de transacción que esta billetera no puede adjuntar. Private Send no está disponible para este token.</string>
     <string name="PrivateSend_Caution_BufferUnknown">La tarifa mostrada es una estimación superior; el costo final puede ser menor.</string>
-    <string name="PrivateSend_NotAvailable">El memo no está disponible cuando Private Send está activado.</string>
+    <string name="PrivateSend_NotAvailable">La nota no está disponible cuando Private Send está activado.</string>
     <string name="NetworkSettings_AutoSelect">Selección automática</string>
     <string name="NetworkSettings_Unreachable">No disponible</string>
     <string name="NetworkSettings_Latency">%d ms</string>

--- a/walletkit/src/main/res/values-es/strings.xml
+++ b/walletkit/src/main/res/values-es/strings.xml
@@ -1860,7 +1860,7 @@
     <string name="PrivateSend_Caution_TokenUnsupported">El envío privado ya no está disponible para este token.</string>
     <string name="PrivateSend_Caution_AttachmentUnsupported">Esta ruta privada requiere una etiqueta de transacción que esta billetera no puede adjuntar. Private Send no está disponible para este token.</string>
     <string name="PrivateSend_Caution_BufferUnknown">La tarifa mostrada es una estimación superior; el costo final puede ser menor.</string>
-    <string name="PrivateSend_NotAvailable">No disponible cuando Private Send está activado.</string>
+    <string name="PrivateSend_NotAvailable">El memo no está disponible cuando Private Send está activado.</string>
     <string name="NetworkSettings_AutoSelect">Selección automática</string>
     <string name="NetworkSettings_Unreachable">No disponible</string>
     <string name="NetworkSettings_Latency">%d ms</string>

--- a/walletkit/src/main/res/values-fa/strings.xml
+++ b/walletkit/src/main/res/values-fa/strings.xml
@@ -793,7 +793,7 @@
     <string name="PrivateSend_Caution_TokenUnsupported">ارسال خصوصی دیگر برای این توکن در دسترس نیست.</string>
     <string name="PrivateSend_Caution_AttachmentUnsupported">این مسیر خصوصی به برچسب تراکنشی نیاز دارد که این کیف پول نمی‌تواند آن را ضمیمه کند. Private Send برای این توکن در دسترس نیست.</string>
     <string name="PrivateSend_Caution_BufferUnknown">کارمزد نمایش‌داده شده تخمین بالایی است؛ هزینه نهایی می‌تواند کمتر باشد.</string>
-    <string name="PrivateSend_NotAvailable">وقتی Private Send روشن است در دسترس نیست.</string>
+    <string name="PrivateSend_NotAvailable">وقتی Private Send روشن است، یادداشت در دسترس نیست.</string>
     <string name="NetworkSettings_AutoSelect">انتخاب خودکار</string>
     <string name="NetworkSettings_Unreachable">غیرقابل دسترس</string>
     <string name="NetworkSettings_Latency">%d ms</string>

--- a/walletkit/src/main/res/values-fa/strings.xml
+++ b/walletkit/src/main/res/values-fa/strings.xml
@@ -793,7 +793,7 @@
     <string name="PrivateSend_Caution_TokenUnsupported">ارسال خصوصی دیگر برای این توکن در دسترس نیست.</string>
     <string name="PrivateSend_Caution_AttachmentUnsupported">این مسیر خصوصی به برچسب تراکنشی نیاز دارد که این کیف پول نمی‌تواند آن را ضمیمه کند. Private Send برای این توکن در دسترس نیست.</string>
     <string name="PrivateSend_Caution_BufferUnknown">کارمزد نمایش‌داده شده تخمین بالایی است؛ هزینه نهایی می‌تواند کمتر باشد.</string>
-    <string name="PrivateSend_NotAvailable">وقتی Private Send روشن است، یادداشت در دسترس نیست.</string>
+    <string name="PrivateSend_NotAvailable">یادداشت در دسترس نیست زمانی که Private Send فعال است.</string>
     <string name="NetworkSettings_AutoSelect">انتخاب خودکار</string>
     <string name="NetworkSettings_Unreachable">غیرقابل دسترس</string>
     <string name="NetworkSettings_Latency">%d ms</string>

--- a/walletkit/src/main/res/values-fr/strings.xml
+++ b/walletkit/src/main/res/values-fr/strings.xml
@@ -1862,7 +1862,7 @@
     <string name="PrivateSend_Caution_TokenUnsupported">L\'envoi privé n\'est plus disponible pour ce token.</string>
     <string name="PrivateSend_Caution_AttachmentUnsupported">Cette route privée nécessite une étiquette de transaction que ce portefeuille ne peut pas joindre. Private Send n\'est pas disponible pour ce token.</string>
     <string name="PrivateSend_Caution_BufferUnknown">Les frais affichés sont une estimation supérieure; le coût final peut être inférieur.</string>
-    <string name="PrivateSend_NotAvailable">Non disponible lorsque Private Send est activé.</string>
+    <string name="PrivateSend_NotAvailable">Le mémo n\'est pas disponible lorsque Private Send est activé.</string>
     <string name="NetworkSettings_AutoSelect">Sélection automatique</string>
     <string name="NetworkSettings_Unreachable">Inaccessible</string>
     <string name="NetworkSettings_Latency">%d ms</string>

--- a/walletkit/src/main/res/values-fr/strings.xml
+++ b/walletkit/src/main/res/values-fr/strings.xml
@@ -1862,7 +1862,7 @@
     <string name="PrivateSend_Caution_TokenUnsupported">L\'envoi privé n\'est plus disponible pour ce token.</string>
     <string name="PrivateSend_Caution_AttachmentUnsupported">Cette route privée nécessite une étiquette de transaction que ce portefeuille ne peut pas joindre. Private Send n\'est pas disponible pour ce token.</string>
     <string name="PrivateSend_Caution_BufferUnknown">Les frais affichés sont une estimation supérieure; le coût final peut être inférieur.</string>
-    <string name="PrivateSend_NotAvailable">Le mémo n\'est pas disponible lorsque Private Send est activé.</string>
+    <string name="PrivateSend_NotAvailable">Le mémo n\'est pas disponible quand Private Send est activé.</string>
     <string name="NetworkSettings_AutoSelect">Sélection automatique</string>
     <string name="NetworkSettings_Unreachable">Inaccessible</string>
     <string name="NetworkSettings_Latency">%d ms</string>

--- a/walletkit/src/main/res/values-ko/strings.xml
+++ b/walletkit/src/main/res/values-ko/strings.xml
@@ -1861,7 +1861,7 @@
     <string name="PrivateSend_Caution_TokenUnsupported">이 토큰에 대해 프라이빗 송금을 더 이상 사용할 수 없습니다.</string>
     <string name="PrivateSend_Caution_AttachmentUnsupported">이 프라이빗 경로는 이 지갑이 첨부할 수 없는 거래 태그가 필요합니다. Private Send는 이 토큰에 대해 사용할 수 없습니다.</string>
     <string name="PrivateSend_Caution_BufferUnknown">표시된 수수료는 상한 추정치입니다. 최종 비용은 더 낮을 수 있습니다.</string>
-    <string name="PrivateSend_NotAvailable">Private Send가 켜져 있을 때는 사용할 수 없습니다.</string>
+    <string name="PrivateSend_NotAvailable">Private Send가 켜져 있을 때는 메모를 사용할 수 없습니다.</string>
     <string name="NetworkSettings_AutoSelect">자동 선택</string>
     <string name="NetworkSettings_Unreachable">연결 불가</string>
     <string name="NetworkSettings_Latency">%d ms</string>

--- a/walletkit/src/main/res/values-pt-rBR/strings.xml
+++ b/walletkit/src/main/res/values-pt-rBR/strings.xml
@@ -1865,7 +1865,7 @@
     <string name="PrivateSend_Caution_TokenUnsupported">O envio privado não está mais disponível para este token.</string>
     <string name="PrivateSend_Caution_AttachmentUnsupported">Esta rota privada requer uma tag de transação que esta carteira não consegue anexar. Private Send não está disponível para este token.</string>
     <string name="PrivateSend_Caution_BufferUnknown">A taxa exibida é uma estimativa superior; o custo final pode ser menor.</string>
-    <string name="PrivateSend_NotAvailable">O memorando não está disponível quando Private Send está ativado.</string>
+    <string name="PrivateSend_NotAvailable">Memorando não está disponível quando Private Send está ativado.</string>
     <string name="NetworkSettings_AutoSelect">Seleção automática</string>
     <string name="NetworkSettings_Unreachable">Inacessível</string>
     <string name="NetworkSettings_Latency">%d ms</string>

--- a/walletkit/src/main/res/values-pt-rBR/strings.xml
+++ b/walletkit/src/main/res/values-pt-rBR/strings.xml
@@ -1865,7 +1865,7 @@
     <string name="PrivateSend_Caution_TokenUnsupported">O envio privado não está mais disponível para este token.</string>
     <string name="PrivateSend_Caution_AttachmentUnsupported">Esta rota privada requer uma tag de transação que esta carteira não consegue anexar. Private Send não está disponível para este token.</string>
     <string name="PrivateSend_Caution_BufferUnknown">A taxa exibida é uma estimativa superior; o custo final pode ser menor.</string>
-    <string name="PrivateSend_NotAvailable">Não disponível quando Private Send está ativado.</string>
+    <string name="PrivateSend_NotAvailable">O memorando não está disponível quando Private Send está ativado.</string>
     <string name="NetworkSettings_AutoSelect">Seleção automática</string>
     <string name="NetworkSettings_Unreachable">Inacessível</string>
     <string name="NetworkSettings_Latency">%d ms</string>

--- a/walletkit/src/main/res/values-ru/strings.xml
+++ b/walletkit/src/main/res/values-ru/strings.xml
@@ -1867,7 +1867,7 @@
     <string name="PrivateSend_Caution_TokenUnsupported">Приватный перевод больше не доступен для этого токена.</string>
     <string name="PrivateSend_Caution_AttachmentUnsupported">Этот приватный маршрут требует тег транзакции, который это хранилище не может присоединить. Private Send недоступен для этого токена.</string>
     <string name="PrivateSend_Caution_BufferUnknown">Показанная комиссия является верхней оценкой; финальная стоимость может быть ниже.</string>
-    <string name="PrivateSend_NotAvailable">Меморандум недоступен при включенном Private Send.</string>
+    <string name="PrivateSend_NotAvailable">Заметка недоступна, когда включена функция Private Send.</string>
     <string name="NetworkSettings_AutoSelect">Автоматический выбор</string>
     <string name="NetworkSettings_Unreachable">Недоступно</string>
     <string name="NetworkSettings_Latency">%d ms</string>

--- a/walletkit/src/main/res/values-ru/strings.xml
+++ b/walletkit/src/main/res/values-ru/strings.xml
@@ -1867,7 +1867,7 @@
     <string name="PrivateSend_Caution_TokenUnsupported">Приватный перевод больше не доступен для этого токена.</string>
     <string name="PrivateSend_Caution_AttachmentUnsupported">Этот приватный маршрут требует тег транзакции, который это хранилище не может присоединить. Private Send недоступен для этого токена.</string>
     <string name="PrivateSend_Caution_BufferUnknown">Показанная комиссия является верхней оценкой; финальная стоимость может быть ниже.</string>
-    <string name="PrivateSend_NotAvailable">Недоступно при включенном Private Send.</string>
+    <string name="PrivateSend_NotAvailable">Меморандум недоступен при включенном Private Send.</string>
     <string name="NetworkSettings_AutoSelect">Автоматический выбор</string>
     <string name="NetworkSettings_Unreachable">Недоступно</string>
     <string name="NetworkSettings_Latency">%d ms</string>

--- a/walletkit/src/main/res/values-tr/strings.xml
+++ b/walletkit/src/main/res/values-tr/strings.xml
@@ -1861,7 +1861,7 @@
     <string name="PrivateSend_Caution_TokenUnsupported">Özel gönderim artık bu token için kullanılamaz.</string>
     <string name="PrivateSend_Caution_AttachmentUnsupported">Bu özel rota, bu cüzdanın ekleyemediği bir işlem etiketi gerektirir. Private Send bu token için kullanılamaz.</string>
     <string name="PrivateSend_Caution_BufferUnknown">Gösterilen ücret bir üst tahmindir; nihai maliyet daha düşük olabilir.</string>
-    <string name="PrivateSend_NotAvailable">Private Send açıkken kullanılamaz.</string>
+    <string name="PrivateSend_NotAvailable">Private Send açıkken not kullanılamaz.</string>
     <string name="NetworkSettings_AutoSelect">Otomatik Seç</string>
     <string name="NetworkSettings_Unreachable">Erişilemiyor</string>
     <string name="NetworkSettings_Latency">%d ms</string>

--- a/walletkit/src/main/res/values-zh/strings.xml
+++ b/walletkit/src/main/res/values-zh/strings.xml
@@ -1860,7 +1860,7 @@
     <string name="PrivateSend_Caution_TokenUnsupported">此代币不再支持私密发送。</string>
     <string name="PrivateSend_Caution_AttachmentUnsupported">此私人路由需要此钱包无法附加的交易标签。此代币不支持 Private Send。</string>
     <string name="PrivateSend_Caution_BufferUnknown">显示的费用是上限估算;最终成本可能更低。</string>
-    <string name="PrivateSend_NotAvailable">启用 Private Send 时无法使用备忘录。</string>
+    <string name="PrivateSend_NotAvailable">当启用隐私发送时，备忘录不可用。</string>
     <string name="NetworkSettings_AutoSelect">自动选择</string>
     <string name="NetworkSettings_Unreachable">无法访问</string>
     <string name="NetworkSettings_Latency">%d ms</string>

--- a/walletkit/src/main/res/values-zh/strings.xml
+++ b/walletkit/src/main/res/values-zh/strings.xml
@@ -1860,7 +1860,7 @@
     <string name="PrivateSend_Caution_TokenUnsupported">此代币不再支持私密发送。</string>
     <string name="PrivateSend_Caution_AttachmentUnsupported">此私人路由需要此钱包无法附加的交易标签。此代币不支持 Private Send。</string>
     <string name="PrivateSend_Caution_BufferUnknown">显示的费用是上限估算;最终成本可能更低。</string>
-    <string name="PrivateSend_NotAvailable">启用 Private Send 时不可用。</string>
+    <string name="PrivateSend_NotAvailable">启用 Private Send 时无法使用备忘录。</string>
     <string name="NetworkSettings_AutoSelect">自动选择</string>
     <string name="NetworkSettings_Unreachable">无法访问</string>
     <string name="NetworkSettings_Latency">%d ms</string>

--- a/walletkit/src/main/res/values/strings.xml
+++ b/walletkit/src/main/res/values/strings.xml
@@ -619,7 +619,7 @@
     <string name="PrivateSend_Caution_TokenUnsupported">Private send is no longer available for this token.</string>
     <string name="PrivateSend_Caution_AttachmentUnsupported">This private route requires a transaction tag this wallet can\'t attach. Private send is unavailable for this token.</string>
     <string name="PrivateSend_Caution_BufferUnknown">The fee shown is an upper estimate; the final cost may be lower.</string>
-    <string name="PrivateSend_NotAvailable">Not available when Private Send is on.</string>
+    <string name="PrivateSend_NotAvailable">Memo is not available when Private Send is on.</string>
 
     <!-- Send Evm Settings -->
 


### PR DESCRIPTION
Keep the memo input always enabled; while Private Send is on and a memo is typed, show a warning that the memo will not be attached.

Part of #9545.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Memo fields remain editable while Private Send is enabled.
  - A clear warning appears when memo text is entered with Private Send active.
  - Informational memo guidance is shown only when applicable.

- **Improvements**
  - Updated messaging clarifies that memos are unavailable with Private Send.
  - Improved alignment and spacing for form validation messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->