### PR TITLE
Deduplicate the private send balance caution

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/privatesend/PrivateSendConfirmViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/privatesend/PrivateSendConfirmViewModel.kt
@@ -150,14 +150,13 @@ class PrivateSendConfirmViewModel(
     }
 
     private fun cautions(): List<CautionViewItem> {
-        val cautions = sendTransactionState.cautions.toMutableList()
-
-        // The service's own rejection names no amount, and under exact output the figure the
-        // user needs is the DEPOSIT plus its network fee, not what they entered — without
-        // this the refusal is baffling (MAX always fails here by design).
+        // Replaces the service's own rejection instead of adding to it: the service names no
+        // amount, and under exact output the figure the user needs is the DEPOSIT plus its
+        // network fee, not what they entered — without this the refusal is baffling (MAX always
+        // fails here by design). Two messages for one shortfall read as two problems.
         order?.let { order ->
             if (insufficientBalance(order)) {
-                cautions.add(
+                return listOf(
                     CautionViewItem(
                         title = App.instance.getString(io.horizontalsystems.walletkit.R.string.PrivateSend_Caution_Title),
                         text = App.instance.getString(
@@ -170,7 +169,7 @@ class PrivateSendConfirmViewModel(
             }
         }
 
-        return cautions
+        return sendTransactionState.cautions
     }
 
     private fun insufficientBalance(order: PrivateSendOrder): Boolean {


### PR DESCRIPTION
When the deposit exceeds the balance the confirmation showed two errors for the one shortfall: the send service's generic rejection and the private send one. The private send caution now replaces it, since it is the one naming the deposit figure the user has to act on.

Refs #9545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved insufficient-balance messaging during PrivateSend deposits.
  * The relevant warning now appears clearly when the deposit exceeds the available balance, without being combined with unrelated cautions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->