### PR TITLE
Disable UI stats by default

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/stats/StatsManager.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/stats/StatsManager.kt
@@ -54,7 +54,7 @@ class StatsManager(
     private val backgroundManager: BackgroundManager,
 ) {
     private val scope = CoroutineScope(Dispatchers.IO)
-    private var uiStatsEnabled = localStorage.uiStatsEnabled ?: !io.horizontalsystems.walletkit.core.App.appConfigProvider.fdroidBuild
+    private var uiStatsEnabled = localStorage.uiStatsEnabled ?: false
 
     private val _uiStatsEnabledFlow = MutableStateFlow(uiStatsEnabled)
     val uiStatsEnabledFlow = _uiStatsEnabledFlow.asStateFlow()


### PR DESCRIPTION
## Summary
- Change the default for `uiStatsEnabled` in `StatsManager` from "on for non-F-Droid builds" to off
- UI stats are now collected only when the user explicitly opts in

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Statistics features are now disabled by default when no saved preference exists, providing consistent behavior across app builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->