### PR TITLE
Fix private send refresh sticking on the loading spinner

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/privatesend/PrivateSendConfirmViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/privatesend/PrivateSendConfirmViewModel.kt
@@ -199,6 +199,12 @@ class PrivateSendConfirmViewModel(
         initialLoading = true
         emitState()
 
+        // `initialLoading` only clears when the service's StateFlow emits after the new order
+        // is set, and StateFlow drops a value equal to the current one. A re-estimate of a
+        // like-for-like deposit (same amount, fee and fields) lands on an identical state, so
+        // without a fresh uuid nothing is emitted and the screen spins forever.
+        sendTransactionService.refreshUuid()
+
         commit()
     }
 


### PR DESCRIPTION
After Refresh on the private send confirmation, the screen could stay on the loading spinner forever when the re-estimated deposit produced a state identical to the previous one. Renew the send service uuid on refresh so a new state is always emitted.

Closes #9545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Private Send transaction refresh behavior.
  - Updated transaction estimates now appear reliably, including when values remain unchanged.
  - Loading indicators are cleared correctly after refreshing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->