### PR TITLE
Stop popping to the root screen on incoming deeplink intents

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/Nav3.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/Nav3.kt
@@ -150,11 +150,6 @@ private fun IntentEffect(viewModel: MainActivityViewModel, navigation: HSNavigat
         val consumer = Consumer<Intent> {
             if (!handleWalletConnectDeepLink(it, navigation)) {
                 viewModel.setIntent(it)
-                // The intent is consumed by MainScreen's observer, which only runs while
-                // MainScreen (EntryPage) is composed. If an inner screen (e.g. Receive) is on
-                // top, pop back to the root so the deeplink is processed immediately instead of
-                // waiting until the user manually returns to the main screen.
-                navigation.removeLastUntil(EntryPage::class, false)
             }
         }
         (activity as? ComponentActivity)?.addOnNewIntentListener(consumer)


### PR DESCRIPTION
Tapping the launcher icon delivers a new intent, which popped the back stack to the main screen. Resuming the app now keeps the current screen.

Fixes #9579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of deep links received while viewing an inner screen.
  * Deep links are now processed when you return to the main screen, preserving the current navigation context instead of immediately returning to the root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->