### PR TITLE
Validate the private send commit response

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/privatesend/PrivateSendManager.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/privatesend/PrivateSendManager.kt
@@ -164,8 +164,16 @@ class PrivateSendManager(
             throw PrivateSendError.CommitFailed()
         }
 
-        val depositAddress = execution.depositAddress ?: throw PrivateSendError.CommitFailed()
+        // Blank is as unusable as absent: it reaches the deposit build and dies there on address
+        // parsing, with a real order already standing behind it.
+        val depositAddress = execution.depositAddress
+        if (depositAddress.isNullOrBlank()) throw PrivateSendError.CommitFailed()
+
         val depositAmount = execution.amount?.toBigDecimalOrNull() ?: throw PrivateSendError.CommitFailed()
+
+        // The floor check below only sees this when the provider stated one, so a transfer of
+        // nothing has to be refused on its own terms.
+        if (depositAmount <= BigDecimal.ZERO) throw PrivateSendError.CommitFailed()
 
         val minSellAmount = route.minSellAmount
 


### PR DESCRIPTION
A committed order now requires a non-blank deposit address and a deposit amount above zero, so an unusable response is refused at commit instead of reaching the deposit build.

Refs #9545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PrivateSend transaction validation by rejecting blank or whitespace-only deposit addresses.
  * Prevented transactions with zero or negative deposit amounts from being submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->