### PR TITLE
Single insufficient balance message on private send

### DIFF
--- a/translation_snapshot.json
+++ b/translation_snapshot.json
@@ -969,7 +969,6 @@
     "PrivateSend_Caution_BelowMinimum": "Private send requires the recipient to receive at least %s.",
     "PrivateSend_Caution_BufferUnknown": "The fee shown is an upper estimate; the final cost may be lower.",
     "PrivateSend_Caution_ExactOutputUnsupported": "This route can\\'t guarantee an exact received amount.",
-    "PrivateSend_Caution_InsufficientBalance": "This private send needs %s in your wallet, including fees.",
     "PrivateSend_Caution_NetworkError": "Couldn\\'t reach the private send provider. Check your connection and try again.",
     "PrivateSend_Caution_NoRoute": "No private route is available for this token and amount right now.",
     "PrivateSend_Caution_ProviderSuspended": "The private send provider is temporarily unavailable.",

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/privatesend/PrivateSendConfirmViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/privatesend/PrivateSendConfirmViewModel.kt
@@ -3,7 +3,6 @@ package io.horizontalsystems.walletkit.modules.privatesend
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import io.horizontalsystems.walletkit.core.App
-import io.horizontalsystems.walletkit.core.IBalanceAdapter
 import io.horizontalsystems.walletkit.core.ViewModelUiState
 import io.horizontalsystems.walletkit.core.badge
 import io.horizontalsystems.walletkit.core.ethereum.CautionViewItem
@@ -139,7 +138,7 @@ class PrivateSendConfirmViewModel(
             estimatedTime = order?.estimatedTime,
             currency = currency,
             networkFee = sendTransactionState.networkFee,
-            cautions = cautions(),
+            cautions = sendTransactionState.cautions,
             transactionFields = sendTransactionState.fields,
             canSend = order != null && sendTransactionState.sendable && !expired && error == null,
             expired = expired,
@@ -147,38 +146,6 @@ class PrivateSendConfirmViewModel(
             hasNonceSettings = sendTransactionService.hasNonceSettings,
             error = error,
         )
-    }
-
-    private fun cautions(): List<CautionViewItem> {
-        // Replaces the service's own rejection instead of adding to it: the service names no
-        // amount, and under exact output the figure the user needs is the DEPOSIT plus its
-        // network fee, not what they entered — without this the refusal is baffling (MAX always
-        // fails here by design). Two messages for one shortfall read as two problems.
-        order?.let { order ->
-            if (insufficientBalance(order)) {
-                return listOf(
-                    CautionViewItem(
-                        title = App.instance.getString(io.horizontalsystems.walletkit.R.string.PrivateSend_Caution_Title),
-                        text = App.instance.getString(
-                            io.horizontalsystems.walletkit.R.string.PrivateSend_Caution_InsufficientBalance,
-                            io.horizontalsystems.walletkit.entities.CoinValue(token, order.depositAmount).getFormattedFull(),
-                        ),
-                        type = CautionViewItem.Type.Error,
-                    )
-                )
-            }
-        }
-
-        return sendTransactionState.cautions
-    }
-
-    private fun insufficientBalance(order: PrivateSendOrder): Boolean {
-        val available = App.adapterManager
-            .getAdapterForToken<IBalanceAdapter>(token)
-            ?.balanceData?.available
-            ?: return false
-
-        return order.depositAmount > available
     }
 
     /**

--- a/walletkit/src/main/res/values-de/strings.xml
+++ b/walletkit/src/main/res/values-de/strings.xml
@@ -1861,7 +1861,6 @@
     <string name="PrivateSend_Caution_Title">Privater Versand</string>
     <string name="PrivateSend_Caution_BelowMinimum">Der private Versand erfordert, dass der Empfänger mindestens %s erhält.</string>
     <string name="PrivateSend_Caution_AboveMaximum">Der private Versand unterstützt maximal %s.</string>
-    <string name="PrivateSend_Caution_InsufficientBalance">Diese private Überweisung benötigt %s in deiner Wallet, einschließlich Gebühren.</string>
     <string name="PrivateSend_Caution_NoRoute">Es ist derzeit keine private Route für diesen Token und Betrag verfügbar.</string>
     <string name="PrivateSend_Caution_ExactOutputUnsupported">Diese Route kann keinen exakten Empfangsbetrag garantieren.</string>
     <string name="PrivateSend_Caution_ProviderSuspended">Der Private-Send-Anbieter ist vorübergehend nicht verfügbar.</string>

--- a/walletkit/src/main/res/values-es/strings.xml
+++ b/walletkit/src/main/res/values-es/strings.xml
@@ -1852,7 +1852,6 @@
     <string name="PrivateSend_Caution_Title">Envío privado</string>
     <string name="PrivateSend_Caution_BelowMinimum">El envío privado requiere que el destinatario reciba al menos %s.</string>
     <string name="PrivateSend_Caution_AboveMaximum">El envío privado admite como máximo %s.</string>
-    <string name="PrivateSend_Caution_InsufficientBalance">Este envío privado necesita %s en tu billetera, incluidas las comisiones.</string>
     <string name="PrivateSend_Caution_NoRoute">No hay una ruta privada disponible para este token y cantidad en este momento.</string>
     <string name="PrivateSend_Caution_ExactOutputUnsupported">Esta ruta no puede garantizar una cantidad exacta recibida.</string>
     <string name="PrivateSend_Caution_ProviderSuspended">El proveedor de envío privado no está disponible temporalmente.</string>

--- a/walletkit/src/main/res/values-fa/strings.xml
+++ b/walletkit/src/main/res/values-fa/strings.xml
@@ -785,7 +785,6 @@
     <string name="PrivateSend_Caution_Title">ارسال خصوصی</string>
     <string name="PrivateSend_Caution_BelowMinimum">ارسال خصوصی مستلزم دریافت حداقل %s توسط گیرنده است.</string>
     <string name="PrivateSend_Caution_AboveMaximum">ارسال خصوصی حداکثر %s را پشتیبانی می‌کند.</string>
-    <string name="PrivateSend_Caution_InsufficientBalance">این ارسال خصوصی به %s در کیف پول شما نیاز دارد، شامل کارمزد.</string>
     <string name="PrivateSend_Caution_NoRoute">در حال حاضر هیچ مسیر خصوصی برای این توکن و مقدار در دسترس نیست.</string>
     <string name="PrivateSend_Caution_ExactOutputUnsupported">این مسیر نمی‌تواند مقدار دقیق دریافتی را تضمین کند.</string>
     <string name="PrivateSend_Caution_ProviderSuspended">فراهم‌کننده ارسال خصوصی به طور موقت در دسترس نیست.</string>

--- a/walletkit/src/main/res/values-fr/strings.xml
+++ b/walletkit/src/main/res/values-fr/strings.xml
@@ -1854,7 +1854,6 @@
     <string name="PrivateSend_Caution_Title">Envoi privé</string>
     <string name="PrivateSend_Caution_BelowMinimum">L\'envoi privé exige que le destinataire reçoive au moins %s.</string>
     <string name="PrivateSend_Caution_AboveMaximum">L\'envoi privé prend en charge au maximum %s.</string>
-    <string name="PrivateSend_Caution_InsufficientBalance">Cet envoi privé nécessite %s dans votre portefeuille, frais inclus.</string>
     <string name="PrivateSend_Caution_NoRoute">Aucune route privée n\'est actuellement disponible pour ce token et ce montant.</string>
     <string name="PrivateSend_Caution_ExactOutputUnsupported">Cette route ne peut pas garantir un montant exact reçu.</string>
     <string name="PrivateSend_Caution_ProviderSuspended">Le fournisseur d\'envoi privé est temporairement indisponible.</string>

--- a/walletkit/src/main/res/values-ko/strings.xml
+++ b/walletkit/src/main/res/values-ko/strings.xml
@@ -1853,7 +1853,6 @@
     <string name="PrivateSend_Caution_Title">개인 전송</string>
     <string name="PrivateSend_Caution_BelowMinimum">개인 전송을 위해서는 수신자가 최소 %s를 받아야 합니다.</string>
     <string name="PrivateSend_Caution_AboveMaximum">개인 전송은 최대 %s를 지원합니다.</string>
-    <string name="PrivateSend_Caution_InsufficientBalance">이 프라이빗 송금은 수수료를 포함하여 지갑에 %s가 필요합니다.</string>
     <string name="PrivateSend_Caution_NoRoute">현재 이 토큰과 금액에 대한 프라이빗 경로가 없습니다.</string>
     <string name="PrivateSend_Caution_ExactOutputUnsupported">이 경로는 정확한 수취 금액을 보장할 수 없습니다.</string>
     <string name="PrivateSend_Caution_ProviderSuspended">프라이빗 송금 제공자를 일시적으로 사용할 수 없습니다.</string>

--- a/walletkit/src/main/res/values-pt-rBR/strings.xml
+++ b/walletkit/src/main/res/values-pt-rBR/strings.xml
@@ -1857,7 +1857,6 @@
     <string name="PrivateSend_Caution_Title">Envio privado</string>
     <string name="PrivateSend_Caution_BelowMinimum">O envio privado requer que o destinatário receba pelo menos %s.</string>
     <string name="PrivateSend_Caution_AboveMaximum">O envio privado suporta no máximo %s.</string>
-    <string name="PrivateSend_Caution_InsufficientBalance">Este envio privado precisa de %s em sua carteira, incluindo taxas.</string>
     <string name="PrivateSend_Caution_NoRoute">Nenhuma rota privada está disponível para este token e valor no momento.</string>
     <string name="PrivateSend_Caution_ExactOutputUnsupported">Esta rota não pode garantir um valor exato recebido.</string>
     <string name="PrivateSend_Caution_ProviderSuspended">O provedor de envio privado está temporariamente indisponível.</string>

--- a/walletkit/src/main/res/values-ru/strings.xml
+++ b/walletkit/src/main/res/values-ru/strings.xml
@@ -1859,7 +1859,6 @@
     <string name="PrivateSend_Caution_Title">Приватная отправка</string>
     <string name="PrivateSend_Caution_BelowMinimum">Приватная отправка требует, чтобы получатель получил не менее %s.</string>
     <string name="PrivateSend_Caution_AboveMaximum">Приватная отправка поддерживает максимум %s.</string>
-    <string name="PrivateSend_Caution_InsufficientBalance">Для этого приватного перевода необходимо %s в вашем кошельке, включая комиссии.</string>
     <string name="PrivateSend_Caution_NoRoute">На данный момент нет доступного приватного маршрута для этого токена и суммы.</string>
     <string name="PrivateSend_Caution_ExactOutputUnsupported">Этот маршрут не может гарантировать точную сумму получения.</string>
     <string name="PrivateSend_Caution_ProviderSuspended">Поставщик приватных переводов временно недоступен.</string>

--- a/walletkit/src/main/res/values-tr/strings.xml
+++ b/walletkit/src/main/res/values-tr/strings.xml
@@ -1853,7 +1853,6 @@
     <string name="PrivateSend_Caution_Title">Özel gönderim</string>
     <string name="PrivateSend_Caution_BelowMinimum">Özel gönderim, alıcının en az %s almasını gerektirir.</string>
     <string name="PrivateSend_Caution_AboveMaximum">Özel gönderim en fazla %s destekler.</string>
-    <string name="PrivateSend_Caution_InsufficientBalance">Bu özel gönderim, ücretler dahil olmak üzere cüzdanınızda %s gerektirir.</string>
     <string name="PrivateSend_Caution_NoRoute">Şu anda bu token ve tutar için kullanılabilir özel bir rota yok.</string>
     <string name="PrivateSend_Caution_ExactOutputUnsupported">Bu rota tam alınan tutarı garanti edemez.</string>
     <string name="PrivateSend_Caution_ProviderSuspended">Özel gönderim sağlayıcısı geçici olarak kullanılamaz.</string>

--- a/walletkit/src/main/res/values-zh/strings.xml
+++ b/walletkit/src/main/res/values-zh/strings.xml
@@ -1852,7 +1852,6 @@
     <string name="PrivateSend_Caution_Title">私密发送</string>
     <string name="PrivateSend_Caution_BelowMinimum">私密发送要求接收者至少收到 %s。</string>
     <string name="PrivateSend_Caution_AboveMaximum">私密发送最多支持 %s。</string>
-    <string name="PrivateSend_Caution_InsufficientBalance">此私密发送需要钱包中有 %s，包括手续费。</string>
     <string name="PrivateSend_Caution_NoRoute">目前没有可用的私密路由来处理此代币和金额。</string>
     <string name="PrivateSend_Caution_ExactOutputUnsupported">此路由无法保证确切的接收金额。</string>
     <string name="PrivateSend_Caution_ProviderSuspended">私密发送提供商暂时不可用。</string>

--- a/walletkit/src/main/res/values/strings.xml
+++ b/walletkit/src/main/res/values/strings.xml
@@ -612,7 +612,6 @@
     <string name="PrivateSend_Caution_Title">Private send</string>
     <string name="PrivateSend_Caution_BelowMinimum">Private send requires the recipient to receive at least %s.</string>
     <string name="PrivateSend_Caution_AboveMaximum">Private send supports at most %s.</string>
-    <string name="PrivateSend_Caution_InsufficientBalance">This private send needs %s in your wallet, including fees.</string>
     <string name="PrivateSend_Caution_NoRoute">No private route is available for this token and amount right now.</string>
     <string name="PrivateSend_Caution_ExactOutputUnsupported">This route can\'t guarantee an exact received amount.</string>
     <string name="PrivateSend_Caution_ProviderSuspended">The private send provider is temporarily unavailable.</string>


### PR DESCRIPTION
The confirmation raised its own insufficient balance caution on top of the send service's, so one shortfall read as two problems. The service's message stands alone now, and the private send string it duplicated is gone.

Refs #9545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated private send confirmation to display cautions provided by the transaction service.
  * Removed the separate insufficient-balance warning from the private send flow and translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->