### PR TITLE
Move EVM address validator and handler into EvmChainPlugin

### DIFF
--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/chain/evm/EvmChainPlugin.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/chain/evm/EvmChainPlugin.kt
@@ -27,6 +27,8 @@ import io.horizontalsystems.walletkit.entities.Wallet
 import io.horizontalsystems.walletkit.entities.evmAddress
 import io.horizontalsystems.walletkit.modules.addtoken.AddEvmTokenBlockchainService
 import io.horizontalsystems.walletkit.modules.addtoken.AddTokenModule
+import io.horizontalsystems.walletkit.modules.address.AddressHandlerEvm
+import io.horizontalsystems.walletkit.modules.address.IAddressHandler
 import io.horizontalsystems.walletkit.modules.manageaccount.evmaddress.AddressPage
 import io.horizontalsystems.walletkit.modules.manageaccount.evmprivatekey.PrivateKeyPage
 import io.horizontalsystems.walletkit.modules.multiswap.action.ISwapProviderAction
@@ -192,6 +194,8 @@ class EvmChainPlugin(override val blockchainType: BlockchainType) : ChainPlugin 
         WcRequestEvm(navigation)
         return true
     }
+
+    override fun addressHandlers(): List<IAddressHandler> = listOf(AddressHandlerEvm(blockchainType))
 
     override fun addressValidator(token: Token): EnterAddressValidator = EvmAddressValidator()
 

--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/chain/evm/EvmChainPlugin.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/chain/evm/EvmChainPlugin.kt
@@ -43,6 +43,8 @@ import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.nav3.HSPage
 import io.horizontalsystems.walletkit.modules.opencryptopay.OcpConfirmData
 import io.horizontalsystems.walletkit.modules.opencryptopay.OpenCryptoPayEvmConfirmationPage
+import io.horizontalsystems.walletkit.modules.send.address.EnterAddressValidator
+import io.horizontalsystems.walletkit.modules.send.address.EvmAddressValidator
 import io.horizontalsystems.walletkit.modules.send.evm.SendEvmModule
 import io.horizontalsystems.walletkit.modules.send.evm.SendEvmScreen
 import io.horizontalsystems.walletkit.modules.send.evm.SendEvmViewModel
@@ -190,6 +192,8 @@ class EvmChainPlugin(override val blockchainType: BlockchainType) : ChainPlugin 
         WcRequestEvm(navigation)
         return true
     }
+
+    override fun addressValidator(token: Token): EnterAddressValidator = EvmAddressValidator()
 
     override fun blacklistAddressChecker(): AddressChecker? =
         if (isFamilyAnchor) Eip20BlacklistAddressChecker(Eip20AddressValidator(App.evmSyncSourceManager)) else null

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/factories/AddressValidatorFactory.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/factories/AddressValidatorFactory.kt
@@ -2,8 +2,6 @@ package io.horizontalsystems.walletkit.core.factories
 
 import io.horizontalsystems.walletkit.core.chain.ChainRegistry
 import io.horizontalsystems.walletkit.modules.send.address.EnterAddressValidator
-import io.horizontalsystems.walletkit.modules.send.address.EvmAddressValidator
-import io.horizontalsystems.marketkit.models.BlockchainType
 import io.horizontalsystems.marketkit.models.Token
 
 object AddressValidatorFactory {
@@ -16,28 +14,8 @@ object AddressValidatorFactory {
         token: Token,
         allowOwnAddress: Boolean = false,
         zcashTransparentOnly: Boolean = false,
-    ): EnterAddressValidator {
-        ChainRegistry[token.blockchainType]?.addressValidator(token, allowOwnAddress, zcashTransparentOnly)?.let {
-            return it
-        }
-
-        return when (token.blockchainType) {
-            BlockchainType.Ethereum,
-            BlockchainType.BinanceSmartChain,
-            BlockchainType.Polygon,
-            BlockchainType.Avalanche,
-            BlockchainType.Optimism,
-            BlockchainType.Base,
-            BlockchainType.ZkSync,
-            BlockchainType.RobinhoodChain,
-            BlockchainType.Gnosis,
-            BlockchainType.Fantom,
-            BlockchainType.ArbitrumOne -> {
-                EvmAddressValidator()
-            }
-
-            else -> throw IllegalStateException("Unsupported blockchain type: ${token.blockchainType}")
-        }
-    }
+    ): EnterAddressValidator =
+        ChainRegistry[token.blockchainType]?.addressValidator(token, allowOwnAddress, zcashTransparentOnly)
+            ?: throw IllegalStateException("Unsupported blockchain type: ${token.blockchainType}")
 
 }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/address/PlainAddressHandlers.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/address/PlainAddressHandlers.kt
@@ -8,18 +8,4 @@ import io.horizontalsystems.walletkit.core.chain.ChainRegistry
  * both [AddressHandlerFactory] and [AddressInputModule].
  */
 fun plainAddressHandlers(blockchainType: BlockchainType): List<IAddressHandler> =
-    when (blockchainType) {
-        BlockchainType.Ethereum,
-        BlockchainType.BinanceSmartChain,
-        BlockchainType.Polygon,
-        BlockchainType.Avalanche,
-        BlockchainType.Optimism,
-        BlockchainType.Base,
-        BlockchainType.ZkSync,
-        BlockchainType.RobinhoodChain,
-        BlockchainType.Gnosis,
-        BlockchainType.Fantom,
-        BlockchainType.ArbitrumOne -> listOf(AddressHandlerEvm(blockchainType))
-
-        else -> ChainRegistry[blockchainType]?.addressHandlers().orEmpty()
-    }
+    ChainRegistry[blockchainType]?.addressHandlers().orEmpty()


### PR DESCRIPTION
EvmChainPlugin now supplies its own address validator and plain address handler, so the core factory and plainAddressHandlers() no longer carry a hard-coded list of EVM chains.

Closes #9440

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for validating EVM-compatible wallet addresses.
  * Added address handling for EVM-based chains.

* **Bug Fixes**
  * Improved address validation and handling by using chain-specific configurations, preventing unsupported chains from receiving an incorrect default EVM treatment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->