### PR TITLE
Small UI fixes for MultiSwap fiat row and chart Indicators cell

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/overview/ui/CoinOverviewScreen.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/overview/ui/CoinOverviewScreen.kt
@@ -175,6 +175,7 @@ fun CoinOverviewScreen(
                                             if (chartIndicatorsState.hasActiveSubscription) {
                                                 if (chartIndicatorsState.enabled) {
                                                     ButtonSecondaryDefault(
+                                                        modifier = Modifier.height(28.dp),
                                                         title = stringResource(id = R.string.Button_Hide),
                                                         onClick = {
                                                             viewModel.disableChartIndicators()

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapPage.kt
@@ -436,6 +436,7 @@ private fun SwapScreenInner(
                     switchPairsEnabled = !uiState.externalRecipientRequired,
                     amountOut = quote?.amountOut,
                     fiatAmountOut = uiState.fiatAmountOut,
+                    hasRateOut = uiState.hasRateOut,
                     fiatPriceImpact = uiState.fiatPriceImpact,
                     fiatPriceImpactLevel = uiState.fiatPriceImpactLevel,
                     onValueChange = onEnterAmount,
@@ -852,6 +853,7 @@ private fun SwapInput(
     switchPairsEnabled: Boolean,
     amountOut: BigDecimal?,
     fiatAmountOut: BigDecimal?,
+    hasRateOut: Boolean,
     fiatPriceImpact: BigDecimal?,
     fiatPriceImpactLevel: PriceImpactLevel?,
     onValueChange: (BigDecimal?) -> Unit,
@@ -883,6 +885,7 @@ private fun SwapInput(
             SwapCoinInputTo(
                 coinAmount = amountOut,
                 fiatAmount = fiatAmountOut,
+                hasRate = hasRateOut,
                 fiatPriceImpact = fiatPriceImpact,
                 fiatPriceImpactLevel = fiatPriceImpactLevel,
                 currency = currency,
@@ -931,13 +934,15 @@ private fun SwapCoinInputIn(
                 onValueChange = onValueChange,
                 focusRequester = focusRequester
             )
-            VSpacer(height = 3.dp)
-            FiatAmountInput(
-                value = fiatAmount,
-                currency = currency,
-                onValueChange = onFiatValueChange,
-                enabled = fiatAmountInputEnabled
-            )
+            if (fiatAmountInputEnabled || fiatAmount != null) {
+                VSpacer(height = 3.dp)
+                FiatAmountInput(
+                    value = fiatAmount,
+                    currency = currency,
+                    onValueChange = onFiatValueChange,
+                    enabled = fiatAmountInputEnabled
+                )
+            }
         }
     }
 }
@@ -946,6 +951,7 @@ private fun SwapCoinInputIn(
 private fun SwapCoinInputTo(
     coinAmount: BigDecimal?,
     fiatAmount: BigDecimal?,
+    hasRate: Boolean,
     fiatPriceImpact: BigDecimal?,
     fiatPriceImpactLevel: PriceImpactLevel?,
     currency: Currency,
@@ -972,10 +978,11 @@ private fun SwapCoinInputTo(
                     overflow = TextOverflow.Ellipsis
                 )
             }
-            VSpacer(height = 3.dp)
-            if (fiatAmount == null) {
+            if (hasRate && fiatAmount == null) {
+                VSpacer(height = 3.dp)
                 body_grey(text = "${currency.symbol}0")
-            } else {
+            } else if (fiatAmount != null) {
+                VSpacer(height = 3.dp)
                 Row {
                     body_grey(text = "${currency.symbol}${fiatAmount.toPlainString()}")
                     fiatPriceImpact?.let { diff ->

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapViewModel.kt
@@ -128,7 +128,7 @@ class SwapViewModel(
         viewModelScope.launch {
             fiatServiceOut.stateFlow.collect {
                 fiatAmountOut = it.fiatAmount
-                hasRateOut = it.coinPrice != null
+                hasRateOut = it.coinPrice != null && !it.coinPrice.expired
 
                 priceImpactService.setAmountOut(fiatAmountOut)
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapViewModel.kt
@@ -70,6 +70,7 @@ class SwapViewModel(
     private var fiatAmountIn: BigDecimal? = null
     private var fiatAmountOut: BigDecimal? = null
     private var fiatAmountInputEnabled = false
+    private var hasRateOut = false
     private var currency = currencyManager.baseCurrency
     private var requoteOnTimeout = true
     private var swapTermsAccepted = swapTermsManager.swapTermsAcceptedStateFlow.value
@@ -127,6 +128,7 @@ class SwapViewModel(
         viewModelScope.launch {
             fiatServiceOut.stateFlow.collect {
                 fiatAmountOut = it.fiatAmount
+                hasRateOut = it.coinPrice != null
 
                 priceImpactService.setAmountOut(fiatAmountOut)
 
@@ -272,6 +274,7 @@ class SwapViewModel(
         fiatAmountOut = fiatAmountOut,
         currency = currency,
         fiatAmountInputEnabled = fiatAmountInputEnabled,
+        hasRateOut = hasRateOut,
         needToAcceptTerms = !swapTermsAccepted && quoteState.quote?.provider?.requireTerms == true,
         amlChecking = amlChecking,
         initialShowRegularPrice = initialShowRegularPrice,
@@ -509,6 +512,7 @@ data class SwapUiState(
     val fiatPriceImpact: BigDecimal?,
     val currency: Currency,
     val fiatAmountInputEnabled: Boolean,
+    val hasRateOut: Boolean,
     val fiatPriceImpactLevel: PriceImpactLevel?,
     val needToAcceptTerms: Boolean,
     val amlChecking: Boolean,


### PR DESCRIPTION
## Summary
- Hide the fiat row in MultiSwap inputs when no rate is available instead of rendering an empty/`$0` line
- Give the chart Indicators "Hide" button the same fixed 28dp height as the "Show" button, so the cell no longer grows after tapping Show

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NL6z7ss9F7RCWxEBbZxNv6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **UI Improvements**
  - Standardized the height of chart indicator controls for a more consistent appearance.
  - Improved swap amount fields by showing fiat inputs only when relevant.
  - Prevented the destination fiat placeholder from appearing when no current exchange rate is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->