### PR TITLE
Omit the 100% suggestion for assets that pay own fees

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapPage.kt
@@ -618,6 +618,7 @@ private fun SwapScreenInner(
                             uiState.availableBalance != null && uiState.availableBalance > BigDecimal.ZERO
                         VSpacer(height = 16.dp)
                         SuggestionsBar(
+                            percents = uiState.percentOptions,
                             onDelete = {
                                 onEnterAmount.invoke(null)
                             },

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapViewModel.kt
@@ -284,7 +284,23 @@ class SwapViewModel(
         ),
         allowanceActionSuppressed = allowanceActionSuppressed(),
         externalRecipientRequired = externalRecipientRequired(quoteState.tokenOut),
+        percentOptions = percentOptions(quoteState.tokenIn),
     )
+
+    // The network fee is only estimated on the confirmation screen, so 100% of an asset
+    // that also pays its own fee always ends in an insufficient balance error. Offer it
+    // only for tokens whose fee is paid with a separate native asset.
+    private fun percentOptions(tokenIn: Token?): List<Int> {
+        val feePaidFromAsset = when (tokenIn?.type) {
+            null,
+            TokenType.Native,
+            is TokenType.Derived,
+            is TokenType.AddressTyped,
+            is TokenType.Unsupported -> true
+            else -> false
+        }
+        return if (feePaidFromAsset) listOf(25, 50, 75) else listOf(25, 50, 75, 100)
+    }
 
     // tokenOut the account can't hold: the swap is deliverable only to an external
     // address, which the user is asked for before the confirmation screen
@@ -520,6 +536,7 @@ data class SwapUiState(
     val swapTimeStatus: SwapTimeStatus,
     val allowanceActionSuppressed: Boolean = false,
     val externalRecipientRequired: Boolean = false,
+    val percentOptions: List<Int> = listOf(25, 50, 75, 100),
 ) {
     val currentStep: SwapStep = when {
         quoting -> SwapStep.Quoting


### PR DESCRIPTION
## Summary
- When swapping a native asset, selecting 100% always ends in an insufficient balance error because the network fee is only estimated on the Confirm screen.
- Until the fee can be estimated before confirmation, the 100% option is hidden for assets that pay their own fee (`Native`, `Derived`, `AddressTyped`, `Unsupported`); 25/50/75% remain.
- 100% stays available for tokens whose fee is paid with a separate native asset (EIP-20, SPL, Jetton, Stellar/Zano/Thorchain assets).

## Changes
- `SwapViewModel`: new `SwapUiState.percentOptions` computed from `tokenIn.type`.
- `SwapPage`: pass `percents = uiState.percentOptions` to `SuggestionsBar`.

## Test plan
- [ ] Swap ETH → only 25/50/75% shown
- [ ] Swap BTC → only 25/50/75% shown
- [ ] Swap USDT (ERC-20) → 25/50/75/100% shown
- [ ] `./gradlew :walletkit:compileDebugKotlin` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014n5FNMw148RrQGAfwMmiwM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated swap amount shortcuts to prevent selecting 100% for tokens that use the swapped asset to pay network fees.
  * Tokens with separate fee assets continue to offer 25%, 50%, 75%, and 100% shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->