### PR TITLE
Allow read-only Market access while the app is locked

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/App.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/App.kt
@@ -95,6 +95,7 @@ import io.horizontalsystems.walletkit.modules.multiswap.providers.SwapProviderIn
 import io.horizontalsystems.walletkit.modules.privatesend.PrivateSendManager
 import io.horizontalsystems.walletkit.modules.opencryptopay.OcpProofSubmissionWorker
 import io.horizontalsystems.walletkit.modules.pin.PinComponent
+import io.horizontalsystems.walletkit.modules.pin.core.LockGate
 import io.horizontalsystems.walletkit.modules.pin.core.PinDbStorage
 import io.horizontalsystems.walletkit.modules.roi.RoiManager
 import io.horizontalsystems.walletkit.modules.settings.appearance.AppIconService
@@ -119,6 +120,7 @@ import io.reactivex.plugins.RxJavaPlugins
 import io.horizontalsystems.walletkit.ui.helpers.TextHelper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
@@ -173,6 +175,7 @@ abstract class App : CoreApp(), WorkConfiguration.Provider, ImageLoaderFactory {
         lateinit var coinManager: ICoinManager
         lateinit var wcSessionManager: WCSessionManager
         lateinit var wcManager: WCManager
+        lateinit var lockGate: LockGate
         var wcWalletRequestHandler: IWCWalletRequestHandler? = null
         lateinit var termsManager: ITermsManager
         lateinit var swapTermsManager: SwapTermsManager
@@ -383,6 +386,13 @@ abstract class App : CoreApp(), WorkConfiguration.Provider, ImageLoaderFactory {
             pinDbStorage = PinDbStorage(appDatabase.pinDao()),
             backgroundManager = backgroundManager,
             localStorage = localStorage
+        )
+
+        lockGate = LockGate(
+            isLockedFlow = pinComponent.isLockedFlow,
+            marketsTabEnabledFlow = localStorage.marketsTabEnabledFlow,
+            // Main.immediate: the held navigation action touches the nav back stack.
+            scope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob())
         )
 
         statsManager = StatsManager(appDatabase.statsDao(), localStorage, marketKit, appConfigProvider, backgroundManager)

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/CoinPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/CoinPage.kt
@@ -21,7 +21,7 @@ import io.horizontalsystems.walletkit.uiv3.components.HSScaffold
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class CoinPage(val input: Input) : HSPage() {
+data class CoinPage(val input: Input) : HSPage(accessibleWhileLocked = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/audits/CoinAuditsPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/audits/CoinAuditsPage.kt
@@ -33,7 +33,7 @@ import io.horizontalsystems.walletkit.uiv3.components.HSScaffold
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class CoinAuditsPage(val input: Input) : HSPage() {
+data class CoinAuditsPage(val input: Input) : HSPage(accessibleWhileLocked = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/detectors/DetectorsPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/detectors/DetectorsPage.kt
@@ -50,7 +50,7 @@ import io.horizontalsystems.walletkit.uiv3.components.tabs.TabsTopType
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class DetectorsPage(val input: Input) : HSPage() {
+data class DetectorsPage(val input: Input) : HSPage(accessibleWhileLocked = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/indicators/IndicatorSettingsPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/indicators/IndicatorSettingsPage.kt
@@ -11,7 +11,7 @@ import io.horizontalsystems.walletkit.modules.nav3.HSPage
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class IndicatorSettingsPage(val input: Input) : HSPage() {
+data class IndicatorSettingsPage(val input: Input) : HSPage(accessibleWhileLocked = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/indicators/IndicatorsPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/indicators/IndicatorsPage.kt
@@ -29,7 +29,7 @@ import io.horizontalsystems.walletkit.uiv3.components.HSScaffold
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object IndicatorsPage : HSPage() {
+data object IndicatorsPage : HSPage(accessibleWhileLocked = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/investments/CoinInvestmentsPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/investments/CoinInvestmentsPage.kt
@@ -42,7 +42,7 @@ import io.horizontalsystems.walletkit.uiv3.components.HSScaffold
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class CoinInvestmentsPage(val input: Input) : HSPage() {
+data class CoinInvestmentsPage(val input: Input) : HSPage(accessibleWhileLocked = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/majorholders/CoinMajorHoldersPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/majorholders/CoinMajorHoldersPage.kt
@@ -54,7 +54,7 @@ import io.horizontalsystems.marketkit.models.Blockchain
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class CoinMajorHoldersPage(val input: Input) : HSPage() {
+data class CoinMajorHoldersPage(val input: Input) : HSPage(accessibleWhileLocked = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/overview/ui/CoinOverviewScreen.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/overview/ui/CoinOverviewScreen.kt
@@ -30,6 +30,7 @@ import io.horizontalsystems.marketkit.models.FullCoin
 import io.horizontalsystems.marketkit.models.LinkType
 import io.horizontalsystems.marketkit.models.Token
 import io.horizontalsystems.walletkit.R
+import io.horizontalsystems.walletkit.core.App
 import io.horizontalsystems.walletkit.core.alternativeImageUrl
 import io.horizontalsystems.walletkit.core.iconPlaceholder
 import io.horizontalsystems.walletkit.core.imageUrl
@@ -243,21 +244,27 @@ fun CoinOverviewScreen(
                                         Spacer(modifier = Modifier.height(24.dp))
                                         TokenVariants(
                                             tokenVariants = tokenVariants,
-                                            onClickAddToWallet = {
-                                                manageWalletsViewModel.enable(it)
+                                            // The page is browsable while locked; changing the
+                                            // wallet is not.
+                                            onClickAddToWallet = { token ->
+                                                App.lockGate.requireUnlocked {
+                                                    manageWalletsViewModel.enable(token)
 
-                                                stat(
-                                                    page = StatPage.CoinOverview,
-                                                    event = StatEvent.AddToWallet
-                                                )
+                                                    stat(
+                                                        page = StatPage.CoinOverview,
+                                                        event = StatEvent.AddToWallet
+                                                    )
+                                                }
                                             },
-                                            onClickRemoveWallet = {
-                                                manageWalletsViewModel.disable(it)
+                                            onClickRemoveWallet = { token ->
+                                                App.lockGate.requireUnlocked {
+                                                    manageWalletsViewModel.disable(token)
 
-                                                stat(
-                                                    page = StatPage.CoinOverview,
-                                                    event = StatEvent.RemoveFromWallet
-                                                )
+                                                    stat(
+                                                        page = StatPage.CoinOverview,
+                                                        event = StatEvent.RemoveFromWallet
+                                                    )
+                                                }
                                             },
                                             onClickCopy = {
                                                 TextHelper.copyText(it)

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/ranks/CoinRankPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/ranks/CoinRankPage.kt
@@ -61,7 +61,7 @@ import io.horizontalsystems.walletkit.uiv3.components.HSScaffold
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class CoinRankPage(val type: RankType) : HSPage() {
+data class CoinRankPage(val type: RankType) : HSPage(accessibleWhileLocked = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/reports/CoinReportsPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/reports/CoinReportsPage.kt
@@ -27,7 +27,7 @@ import io.horizontalsystems.walletkit.uiv3.components.HSScaffold
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class CoinReportsPage(val input: Input) : HSPage() {
+data class CoinReportsPage(val input: Input) : HSPage(accessibleWhileLocked = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/treasuries/CoinTreasuriesPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/treasuries/CoinTreasuriesPage.kt
@@ -42,7 +42,7 @@ import io.horizontalsystems.marketkit.models.Coin
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class CoinTreasuriesPage(val input: Coin) : HSPage() {
+data class CoinTreasuriesPage(val input: Coin) : HSPage(accessibleWhileLocked = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainModule.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainModule.kt
@@ -30,7 +30,8 @@ object MainModule {
                 App.wcSessionManager,
                 App.wcManager,
                 App.networkManager,
-                ActionCompletedDelegate
+                ActionCompletedDelegate,
+                App.lockGate,
             ) as T
         }
     }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainModule.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainModule.kt
@@ -102,7 +102,11 @@ object MainModule {
         val torEnabled: Boolean,
         val wcSupportState: WCManager.SupportState?,
         val openSend: OpenSendTokenSelect?,
-        val selectedTabItem: MainNavigation
+        val selectedTabItem: MainNavigation,
+        // Render this tab change without animation. Travels in the same state emission as
+        // selectedTabItem so the decision cannot race the lock state: a crossfade after the
+        // lock fallback would keep the outgoing wallet tab composed while locked.
+        val snapTabSwitch: Boolean = false,
     )
 }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainPage.kt
@@ -173,10 +173,11 @@ private fun MainScreen(
         Column {
             Crossfade(
                 targetState = uiState.selectedTabItem,
-                // Snap while locked: after the lock fallback switches to Market, a crossfade
-                // would keep the outgoing wallet tab composed and visible (and capturable,
-                // FLAG_SECURE is already cleared) for the animation's duration.
-                animationSpec = if (isLocked) snap() else tween()
+                // snapTabSwitch arrives in the same UiState emission as the tab itself, so a
+                // locked-time switch (lock fallback, widget deeplink) can never start animating
+                // before the lock state reaches this composition. isLocked stays as
+                // belt-and-braces: snapping while locked is always safe.
+                animationSpec = if (uiState.snapTabSwitch || isLocked) snap() else tween()
             ) { navItem ->
                 when (navItem) {
                     MainNavigation.Market -> MarketScreen(navigation)

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainPage.kt
@@ -94,9 +94,17 @@ private fun MainScreen(
     // go through right away.
     LaunchedEffect(activityIntent, isLocked) {
         val uri = activityIntent?.data
-        if (isLocked && !(uri != null && viewModel.isPublicDeepLink(uri))) return@LaunchedEffect
+        val publicWhileLocked = isLocked && uri != null && viewModel.isPublicDeepLink(uri)
+        if (isLocked && !publicWhileLocked) return@LaunchedEffect
 
         uri?.let {
+            if (publicWhileLocked) {
+                // The app may be sitting on the keypad because of a pending unlock request
+                // (e.g. a wallet tab was tapped earlier). The user now asked for public
+                // content, so drop that request — otherwise the keypad would keep covering
+                // the page this deeplink opens.
+                viewModel.cancelPendingUnlockRequest()
+            }
             delay(1000)
             viewModel.handleDeepLink(it)
             mainActivityViewModel.intentHandled()

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainPage.kt
@@ -1,6 +1,8 @@
 package io.horizontalsystems.walletkit.modules.main
 
 import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.snap
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -161,7 +163,13 @@ private fun MainScreen(
         }
     ) { paddingValues ->
         Column {
-            Crossfade(uiState.selectedTabItem) { navItem ->
+            Crossfade(
+                targetState = uiState.selectedTabItem,
+                // Snap while locked: after the lock fallback switches to Market, a crossfade
+                // would keep the outgoing wallet tab composed and visible (and capturable,
+                // FLAG_SECURE is already cleared) for the animation's duration.
+                animationSpec = if (isLocked) snap() else tween()
+            ) { navItem ->
                 when (navItem) {
                     MainNavigation.Market -> MarketScreen(navigation)
                     MainNavigation.Balance -> BalanceScreen(navigation)

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainPage.kt
@@ -88,10 +88,13 @@ private fun MainScreen(
     // while the app is locked would be acted on behind the lock screen — referral registration,
     // TonConnect links, prefilled send flows, the WalletConnect list. The intent is deliberately
     // left unconsumed (no intentHandled() call) so this effect re-runs when isLocked flips back.
+    // Market deeplinks (widget taps) only open pages that are browsable while locked, so they
+    // go through right away.
     LaunchedEffect(activityIntent, isLocked) {
-        if (isLocked) return@LaunchedEffect
+        val uri = activityIntent?.data
+        if (isLocked && !(uri != null && viewModel.isPublicDeepLink(uri))) return@LaunchedEffect
 
-        activityIntent?.data?.let {
+        uri?.let {
             delay(1000)
             viewModel.handleDeepLink(it)
             mainActivityViewModel.intentHandled()

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainViewModel.kt
@@ -31,6 +31,7 @@ import io.horizontalsystems.walletkit.modules.coin.CoinPage
 import io.horizontalsystems.walletkit.modules.main.MainModule.MainNavigation
 import io.horizontalsystems.walletkit.modules.market.platform.MarketPlatformPage
 import io.horizontalsystems.walletkit.modules.market.topplatforms.Platform
+import io.horizontalsystems.walletkit.modules.pin.core.LockGate
 import io.horizontalsystems.walletkit.modules.walletconnect.WCManager
 import io.horizontalsystems.walletkit.modules.walletconnect.WCSessionManager
 import io.horizontalsystems.walletkit.modules.walletconnect.list.WCListPage
@@ -53,7 +54,8 @@ class MainViewModel(
     wcSessionManager: WCSessionManager,
     private val wcManager: WCManager,
     private val networkManager: INetworkManager,
-    private val actionCompletedDelegate: ActionCompletedDelegate
+    private val actionCompletedDelegate: ActionCompletedDelegate,
+    private val lockGate: LockGate,
 ) : ViewModelUiState<MainModule.UiState>() {
 
     private var wcPendingRequestsCount = 0
@@ -106,7 +108,18 @@ class MainViewModel(
     private var torEnabled = localStorage.torEnabled
     private var openSendTokenSelect: OpenSendTokenSelect? = null
 
+    // App locked while a public screen was showing: fall back to the Market tab so the user
+    // keeps browsing instead of getting the keypad. The stored launch tab is left untouched.
+    private val restrictedLockListener: () -> Unit = {
+        if (items.contains(MainNavigation.Market)) {
+            selectTab(MainNavigation.Market)
+        }
+    }
+
     init {
+        reportSelectedTab()
+        lockGate.addRestrictedLockListener(restrictedLockListener)
+
         viewModelScope.launch {
             localStorage.marketsTabEnabledFlow.collect { enabled ->
                 marketsTabEnabled = enabled
@@ -172,6 +185,15 @@ class MainViewModel(
         updateTransactionsTabEnabled()
     }
 
+    override fun onCleared() {
+        lockGate.removeRestrictedLockListener(restrictedLockListener)
+        super.onCleared()
+    }
+
+    private fun reportSelectedTab() {
+        lockGate.selectedTab = selectedTabItem
+    }
+
     override fun createState() = MainModule.UiState(
         deeplinkPage = deeplinkPage,
         mainNavItems = mainNavItems,
@@ -212,18 +234,34 @@ class MainViewModel(
     }
 
     fun onSelect(mainNavItem: MainNavigation) {
-        val newIndex = items.indexOf(mainNavItem)
-
-        if (newIndex == selectedTabIndex) {
+        if (items.indexOf(mainNavItem) == selectedTabIndex) {
             return
         }
 
+        if (lockGate.isLocked && !lockGate.isTabAccessibleWhileLocked(mainNavItem)) {
+            // Wallet tab tapped while browsing Market locked: ask for the PIN, then switch.
+            lockGate.requireUnlocked { select(mainNavItem) }
+            return
+        }
+
+        select(mainNavItem)
+    }
+
+    private fun select(mainNavItem: MainNavigation) {
         if (mainNavItem != MainNavigation.Settings) {
             currentMainTab = mainNavItem
         }
+        selectTab(mainNavItem)
+    }
 
+    private fun selectTab(mainNavItem: MainNavigation) {
+        val newIndex = items.indexOf(mainNavItem)
+        if (newIndex < 0 || newIndex == selectedTabIndex) {
+            return
+        }
         updateSelectedTab(selectedTabIndex, newIndex)
         selectedTabIndex = newIndex
+        reportSelectedTab()
         emitState()
     }
 
@@ -309,6 +347,9 @@ class MainViewModel(
             !marketsTabEnabled -> {
                 MainNavigation.Balance
             }
+
+            // Cold start while locked: open the public Market tab instead of the keypad.
+            lockGate.isRestricted -> MainNavigation.Market
 
             else -> getLaunchTab()
         }
@@ -417,6 +458,7 @@ class MainViewModel(
 
         if (structureChanged) {
             mainNavItems = newNavItems
+            reportSelectedTab()
             emitState()
         }
     }
@@ -521,6 +563,7 @@ class MainViewModel(
         updateSelectedTab(selectedTabIndex, newTabIndex)
         selectedTabIndex = newTabIndex
         syncNavigation()
+        reportSelectedTab()
         emitState()
     }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainViewModel.kt
@@ -489,6 +489,11 @@ class MainViewModel(
         syncNavigation()
     }
 
+    /** Dismisses a keypad shown for a deferred action and drops that action. */
+    fun cancelPendingUnlockRequest() {
+        lockGate.cancelUnlockRequest()
+    }
+
     /** Deeplink that resolves to Market content only (widget taps); safe to open while locked. */
     fun isPublicDeepLink(uri: Uri): Boolean =
         lockGate.isRestricted && MarketDeepLinks.isMarketDeepLink(

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainViewModel.kt
@@ -107,6 +107,7 @@ class MainViewModel(
     private var wcSupportState: WCManager.SupportState? = null
     private var torEnabled = localStorage.torEnabled
     private var openSendTokenSelect: OpenSendTokenSelect? = null
+    private var snapTabSwitch = false
 
     // App locked while a public screen was showing: fall back to the Market tab so the user
     // keeps browsing instead of getting the keypad. The stored launch tab is left untouched.
@@ -204,6 +205,7 @@ class MainViewModel(
         torEnabled = torEnabled,
         openSend = openSendTokenSelect,
         selectedTabItem = selectedTabItem,
+        snapTabSwitch = snapTabSwitch,
     )
 
     private fun isTransactionsTabEnabled(): Boolean = !accountManager.isAccountsEmpty
@@ -259,6 +261,9 @@ class MainViewModel(
         if (newIndex < 0 || newIndex == selectedTabIndex) {
             return
         }
+        // A tab switched while locked (lock fallback, widget deeplink) must not animate:
+        // the outgoing wallet tab would stay composed for the crossfade's duration.
+        snapTabSwitch = lockGate.isLocked
         updateSelectedTab(selectedTabIndex, newIndex)
         selectedTabIndex = newIndex
         reportSelectedTab()
@@ -572,6 +577,7 @@ class MainViewModel(
         deeplinkPage = deeplinkPageData
         currentMainTab = tab
         val newTabIndex = items.indexOf(tab)
+        snapTabSwitch = lockGate.isLocked
         updateSelectedTab(selectedTabIndex, newTabIndex)
         selectedTabIndex = newTabIndex
         syncNavigation()

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainViewModel.kt
@@ -385,7 +385,7 @@ class MainViewModel(
                 }
             }
 
-            deeplinkString.startsWith("$deeplinkScheme:") -> {
+            MarketDeepLinks.isMarketDeepLink(deeplinkString, deeplinkScheme) -> {
                 val uid = deepLink.getQueryParameter("uid")
                 when {
                     deeplinkString.contains("coin-page") -> {
@@ -488,6 +488,13 @@ class MainViewModel(
         }
         syncNavigation()
     }
+
+    /** Deeplink that resolves to Market content only (widget taps); safe to open while locked. */
+    fun isPublicDeepLink(uri: Uri): Boolean =
+        lockGate.isRestricted && MarketDeepLinks.isMarketDeepLink(
+            uri.toString(),
+            Translator.getString(R.string.DeeplinkScheme)
+        )
 
     fun deeplinkPageHandled() {
         deeplinkPage = null

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MarketDeepLinks.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MarketDeepLinks.kt
@@ -1,0 +1,12 @@
+package io.horizontalsystems.walletkit.modules.main
+
+/** Deeplinks produced by the market widget; they lead to read-only Market pages. */
+object MarketDeepLinks {
+    private val paths = listOf("coin-page", "top-platforms")
+
+    fun isMarketDeepLink(deeplink: String, scheme: String): Boolean {
+        if (!deeplink.startsWith("$scheme:")) return false
+        val path = deeplink.removePrefix("$scheme:").trimStart('/').substringBefore('?')
+        return path in paths
+    }
+}

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/earn/VaultBlockchainsSelectorPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/earn/VaultBlockchainsSelectorPage.kt
@@ -33,7 +33,7 @@ import io.horizontalsystems.marketkit.models.Blockchain
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class VaultBlockchainsSelectorPage(val input: Input) : HSPage() {
+data class VaultBlockchainsSelectorPage(val input: Input) : HSPage(accessibleWhileLocked = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/earn/vault/VaultPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/earn/vault/VaultPage.kt
@@ -43,7 +43,7 @@ import io.horizontalsystems.walletkit.uiv3.components.HSScaffold
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class VaultPage(val input: Input) : HSPage() {
+data class VaultPage(val input: Input) : HSPage(accessibleWhileLocked = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/etf/EtfPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/etf/EtfPage.kt
@@ -91,7 +91,7 @@ import java.math.BigDecimal
 import kotlin.math.abs
 
 @Serializable
-data object EtfPage : HSPage() {
+data object EtfPage : HSPage(accessibleWhileLocked = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/favorites/MarketSignalsPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/favorites/MarketSignalsPage.kt
@@ -37,7 +37,7 @@ import io.horizontalsystems.marketkit.models.Analytics.TechnicalAdvice.Advice
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object MarketSignalsPage : HSPage() {
+data object MarketSignalsPage : HSPage(accessibleWhileLocked = true) {
     @Composable
     override fun GetContent(navigation: HSNavigation) {
         MarketSignalsScreen(navigation)

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/filters/BlockchainsSelectorPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/filters/BlockchainsSelectorPage.kt
@@ -31,7 +31,7 @@ import io.horizontalsystems.walletkit.ui.compose.components.cell.SectionUniversa
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object BlockchainsSelectorPage : HSPage() {
+data object BlockchainsSelectorPage : HSPage(accessibleWhileLocked = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/filters/MarketFiltersPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/filters/MarketFiltersPage.kt
@@ -67,7 +67,7 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object MarketFiltersPage : HSPage() {
+data object MarketFiltersPage : HSPage(accessibleWhileLocked = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/filters/SectorsSelectorPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/filters/SectorsSelectorPage.kt
@@ -36,7 +36,7 @@ import io.horizontalsystems.walletkit.ui.compose.components.body_leah
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object SectorsSelectorPage : HSPage() {
+data object SectorsSelectorPage : HSPage(accessibleWhileLocked = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/filtersresult/MarketFiltersResultsPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/filtersresult/MarketFiltersResultsPage.kt
@@ -42,7 +42,7 @@ import io.horizontalsystems.subscriptions.core.TradeSignals
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object MarketFiltersResultsPage : HSPage() {
+data object MarketFiltersResultsPage : HSPage(accessibleWhileLocked = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/metricspage/MetricsPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/metricspage/MetricsPage.kt
@@ -49,7 +49,7 @@ import io.horizontalsystems.walletkit.uiv3.components.controls.HSButton
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class MetricsPage(val metricsType: MetricsType) : HSPage() {
+data class MetricsPage(val metricsType: MetricsType) : HSPage(accessibleWhileLocked = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/platform/MarketPlatformPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/platform/MarketPlatformPage.kt
@@ -69,7 +69,7 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class MarketPlatformPage(val platform: Platform) : HSPage() {
+data class MarketPlatformPage(val platform: Platform) : HSPage(accessibleWhileLocked = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/search/MarketSearchPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/search/MarketSearchPage.kt
@@ -67,7 +67,7 @@ import kotlinx.serialization.Serializable
 import java.util.Optional
 
 @Serializable
-data object MarketSearchPage : HSPage() {
+data object MarketSearchPage : HSPage(accessibleWhileLocked = true) {
     @Composable
     override fun GetContent(navigation: HSNavigation) {
         val viewModel = viewModel<MarketSearchViewModel>(

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/sector/MarketSectorPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/sector/MarketSectorPage.kt
@@ -47,7 +47,7 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class MarketSectorPage(val input: CoinCategory) : HSPage() {
+data class MarketSectorPage(val input: CoinCategory) : HSPage(accessibleWhileLocked = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/tvl/TvlPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/tvl/TvlPage.kt
@@ -65,7 +65,7 @@ import io.horizontalsystems.walletkit.uiv3.components.controls.HSIconButton
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object TvlPage : HSPage() {
+data object TvlPage : HSPage(accessibleWhileLocked = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/BottomSheetSceneStrategy.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/BottomSheetSceneStrategy.kt
@@ -36,8 +36,10 @@ internal class BottomSheetScene<T : Any>(
         // Default-dispatcher coroutine), so a sheet can slip onto the stack in the same frame the
         // app locks. Keep the entry on the stack but don't compose the sheet while locked: the
         // window is torn down for the whole lock, and the sheet re-enters intact on unlock.
-        val isLocked by App.pinComponent.isLockedFlow.collectAsStateWithLifecycle()
-        if (!isLocked) {
+        // Keyed on the keypad's visibility, not the raw lock: market sheets (filters, etc.) stay
+        // usable while browsing the Market tab locked.
+        val showUnlock by App.lockGate.showUnlockFlow.collectAsStateWithLifecycle()
+        if (!showUnlock) {
             ModalBottomSheet(
                 onDismissRequest = onBack,
                 sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = skipPartiallyExpanded),

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/EntryPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/EntryPage.kt
@@ -9,7 +9,7 @@ import io.horizontalsystems.walletkit.modules.intro.IntroScreen
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object EntryPage : HSPage() {
+data object EntryPage : HSPage(accessibleWhileLocked = true) {
     @Composable
     override fun GetContent(navigation: HSNavigation) {
         val mainShowedOnce by

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/HSNavigation.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/HSNavigation.kt
@@ -14,6 +14,7 @@ import io.horizontalsystems.walletkit.core.stats.StatPage
 import io.horizontalsystems.walletkit.core.stats.stat
 import io.horizontalsystems.walletkit.modules.pin.ConfirmPinPage
 import io.horizontalsystems.walletkit.modules.pin.SetPinPage
+import io.horizontalsystems.walletkit.modules.pin.core.LockGate
 import io.horizontalsystems.walletkit.modules.settings.terms.TermsPage
 import io.horizontalsystems.walletkit.modules.usersubscription.BuySubscriptionHavHostPage
 import io.horizontalsystems.subscriptions.core.IPaidAction
@@ -23,7 +24,10 @@ import kotlinx.serialization.serializerOrNull
 import java.util.UUID
 import kotlin.reflect.KClass
 
-class HSNavigation(val backStack: NavBackStack<HSPage>) {
+class HSNavigation(
+    val backStack: NavBackStack<HSPage>,
+    private val lockGate: LockGate = App.lockGate,
+) {
 
     fun slideFromRight(screen: HSPage) {
         screen.navType = NavigationType.SlideFromRight
@@ -95,6 +99,12 @@ class HSNavigation(val backStack: NavBackStack<HSPage>) {
 
     private fun push(screen: HSPage): Boolean {
         verifyPageSerializable(screen)
+        // While the app is locked only read-only market pages open directly; anything else
+        // shows the keypad first and is pushed once the PIN is entered.
+        if (!screen.accessibleWhileLocked && lockGate.isLocked) {
+            lockGate.requireUnlocked { backStack.add(screen) }
+            return false
+        }
         return backStack.add(screen)
     }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/HSPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/HSPage.kt
@@ -23,6 +23,9 @@ abstract class HSPage(
     // for tall sheet content that would otherwise show partially
     val expandedBottomSheet: Boolean = false,
     val screenshotEnabled: Boolean = true,
+    // May be shown while the app is PIN-locked (read-only market content). Pushing a page
+    // without this while locked shows the keypad first — see LockGate.
+    val accessibleWhileLocked: Boolean = false,
     var resultKey: String? = null,
     val uuid: String = UUID.randomUUID().toString(),
     var navType: NavigationType = NavigationType.SlideFromRight,

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/Nav3.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/Nav3.kt
@@ -52,6 +52,9 @@ import io.horizontalsystems.dapp.core.HSDAppEvent
 fun Nav3(entryPage: HSPage) {
     val mainActivityViewModel = viewModel<MainActivityViewModel>(factory = Factory())
     val isLocked by App.pinComponent.isLockedFlow.collectAsState()
+    // The keypad covers only screens that need the wallet; the Market tab and its read-only
+    // pages stay browsable while locked (see LockGate).
+    val showUnlock by App.lockGate.showUnlockFlow.collectAsState()
 
     val backStack = rememberSerializable(
         serializer = NavBackStackSerializer(elementSerializer = NavKeySerializer())
@@ -65,7 +68,8 @@ fun Nav3(entryPage: HSPage) {
     IntentEffect(mainActivityViewModel, hsNavigation)
     Validate(mainActivityViewModel)
     HandleWcEvent(mainActivityViewModel, hsNavigation)
-    ToggleScreenshot(hsNavigation, isLocked)
+    ToggleScreenshot(hsNavigation, showUnlock)
+    ReportCurrentPageToLockGate(hsNavigation)
 
     LaunchedEffect(isLocked) {
         if (!isLocked) {
@@ -106,19 +110,24 @@ fun Nav3(entryPage: HSPage) {
         )
 
         AnimatedVisibility(
-            visible = isLocked,
+            visible = showUnlock,
             enter = fadeIn(),
             // Leaves immediately rather than fading. The secure flag is cleared as soon as the app
             // unlocks, so an exit animation would keep the keypad composited on a surface that is
             // capturable again. Entering is unaffected: the flag is set before the fade in starts.
             exit = ExitTransition.None
         ) {
-            PinUnlock(isLocked = isLocked)
+            PinUnlock(isLocked = showUnlock)
         }
     }
 
-    BackHandler(enabled = isLocked) {
-        activity?.moveTaskToBack(true)
+    BackHandler(enabled = showUnlock) {
+        if (App.lockGate.unlockRequested) {
+            // Keypad was opened for a wallet action from a public screen: back just dismisses it.
+            App.lockGate.cancelUnlockRequest()
+        } else {
+            activity?.moveTaskToBack(true)
+        }
     }
 }
 
@@ -260,17 +269,25 @@ private fun HandleWcEvent(
 }
 
 @Composable
-private fun ToggleScreenshot(navigation: HSNavigation, isLocked: Boolean) {
+private fun ReportCurrentPageToLockGate(navigation: HSNavigation) {
+    val currentScreen = navigation.lastOrNull()
+    LaunchedEffect(currentScreen) {
+        App.lockGate.currentPageAccessibleWhileLocked = currentScreen?.accessibleWhileLocked ?: false
+    }
+}
+
+@Composable
+private fun ToggleScreenshot(navigation: HSNavigation, showUnlock: Boolean) {
     val activity = LocalActivity.current
     val currentScreen = navigation.lastOrNull()
-    LaunchedEffect(currentScreen, isLocked) {
+    LaunchedEffect(currentScreen, showUnlock) {
         if (activity != null) {
             activity.currentFocus?.hideKeyboard(activity)
             // The unlock keypad is drawn as an overlay rather than pushed as a page, so it has no
             // screenshotEnabled of its own. Without the lock state here the flag stays however the
             // page underneath left it, and locking over an ordinary screen leaves passcode entry
             // recordable.
-            if (isLocked || currentScreen?.screenshotEnabled == false) {
+            if (showUnlock || currentScreen?.screenshotEnabled == false) {
                 activity.window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
             } else {
                 activity.window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/pin/core/LockGate.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/pin/core/LockGate.kt
@@ -1,11 +1,13 @@
 package io.horizontalsystems.walletkit.modules.pin.core
 
 import io.horizontalsystems.walletkit.modules.main.MainModule.MainNavigation
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 /**
  * Decides when the PIN keypad has to cover the screen.
@@ -71,12 +73,12 @@ class LockGate(
                     pendingAction = null
                     _unlockRequestedFlow.value = false
                     recompute()
-                    action?.invoke()
+                    action?.let { runDeferred(it) }
                 } else {
                     if (!wasLocked && marketsTabEnabledFlow.value && currentPageAccessibleWhileLocked) {
                         // Locked while browsing something public: let the main screen fall back
                         // to the Market tab so the user is not faced with the keypad.
-                        restrictedLockListeners.toList().forEach { it.invoke() }
+                        restrictedLockListeners.toList().forEach { runDeferred(it) }
                     }
                     recompute()
                 }
@@ -121,6 +123,18 @@ class LockGate(
 
     fun removeRestrictedLockListener(listener: () -> Unit) {
         restrictedLockListeners.remove(listener)
+    }
+
+    // A throwing callback must not cancel the isLockedFlow collector: the gate would stop
+    // recomputing and showUnlockFlow would go stale on every later lock transition.
+    private fun runDeferred(block: () -> Unit) {
+        try {
+            block.invoke()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "LockGate callback failed")
+        }
     }
 
     private fun currentScreenAccessible(): Boolean {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/pin/core/LockGate.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/pin/core/LockGate.kt
@@ -1,0 +1,139 @@
+package io.horizontalsystems.walletkit.modules.pin.core
+
+import io.horizontalsystems.walletkit.modules.main.MainModule.MainNavigation
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Decides when the PIN keypad has to cover the screen.
+ *
+ * The app lock ([isLockedFlow]) is a single boolean, but the Market tab and its read-only
+ * sub-pages (pages created with `HSPage(accessibleWhileLocked = true)`) may be browsed without
+ * unlocking. The keypad is therefore shown only when the app is locked AND one of:
+ *  - the Market tab is disabled in settings (nothing public to show, behave as a full lock),
+ *  - the screen on top is not accessible while locked (a wallet page, or the main page with a
+ *    non-Market tab selected),
+ *  - the user asked for something that needs the wallet ([requireUnlocked]); the action is held
+ *    and replayed once the PIN is entered, or dropped if the request is cancelled.
+ *
+ * The UI reports what is currently on screen through [selectedTab] and
+ * [currentPageAccessibleWhileLocked]; everything else is derived. Pure Kotlin so it can be unit
+ * tested without Android.
+ */
+class LockGate(
+    private val isLockedFlow: StateFlow<Boolean>,
+    private val marketsTabEnabledFlow: StateFlow<Boolean>,
+    scope: CoroutineScope,
+) {
+    private val _showUnlockFlow = MutableStateFlow(false)
+
+    /** True while the PIN keypad must be drawn over the content. */
+    val showUnlockFlow: StateFlow<Boolean> = _showUnlockFlow.asStateFlow()
+    val showUnlock: Boolean get() = _showUnlockFlow.value
+
+    private val _unlockRequestedFlow = MutableStateFlow(false)
+
+    /** True while the keypad is shown because of a [requireUnlocked] call (cancellable). */
+    val unlockRequestedFlow: StateFlow<Boolean> = _unlockRequestedFlow.asStateFlow()
+    val unlockRequested: Boolean get() = _unlockRequestedFlow.value
+
+    private var pendingAction: (() -> Unit)? = null
+    private val restrictedLockListeners = mutableListOf<() -> Unit>()
+
+    val isLocked: Boolean get() = isLockedFlow.value
+
+    /** Locked, but the Market tab is available so the app can stay usable in read-only mode. */
+    val isRestricted: Boolean get() = isLocked && marketsTabEnabledFlow.value
+
+    /** Main tab currently selected; null until the main screen reports one. */
+    var selectedTab: MainNavigation? = null
+        set(value) {
+            field = value
+            recompute()
+        }
+
+    /** Whether the page on top of the nav back stack may be shown while locked. */
+    var currentPageAccessibleWhileLocked: Boolean = true
+        set(value) {
+            field = value
+            recompute()
+        }
+
+    init {
+        scope.launch {
+            var wasLocked = isLockedFlow.value
+            isLockedFlow.collect { locked ->
+                if (!locked) {
+                    val action = pendingAction
+                    pendingAction = null
+                    _unlockRequestedFlow.value = false
+                    recompute()
+                    action?.invoke()
+                } else {
+                    if (!wasLocked && marketsTabEnabledFlow.value && currentPageAccessibleWhileLocked) {
+                        // Locked while browsing something public: let the main screen fall back
+                        // to the Market tab so the user is not faced with the keypad.
+                        restrictedLockListeners.toList().forEach { it.invoke() }
+                    }
+                    recompute()
+                }
+                wasLocked = locked
+            }
+        }
+        scope.launch {
+            marketsTabEnabledFlow.collect { recompute() }
+        }
+    }
+
+    fun isTabAccessibleWhileLocked(tab: MainNavigation): Boolean = tab == MainNavigation.Market
+
+    /**
+     * Runs [action] now if the wallet is available, otherwise shows the keypad and runs it right
+     * after a successful unlock. A newer request replaces a pending one.
+     */
+    fun requireUnlocked(action: () -> Unit) {
+        if (!isLocked) {
+            action.invoke()
+            return
+        }
+        pendingAction = action
+        _unlockRequestedFlow.value = true
+        recompute()
+    }
+
+    /** Dismisses a keypad shown by [requireUnlocked] and drops the held action. */
+    fun cancelUnlockRequest() {
+        pendingAction = null
+        _unlockRequestedFlow.value = false
+        recompute()
+    }
+
+    /**
+     * Called when the app locks while a public screen is showing and the Market tab is enabled.
+     * The main screen uses it to switch to the Market tab.
+     */
+    fun addRestrictedLockListener(listener: () -> Unit) {
+        restrictedLockListeners.add(listener)
+    }
+
+    fun removeRestrictedLockListener(listener: () -> Unit) {
+        restrictedLockListeners.remove(listener)
+    }
+
+    private fun currentScreenAccessible(): Boolean {
+        val tab = selectedTab
+        return currentPageAccessibleWhileLocked && (tab == null || isTabAccessibleWhileLocked(tab))
+    }
+
+    private fun recompute() {
+        _showUnlockFlow.value = when {
+            !isLocked -> false
+            !marketsTabEnabledFlow.value -> true
+            unlockRequested -> true
+            else -> !currentScreenAccessible()
+        }
+    }
+}

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/widgets/MarketWidget.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/widgets/MarketWidget.kt
@@ -324,6 +324,8 @@ class UpdateMarketAction : ActionCallback {
         }
         MarketWidget().update(context, glanceId)
 
+        // Awaited on purpose: the callback's receiver is finished as soon as this returns and
+        // a detached refresh may not survive that.
         MarketWidgetManager().refresh(glanceId)
     }
 }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/widgets/MarketWidgetConfigurationActivity.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/widgets/MarketWidgetConfigurationActivity.kt
@@ -125,11 +125,13 @@ class MarketWidgetConfigurationActivity : AppCompatActivity() {
         scope.launch {
             glanceId?.let {
                 updateAppWidgetState(context, MarketWidgetStateDefinition, glanceId) {
-                    it.copy(widgetId = appWidgetId, type = selectedType)
+                    // Reconfiguring: drop the previous type's rows and show the spinner
+                    // until the new data arrives.
+                    it.copy(widgetId = appWidgetId, type = selectedType, items = emptyList(), loading = true, error = null)
                 }
                 MarketWidget().update(context, glanceId)
-                MarketWidgetManager().refresh(glanceId)
                 MarketWidgetWorker.enqueueWork(App.instance)
+                App.marketWidgetManager.refreshInBackground(glanceId)
             }
 
             val resultValue = Intent().putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/widgets/MarketWidgetManager.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/widgets/MarketWidgetManager.kt
@@ -25,7 +25,7 @@ class MarketWidgetManager {
     private val coroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
     fun updateWatchListWidgets() {
-        coroutineScope.launch {
+        launchContained {
             val context = App.instance
             val manager = GlanceAppWidgetManager(context)
             val glanceIds = manager.getGlanceIds(MarketWidget::class.java)
@@ -45,7 +45,22 @@ class MarketWidgetManager {
      * running on a detached scope would die with it.
      */
     fun refreshInBackground(glanceId: GlanceId) {
-        coroutineScope.launch { refresh(glanceId) }
+        launchContained { refresh(glanceId) }
+    }
+
+    // refresh() catches fetch errors itself, but its failure path (widget state IO, work
+    // scheduling) can throw too; nothing above this scope handles that, so it would crash
+    // the app. Contain everything except cancellation.
+    private fun launchContained(block: suspend () -> Unit) {
+        coroutineScope.launch {
+            try {
+                block()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.e(e, "Market widget update failed")
+            }
+        }
     }
 
     /**

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/widgets/MarketWidgetManager.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/widgets/MarketWidgetManager.kt
@@ -11,18 +11,21 @@ import coil.request.ErrorResult
 import coil.request.ImageRequest
 import io.horizontalsystems.walletkit.R
 import io.horizontalsystems.walletkit.core.App
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import java.net.UnknownHostException
 
 class MarketWidgetManager {
 
-    private var coroutineScope: CoroutineScope? = CoroutineScope(Dispatchers.Default)
+    private val coroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
     fun updateWatchListWidgets() {
-        coroutineScope?.launch {
+        coroutineScope.launch {
             val context = App.instance
             val manager = GlanceAppWidgetManager(context)
             val glanceIds = manager.getGlanceIds(MarketWidget::class.java)
@@ -36,25 +39,46 @@ class MarketWidgetManager {
         }
     }
 
-    fun refresh(glanceId: GlanceId) {
-        coroutineScope?.launch {
-            val context = App.instance
-            try {
-                executeWithRetry {
-                    updateData(glanceId)
-                }
-            } catch (exception: Exception) {
-                var state = getAppWidgetState(context, MarketWidgetStateDefinition, glanceId)
+    /**
+     * Fire-and-forget refresh for callers that cannot suspend. Prefer [refresh] from a worker or
+     * an action callback: the process may be killed as soon as those return, and a refresh left
+     * running on a detached scope would die with it.
+     */
+    fun refreshInBackground(glanceId: GlanceId) {
+        coroutineScope.launch { refresh(glanceId) }
+    }
 
-                val errorText = if (exception is UnknownHostException)
-                    context.getString(R.string.Hud_Text_NoInternet)
-                else {
-                    context.getString(R.string.SyncError) + "\n\n\n" + "[ ${state.error} ]"
-                }
-
-                state = state.copy(loading = false, error = errorText)
-                setWidgetState(context, glanceId, state)
+    /**
+     * Fetches fresh data for the widget and re-renders it.
+     *
+     * @return true when the data was updated, false when every attempt failed. On failure the
+     * previously shown items are kept; the error is only shown when there is nothing to show.
+     */
+    suspend fun refresh(glanceId: GlanceId): Boolean {
+        val context = App.instance
+        return try {
+            executeWithRetry {
+                updateData(glanceId)
             }
+            true
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (exception: Exception) {
+            Timber.e(exception, "Market widget refresh failed")
+            var state = getAppWidgetState(context, MarketWidgetStateDefinition, glanceId)
+
+            val errorText = if (exception is UnknownHostException) {
+                context.getString(R.string.Hud_Text_NoInternet)
+            } else {
+                context.getString(R.string.SyncError) + "\n\n\n" + "[ ${exception.message} ]"
+            }
+
+            state = state.afterRefreshFailure(errorText)
+            setWidgetState(context, glanceId, state)
+            // Doze or airplane mode: sync as soon as connectivity is back rather than waiting
+            // for the next periodic slot.
+            MarketWidgetWorker.enqueueSyncWhenOnline(context)
+            false
         }
     }
 
@@ -70,9 +94,15 @@ class MarketWidgetManager {
         var marketItems = marketRepository.getMarketItems(state.type)
         marketItems = marketItems.map { it.copy(imageLocalPath = imagePathCache[it.imageRemoteUrl]) }
 
-        state = state.copy(items = marketItems, loading = false, error = null)
+        state = state.copy(
+            items = marketItems,
+            loading = false,
+            error = null,
+            updateTimestampMillis = System.currentTimeMillis()
+        )
         setWidgetState(context, glanceId, state)
 
+        // Icons are best effort: a missing image must not fail the rates update.
         marketItems = marketItems.map { item ->
             item.copy(
                 imageLocalPath = item.imageLocalPath ?: getImage(
@@ -83,12 +113,10 @@ class MarketWidgetManager {
             )
         }
 
-        state =
-            state.copy(
-                items = marketItems,
-                updateTimestampMillis = System.currentTimeMillis()
-            )
-        setWidgetState(context, glanceId, state)
+        if (marketItems != state.items) {
+            state = state.copy(items = marketItems)
+            setWidgetState(context, glanceId, state)
+        }
     }
 
     @OptIn(ExperimentalCoilApi::class)
@@ -130,24 +158,29 @@ class MarketWidgetManager {
         MarketWidget().update(context, glanceId)
     }
 
-    private val MAX_RETRIES = 5
-
     private suspend inline fun executeWithRetry(call: () -> Unit) {
         for (i in 0..MAX_RETRIES) {
             try {
                 call.invoke()
                 break
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: UnknownHostException) {
+                // No network: retrying in-process is pointless, the online sync job handles it.
+                throw e
             } catch (e: Exception) {
-                delay(2000)
-
                 if (i == MAX_RETRIES) {
                     throw e
                 }
+                delay(RETRY_DELAY_MILLIS)
             }
         }
     }
 
     companion object {
+        private const val MAX_RETRIES = 5
+        private const val RETRY_DELAY_MILLIS = 2000L
+
         fun getMarketWidgetTypes(): List<MarketWidgetType> {
             val types = MarketWidgetType.values().toMutableList()
             if (!App.localStorage.marketsTabEnabled) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/widgets/MarketWidgetReceiver.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/widgets/MarketWidgetReceiver.kt
@@ -1,5 +1,6 @@
 package io.horizontalsystems.walletkit.widgets
 
+import android.appwidget.AppWidgetManager
 import android.content.Context
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.GlanceAppWidgetReceiver
@@ -7,6 +8,14 @@ import androidx.glance.appwidget.GlanceAppWidgetReceiver
 class MarketWidgetReceiver : GlanceAppWidgetReceiver() {
 
     override val glanceAppWidget: GlanceAppWidget = MarketWidget()
+
+    // The system calls this on placement, reboot, app update and every updatePeriodMillis.
+    // Re-enqueueing (UPDATE policy) keeps the periodic refresh alive even if the app itself
+    // was never launched since, e.g. after a restore or a force stop.
+    override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
+        super.onUpdate(context, appWidgetManager, appWidgetIds)
+        MarketWidgetWorker.enqueueWork(context)
+    }
 
     override fun onDeleted(context: Context, appWidgetIds: IntArray) {
         super.onDeleted(context, appWidgetIds)

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/widgets/MarketWidgetState.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/widgets/MarketWidgetState.kt
@@ -14,6 +14,16 @@ data class MarketWidgetState(
     val error: String? = null,
     val updateTimestampMillis: Long = System.currentTimeMillis()
 ) {
+    /**
+     * State to show after a refresh attempt failed. Cached rows stay on screen (a stale price
+     * beats an error screen, e.g. during Doze when the network is cut); the error takes over the
+     * widget only when there is nothing cached yet.
+     */
+    fun afterRefreshFailure(errorText: String): MarketWidgetState = copy(
+        loading = false,
+        error = if (items.isEmpty()) errorText else null
+    )
+
     override fun toString(): String {
         return "{ widgetId: $widgetId, " +
                 "type: ${type.id}, " +

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/widgets/MarketWidgetWorker.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/widgets/MarketWidgetWorker.kt
@@ -4,8 +4,12 @@ import android.appwidget.AppWidgetManager
 import android.content.ComponentName
 import android.content.Context
 import androidx.glance.appwidget.GlanceAppWidgetManager
+import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
@@ -19,10 +23,15 @@ class MarketWidgetWorker(
     companion object {
         private const val updatePeriodMillis: Long = 15 * 60 * 1000 // 15 minutes
         private const val workName = "widget_update_work"
+        private const val syncWhenOnlineWorkName = "widget_sync_when_online"
+        private val connectedConstraints = Constraints(requiredNetworkType = NetworkType.CONNECTED)
 
         fun enqueueWork(context: Context) {
             val manager = WorkManager.getInstance(context)
             val requestBuilder = PeriodicWorkRequestBuilder<MarketWidgetWorker>(Duration.ofMillis(updatePeriodMillis))
+                // Without a network the fetch can only fail; let WorkManager wait for connectivity
+                // instead of burning the run on retries.
+                .setConstraints(connectedConstraints)
 
             manager.enqueueUniquePeriodicWork(
                 workName,
@@ -31,9 +40,28 @@ class MarketWidgetWorker(
             )
         }
 
+        /**
+         * One-shot refresh that runs as soon as the device is online. Enqueued after a failed
+         * refresh so the widget recovers from Doze/offline without waiting for the next
+         * periodic slot. KEEP: one pending sync is enough.
+         */
+        fun enqueueSyncWhenOnline(context: Context) {
+            if (!hasEnabledWidgets(context)) return
+            val request = OneTimeWorkRequestBuilder<MarketWidgetWorker>()
+                .setConstraints(connectedConstraints)
+                .build()
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                syncWhenOnlineWorkName,
+                ExistingWorkPolicy.KEEP,
+                request
+            )
+        }
+
         fun cancel(context: Context) {
             if (!hasEnabledWidgets(context)) {
-                WorkManager.getInstance(context).cancelUniqueWork(workName)
+                val manager = WorkManager.getInstance(context)
+                manager.cancelUniqueWork(workName)
+                manager.cancelUniqueWork(syncWhenOnlineWorkName)
             }
         }
 
@@ -59,10 +87,15 @@ class MarketWidgetWorker(
         val glanceIds = manager.getGlanceIds(MarketWidget::class.java)
         val marketWidgetManager = MarketWidgetManager()
 
+        // Awaited: returning before the refresh finishes lets the process be killed mid-fetch,
+        // which left widgets showing stale rates.
+        var allUpdated = true
         for (glanceId in glanceIds) {
-            marketWidgetManager.refresh(glanceId)
+            if (!marketWidgetManager.refresh(glanceId)) {
+                allUpdated = false
+            }
         }
-        return Result.success()
+        return if (allUpdated) Result.success() else Result.retry()
     }
 
 }

--- a/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/main/MarketDeepLinksTest.kt
+++ b/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/main/MarketDeepLinksTest.kt
@@ -1,0 +1,32 @@
+package io.horizontalsystems.walletkit.modules.main
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MarketDeepLinksTest {
+
+    private fun isMarket(link: String) = MarketDeepLinks.isMarketDeepLink(link, "unstoppable")
+
+    @Test
+    fun `widget coin and platform links are market links`() {
+        assertTrue(isMarket("unstoppable://coin-page?uid=bitcoin"))
+        assertTrue(isMarket("unstoppable://top-platforms?uid=ethereum&title=Ethereum"))
+        assertTrue(isMarket("unstoppable://coin-page"))
+    }
+
+    @Test
+    fun `other app scheme links are not market links`() {
+        assertFalse(isMarket("unstoppable://wc?uri=wc:abc"))
+        assertFalse(isMarket("unstoppable://referral?userId=1"))
+        assertFalse(isMarket("unstoppable://coin-page-x?uid=bitcoin"))
+    }
+
+    @Test
+    fun `foreign schemes are not market links`() {
+        assertFalse(isMarket("bitcoin:bc1qxyz"))
+        assertFalse(isMarket("wc:abc@2?relay"))
+        assertFalse(isMarket("https://unstoppable.money/referral?userId=1"))
+        assertFalse(isMarket("myscheme://coin-page?uid=bitcoin"))
+    }
+}

--- a/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/pin/core/LockGateTest.kt
+++ b/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/pin/core/LockGateTest.kt
@@ -232,6 +232,42 @@ class LockGateTest {
     }
 
     @Test
+    fun `throwing pending action does not break the gate`() {
+        gate.selectedTab = MainNavigation.Market
+
+        gate.requireUnlocked { throw RuntimeException("boom") }
+        isLocked.value = false // must not propagate
+
+        // Collector must still be alive: later transitions keep updating the state.
+        isLocked.value = true
+        gate.selectedTab = MainNavigation.Balance
+        assertTrue(gate.showUnlock)
+
+        var runs = 0
+        gate.requireUnlocked { runs++ }
+        isLocked.value = false
+        assertEquals(1, runs)
+        assertFalse(gate.showUnlock)
+    }
+
+    @Test
+    fun `throwing listener does not break the gate or other listeners`() {
+        isLocked.value = false
+        gate.selectedTab = MainNavigation.Balance
+        var notified = 0
+        gate.addRestrictedLockListener { throw RuntimeException("boom") }
+        gate.addRestrictedLockListener { notified++ }
+
+        isLocked.value = true // must not propagate
+
+        assertEquals(1, notified)
+        assertTrue(gate.showUnlock)
+
+        isLocked.value = false
+        assertFalse(gate.showUnlock)
+    }
+
+    @Test
     fun `listener switching tab to market keeps keypad hidden`() {
         isLocked.value = false
         gate.selectedTab = MainNavigation.Balance

--- a/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/pin/core/LockGateTest.kt
+++ b/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/pin/core/LockGateTest.kt
@@ -1,0 +1,244 @@
+package io.horizontalsystems.walletkit.modules.pin.core
+
+import io.horizontalsystems.walletkit.modules.main.MainModule.MainNavigation
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LockGateTest {
+
+    private val isLocked = MutableStateFlow(true)
+    private val marketsTabEnabled = MutableStateFlow(true)
+
+    // Unconfined: flow collectors run synchronously on every value change, so the gate's
+    // derived state can be asserted right after mutating the inputs.
+    private val gate = LockGate(isLocked, marketsTabEnabled, CoroutineScope(Dispatchers.Unconfined))
+
+    @Test
+    fun `no keypad when app is not locked`() {
+        isLocked.value = false
+        gate.selectedTab = MainNavigation.Balance
+        gate.currentPageAccessibleWhileLocked = false
+
+        assertFalse(gate.showUnlock)
+        assertFalse(gate.isRestricted)
+    }
+
+    @Test
+    fun `market tab is browsable while locked`() {
+        gate.selectedTab = MainNavigation.Market
+        gate.currentPageAccessibleWhileLocked = true
+
+        assertFalse(gate.showUnlock)
+        assertTrue(gate.isRestricted)
+    }
+
+    @Test
+    fun `keypad shown before main screen reports a tab only if page is private`() {
+        // selectedTab is null on cold start until MainViewModel reports it
+        gate.currentPageAccessibleWhileLocked = true
+        assertFalse(gate.showUnlock)
+
+        gate.currentPageAccessibleWhileLocked = false
+        assertTrue(gate.showUnlock)
+    }
+
+    @Test
+    fun `wallet tabs require unlock`() {
+        gate.currentPageAccessibleWhileLocked = true
+
+        for (tab in listOf(MainNavigation.Balance, MainNavigation.Swap, MainNavigation.Settings)) {
+            gate.selectedTab = tab
+            assertTrue("keypad expected for $tab", gate.showUnlock)
+            assertFalse(gate.isTabAccessibleWhileLocked(tab))
+        }
+        assertTrue(gate.isTabAccessibleWhileLocked(MainNavigation.Market))
+    }
+
+    @Test
+    fun `private page on top requires unlock even on market tab`() {
+        gate.selectedTab = MainNavigation.Market
+        gate.currentPageAccessibleWhileLocked = false
+
+        assertTrue(gate.showUnlock)
+    }
+
+    @Test
+    fun `full lock when market tab is disabled`() {
+        marketsTabEnabled.value = false
+        gate.selectedTab = MainNavigation.Market
+        gate.currentPageAccessibleWhileLocked = true
+
+        assertTrue(gate.showUnlock)
+        assertFalse(gate.isRestricted)
+    }
+
+    @Test
+    fun `disabling market tab while browsing it locks the screen`() {
+        gate.selectedTab = MainNavigation.Market
+        assertFalse(gate.showUnlock)
+
+        marketsTabEnabled.value = false
+        assertTrue(gate.showUnlock)
+
+        marketsTabEnabled.value = true
+        assertFalse(gate.showUnlock)
+    }
+
+    @Test
+    fun `requireUnlocked runs action immediately when unlocked`() {
+        isLocked.value = false
+        var runs = 0
+
+        gate.requireUnlocked { runs++ }
+
+        assertEquals(1, runs)
+        assertFalse(gate.unlockRequested)
+        assertFalse(gate.showUnlock)
+    }
+
+    @Test
+    fun `requireUnlocked shows keypad and replays action after unlock`() {
+        gate.selectedTab = MainNavigation.Market
+        var runs = 0
+
+        gate.requireUnlocked { runs++ }
+
+        assertEquals(0, runs)
+        assertTrue(gate.unlockRequested)
+        assertTrue(gate.showUnlock)
+
+        isLocked.value = false
+
+        assertEquals(1, runs)
+        assertFalse(gate.unlockRequested)
+        assertFalse(gate.showUnlock)
+    }
+
+    @Test
+    fun `pending action is dropped when the request is cancelled`() {
+        gate.selectedTab = MainNavigation.Market
+        var runs = 0
+
+        gate.requireUnlocked { runs++ }
+        gate.cancelUnlockRequest()
+
+        assertFalse(gate.unlockRequested)
+        assertFalse(gate.showUnlock)
+
+        isLocked.value = false
+        assertEquals(0, runs)
+    }
+
+    @Test
+    fun `newer request replaces a pending one`() {
+        gate.selectedTab = MainNavigation.Market
+        val runs = mutableListOf<String>()
+
+        gate.requireUnlocked { runs.add("first") }
+        gate.requireUnlocked { runs.add("second") }
+        isLocked.value = false
+
+        assertEquals(listOf("second"), runs)
+    }
+
+    @Test
+    fun `pending action runs only once`() {
+        gate.selectedTab = MainNavigation.Market
+        var runs = 0
+
+        gate.requireUnlocked { runs++ }
+        isLocked.value = false
+        isLocked.value = true
+        isLocked.value = false
+
+        assertEquals(1, runs)
+    }
+
+    @Test
+    fun `keypad stays when unlock request is cancelled on a private screen`() {
+        gate.selectedTab = MainNavigation.Balance
+
+        gate.requireUnlocked { }
+        gate.cancelUnlockRequest()
+
+        assertTrue(gate.showUnlock)
+    }
+
+    @Test
+    fun `locking on a public screen notifies listeners`() {
+        isLocked.value = false
+        gate.selectedTab = MainNavigation.Balance
+        gate.currentPageAccessibleWhileLocked = true
+        var notified = 0
+        gate.addRestrictedLockListener { notified++ }
+
+        isLocked.value = true
+
+        assertEquals(1, notified)
+    }
+
+    @Test
+    fun `locking on a private page does not notify listeners`() {
+        isLocked.value = false
+        gate.currentPageAccessibleWhileLocked = false
+        var notified = 0
+        gate.addRestrictedLockListener { notified++ }
+
+        isLocked.value = true
+
+        assertEquals(0, notified)
+        assertTrue(gate.showUnlock)
+    }
+
+    @Test
+    fun `locking with market tab disabled does not notify listeners`() {
+        isLocked.value = false
+        marketsTabEnabled.value = false
+        gate.currentPageAccessibleWhileLocked = true
+        var notified = 0
+        gate.addRestrictedLockListener { notified++ }
+
+        isLocked.value = true
+
+        assertEquals(0, notified)
+        assertTrue(gate.showUnlock)
+    }
+
+    @Test
+    fun `initial locked state does not notify listeners`() {
+        var notified = 0
+        gate.addRestrictedLockListener { notified++ }
+        gate.currentPageAccessibleWhileLocked = true
+
+        assertEquals(0, notified)
+    }
+
+    @Test
+    fun `removed listener is not notified`() {
+        isLocked.value = false
+        var notified = 0
+        val listener: () -> Unit = { notified++ }
+        gate.addRestrictedLockListener(listener)
+        gate.removeRestrictedLockListener(listener)
+
+        isLocked.value = true
+
+        assertEquals(0, notified)
+    }
+
+    @Test
+    fun `listener switching tab to market keeps keypad hidden`() {
+        isLocked.value = false
+        gate.selectedTab = MainNavigation.Balance
+        gate.addRestrictedLockListener { gate.selectedTab = MainNavigation.Market }
+
+        isLocked.value = true
+
+        assertFalse(gate.showUnlock)
+    }
+}

--- a/walletkit/src/test/java/io/horizontalsystems/walletkit/widgets/MarketWidgetStateTest.kt
+++ b/walletkit/src/test/java/io/horizontalsystems/walletkit/widgets/MarketWidgetStateTest.kt
@@ -1,0 +1,50 @@
+package io.horizontalsystems.walletkit.widgets
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.math.BigDecimal
+
+class MarketWidgetStateTest {
+
+    private val cachedItem = MarketWidgetItem(
+        uid = "bitcoin",
+        title = "BTC",
+        subtitle = "$1.2T",
+        label = "1",
+        value = "$60,000",
+        diff = BigDecimal("1.5"),
+        blockchainTypeUid = null,
+        imageRemoteUrl = "https://example.com/btc.png",
+    )
+
+    @Test
+    fun `offline with cached rows keeps rows and hides error`() {
+        val state = MarketWidgetState(items = listOf(cachedItem), loading = true, updateTimestampMillis = 123L)
+
+        val result = state.afterRefreshFailure("No internet")
+
+        assertEquals(listOf(cachedItem), result.items)
+        assertNull(result.error)
+        assertFalse(result.loading)
+        assertEquals(123L, result.updateTimestampMillis)
+    }
+
+    @Test
+    fun `offline without cached rows shows the error`() {
+        val state = MarketWidgetState(items = emptyList(), loading = true)
+
+        val result = state.afterRefreshFailure("No internet")
+
+        assertEquals("No internet", result.error)
+        assertFalse(result.loading)
+    }
+
+    @Test
+    fun `a stale error is cleared once rows exist`() {
+        val state = MarketWidgetState(items = listOf(cachedItem), error = "old error")
+
+        assertNull(state.afterRefreshFailure("No internet").error)
+    }
+}


### PR DESCRIPTION
## Summary

**PIN-free Market tab.** The PIN keypad now covers only screens that need the wallet. The Market tab and its read-only sub-pages (coin page, categories, ETF, TVL, metrics, filters…) stay browsable while the app is locked:

- New `LockGate` (pure Kotlin) derives keypad visibility from the lock state, the selected main tab, and whether the top nav page is flagged `accessibleWhileLocked`.
- Cold start while locked opens the Market tab; auto-lock while browsing public content falls back to Market instead of showing the keypad.
- Tapping a wallet tab, navigating to a wallet page, or "Add to wallet" asks for the PIN and resumes the action after unlock; back dismisses the request.
- Full lock behavior is unchanged when the Market tab is disabled in settings; WalletConnect deferral, QR scanner close, deeplink gating and FLAG_SECURE semantics are preserved. Unlock still flows through `PinUnlockViewModel`, so lockout/biometrics/duress work as before.

**Market widget reliability.** Widget refreshes were fire-and-forget on a detached scope, so the process could die mid-fetch and rates stayed stale; offline runs replaced cached rows with a "No internet" screen:

- Worker and refresh-button action now await the refresh; periodic work requires connectivity and retries with backoff on failure.
- On failure, cached rows stay visible (error screen only when nothing is cached yet) and a one-time network-constrained job syncs as soon as the device is back online (Doze/airplane recovery).
- Widget deep links (`coin-page`, `top-platforms`) open directly while locked since they lead to public Market pages.

## Tests

- `LockGateTest` — 19 cases: tab/page accessibility, full-lock fallback, request/replay/cancel semantics, lock-transition listeners.
- `MarketDeepLinksTest`, `MarketWidgetStateTest` — deeplink classification and offline state handling.
- `./gradlew :walletkit:testDebugUnitTest` — 109 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014n5FNMw148RrQGAfwMmiwM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Market and public pages can now be browsed while the wallet is locked.
  * Wallet actions and private screens request PIN verification before proceeding.
  * Public market deep links open while locked; private links wait until unlock.
  * Market widgets refresh after updates, connectivity restoration, and scheduled updates.

* **Bug Fixes**
  * Preserves cached widget data when refreshes fail.
  * Improves offline error handling and retry behavior.
  * Prevents inappropriate screens from remaining visible after locking.
  * Keeps widget refresh scheduling active after system-triggered updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->