### PR TITLE
Update tron-kit to RxJava-free version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -81,7 +81,7 @@ ethereumKit = "1a93c92"
 feeRateKit = "393cc14"
 marketKit = "bba6b2e"
 solanaKit = "df341f6"
-tronKit = "6fc27cf"
+tronKit = "5666c3b"
 thorchainKit = "9de6579"
 zcashSdk = "2.7.0-rc.4"
 


### PR DESCRIPTION
Bumps tron-kit-android from `6fc27cf` to `5666c3b`, which removes RxJava from the kit.

- The kit's public API is unchanged — the only difference is internal to `TronGridProvider`, where Retrofit `Single<...>` endpoints became `suspend` functions; the kit's `adapter-rxjava2` and `kotlinx-coroutines-rx2` dependencies were dropped.
- No app-side changes needed: `walletkit-chain-tron` already consumes the Flow-based APIs, and its own `asFlowable()` bridges get `kotlinx-coroutines-rx2` via the `walletkit` module, not transitively from the kit.
- Verified `:walletkit-chain-tron:compileDebugKotlin` and `:app:compileBaseDebugKotlin` build against the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9PVhFpUEfUBko2ixrPJM9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying TronKit component to a newer version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->