### PR TITLE
Update tron-kit

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -81,7 +81,7 @@ ethereumKit = "1a93c92"
 feeRateKit = "393cc14"
 marketKit = "bba6b2e"
 solanaKit = "df341f6"
-tronKit = "5666c3b"
+tronKit = "4033245"
 thorchainKit = "9de6579"
 zcashSdk = "2.7.0-rc.4"
 


### PR DESCRIPTION
Bumps tron-kit-android from `5666c3b` to `4033245`.

Verified the new version resolves and `:walletkit-chain-tron:compileDebugKotlin` builds against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9PVhFpUEfUBko2ixrPJM9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TronKit dependency to a newer version.
  * Includes the latest available dependency updates and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->