### PR TITLE
Restore last selected tab on cold start and app lock

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainViewModel.kt
@@ -353,9 +353,6 @@ class MainViewModel(
                 MainNavigation.Balance
             }
 
-            // Cold start while locked: open the public Market tab instead of the keypad.
-            lockGate.isRestricted -> MainNavigation.Market
-
             else -> getLaunchTab()
         }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/Nav3.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/Nav3.kt
@@ -272,6 +272,7 @@ private fun HandleWcEvent(
 private fun ReportCurrentPageToLockGate(navigation: HSNavigation) {
     val currentScreen = navigation.lastOrNull()
     LaunchedEffect(currentScreen) {
+        App.lockGate.mainPageOnTop = currentScreen is EntryPage
         App.lockGate.currentPageAccessibleWhileLocked = currentScreen?.accessibleWhileLocked ?: false
     }
 }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/pin/core/LockGate.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/pin/core/LockGate.kt
@@ -64,6 +64,13 @@ class LockGate(
             recompute()
         }
 
+    /**
+     * Whether the main (tab) page is on top of the nav back stack. When it is, what the user
+     * actually sees is the selected tab's content, so [currentPageAccessibleWhileLocked] alone
+     * (true for the main page) does not tell whether the visible screen is public.
+     */
+    var mainPageOnTop: Boolean = true
+
     init {
         scope.launch {
             var wasLocked = isLockedFlow.value
@@ -75,9 +82,11 @@ class LockGate(
                     recompute()
                     action?.let { runDeferred(it) }
                 } else {
-                    if (!wasLocked && marketsTabEnabledFlow.value && currentPageAccessibleWhileLocked) {
+                    if (!wasLocked && marketsTabEnabledFlow.value && visibleScreenAccessibleWhileLocked()) {
                         // Locked while browsing something public: let the main screen fall back
-                        // to the Market tab so the user is not faced with the keypad.
+                        // to the Market tab so the user is not faced with the keypad. A wallet
+                        // tab on screen is not public, so it keeps its keypad and stays the
+                        // selected tab for after the unlock.
                         restrictedLockListeners.toList().forEach { runDeferred(it) }
                     }
                     recompute()
@@ -135,6 +144,17 @@ class LockGate(
         } catch (e: Exception) {
             Timber.e(e, "LockGate callback failed")
         }
+    }
+
+    /**
+     * Whether the screen the user is actually looking at may stay visible while locked:
+     * the selected tab's content when the main page is on top, otherwise the pushed page.
+     */
+    private fun visibleScreenAccessibleWhileLocked(): Boolean {
+        if (!currentPageAccessibleWhileLocked) return false
+        if (!mainPageOnTop) return true
+        val tab = selectedTab
+        return tab == null || isTabAccessibleWhileLocked(tab)
     }
 
     private fun currentScreenAccessible(): Boolean {

--- a/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/pin/core/LockGateTest.kt
+++ b/walletkit/src/test/java/io/horizontalsystems/walletkit/modules/pin/core/LockGateTest.kt
@@ -170,10 +170,38 @@ class LockGateTest {
     }
 
     @Test
-    fun `locking on a public screen notifies listeners`() {
+    fun `locking on the market tab notifies listeners`() {
+        isLocked.value = false
+        gate.selectedTab = MainNavigation.Market
+        gate.currentPageAccessibleWhileLocked = true
+        var notified = 0
+        gate.addRestrictedLockListener { notified++ }
+
+        isLocked.value = true
+
+        assertEquals(1, notified)
+    }
+
+    @Test
+    fun `locking on a wallet tab shows keypad and keeps the tab`() {
         isLocked.value = false
         gate.selectedTab = MainNavigation.Balance
         gate.currentPageAccessibleWhileLocked = true
+        var notified = 0
+        gate.addRestrictedLockListener { notified++ }
+
+        isLocked.value = true
+
+        assertEquals(0, notified)
+        assertTrue(gate.showUnlock)
+    }
+
+    @Test
+    fun `locking on a public sub-page over a wallet tab notifies listeners`() {
+        isLocked.value = false
+        gate.selectedTab = MainNavigation.Balance
+        gate.currentPageAccessibleWhileLocked = true
+        gate.mainPageOnTop = false
         var notified = 0
         gate.addRestrictedLockListener { notified++ }
 
@@ -254,6 +282,7 @@ class LockGateTest {
     fun `throwing listener does not break the gate or other listeners`() {
         isLocked.value = false
         gate.selectedTab = MainNavigation.Balance
+        gate.mainPageOnTop = false // public sub-page over a wallet tab
         var notified = 0
         gate.addRestrictedLockListener { throw RuntimeException("boom") }
         gate.addRestrictedLockListener { notified++ }
@@ -271,6 +300,7 @@ class LockGateTest {
     fun `listener switching tab to market keeps keypad hidden`() {
         isLocked.value = false
         gate.selectedTab = MainNavigation.Balance
+        gate.mainPageOnTop = false // public sub-page over a wallet tab
         gate.addRestrictedLockListener { gate.selectedTab = MainNavigation.Market }
 
         isLocked.value = true


### PR DESCRIPTION
## Summary

The Market tab was forced over the user's last selected tab in two cases:

- **Cold start while PIN-locked**: `MainViewModel.getTabIndexToOpen()` had a `lockGate.isRestricted -> Market` branch, and with a PIN set the app always starts locked — so every kill-and-restart opened Markets instead of the stored launch tab.
- **Auto-lock on the main screen**: LockGate's lock fallback only checked `currentPageAccessibleWhileLocked`, which is `true` for the main page (`EntryPage`) regardless of the selected tab. Locking after the background timeout while on the Balance tab was misread as "browsing something public" and redirected to Markets.

## Changes

- `MainViewModel`: cold start resolves through `getLaunchTab()` again; the keypad covers the tab when it needs unlocking.
- `LockGate` + `Nav3`: the gate now knows whether the main page is on top (`mainPageOnTop`). The Market fallback fires only when the visible screen is genuinely public — the Market tab itself or a public sub-page (e.g. a coin page over Balance, which keeps uninterrupted browsing). A wallet tab keeps its keypad and stays selected for after the unlock.
- `LockGateTest`: 3 tests updated to the new semantics, 2 new tests covering lock-on-wallet-tab and public-sub-page-over-wallet-tab.

## Test plan

- `./gradlew :walletkit:testDebugUnitTest --tests "*.LockGateTest"` — 23 tests, 0 failures
- Manual: with PIN set, select Balance, kill app → reopens on Balance behind keypad; background 2–3 min until auto-lock, resume → stays on Balance behind keypad; lock while on Market tab or a coin page → still browsable without PIN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Grw5Cj2iCEkf2J9uTjwoGe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock-screen behavior when navigating between wallet tabs, the Market tab, and public sub-pages.
  * Wallet tabs now remain selected and protected when the app locks, while genuinely public screens continue to be handled appropriately.
  * Locked cold starts now follow the configured launch page or current main tab instead of always opening Market.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->