### PR TITLE
Replace dead default EVM RPC endpoints

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/managers/EvmSyncSourceManager.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/managers/EvmSyncSourceManager.kt
@@ -85,8 +85,8 @@ class EvmSyncSourceManager(
                 ),
                 evmSyncSource(
                     blockchainType,
-                    "LlamaNodes",
-                    listOf(URI("https://polygon.llamarpc.com"))
+                    "PublicNode",
+                    listOf(URI("https://polygon-bor-rpc.publicnode.com"))
                 )
             )
 
@@ -99,7 +99,7 @@ class EvmSyncSourceManager(
                 evmSyncSource(
                     blockchainType,
                     "PublicNode",
-                    listOf(URI("https://avalanche-evm.publicnode.com"))
+                    listOf(URI("https://avalanche-c-chain-rpc.publicnode.com"))
                 )
             )
 
@@ -111,8 +111,8 @@ class EvmSyncSourceManager(
                 ),
                 evmSyncSource(
                     blockchainType,
-                    "Omnia",
-                    listOf(URI("https://endpoints.omniatech.io/v1/op/mainnet/public"))
+                    "PublicNode",
+                    listOf(URI("https://optimism-rpc.publicnode.com"))
                 )
             )
 
@@ -139,6 +139,11 @@ class EvmSyncSourceManager(
                     blockchainType,
                     "ZKsync",
                     listOf(URI("https://mainnet.era.zksync.io"))
+                ),
+                evmSyncSource(
+                    blockchainType,
+                    "dRPC",
+                    listOf(URI("https://zksync.drpc.org"))
                 )
             )
 
@@ -158,8 +163,8 @@ class EvmSyncSourceManager(
                 ),
                 evmSyncSource(
                     blockchainType,
-                    "Omnia",
-                    listOf(URI("https://endpoints.omniatech.io/v1/arbitrum/one/public"))
+                    "PublicNode",
+                    listOf(URI("https://arbitrum-one-rpc.publicnode.com"))
                 )
             )
 
@@ -171,8 +176,8 @@ class EvmSyncSourceManager(
                 ),
                 evmSyncSource(
                     blockchainType,
-                    "Ankr",
-                    listOf(URI("https://rpc.ankr.com/gnosis"))
+                    "dRPC",
+                    listOf(URI("https://gnosis.drpc.org"))
                 )
             )
 
@@ -189,8 +194,8 @@ class EvmSyncSourceManager(
                 ),
                 evmSyncSource(
                     blockchainType,
-                    "Ankr",
-                    listOf(URI("https://rpc.ankr.com/fantom"))
+                    "dRPC",
+                    listOf(URI("https://fantom.drpc.org"))
                 )
             )
 


### PR DESCRIPTION
#9603
Probed every default EVM sync source; five were broken and got replaced with verified keyless public endpoints (3/3 responses, 150–290ms):

- **Polygon**: LlamaNodes (dead, no response) → PublicNode `polygon-bor-rpc.publicnode.com`
- **Optimism**: Omnia (Cloudflare 521, gateway down) → PublicNode `optimism-rpc.publicnode.com`
- **Arbitrum**: Omnia (Cloudflare 521) → PublicNode `arbitrum-one-rpc.publicnode.com`
- **Gnosis**: Ankr (now requires API key) → dRPC `gnosis.drpc.org`
- **Fantom**: Ankr (now requires API key) → dRPC `fantom.drpc.org`

Also:
- **Avalanche**: legacy `avalanche-evm.publicnode.com` → canonical `avalanche-c-chain-rpc.publicnode.com`
- **ZkSync**: added dRPC `zksync.drpc.org` as a second source (was the only chain with a single default)

Source order is unchanged, so existing defaults (first entry per chain) stay the same. Ethereum and BSC were intentionally left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Grw5Cj2iCEkf2J9uTjwoGe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated default network synchronization endpoints for Polygon, Avalanche, Optimism, Arbitrum One, Gnosis, and Fantom.
  * Added a second default synchronization source for ZkSync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->