### PR TITLE
Open widget deep links directly on their page

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/CoinPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/coin/CoinPage.kt
@@ -23,6 +23,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class CoinPage(val input: Input) : HSPage(accessibleWhileLocked = true) {
 
+    override fun contentKey() = "${super.contentKey()}-${input.coinUid}"
+
     @Composable
     override fun GetContent(navigation: HSNavigation) {
         CoinScreen(

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainActivityViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainActivityViewModel.kt
@@ -15,6 +15,7 @@ import io.horizontalsystems.walletkit.core.managers.UserManager
 import io.horizontalsystems.walletkit.modules.walletconnect.WCDelegate
 import io.horizontalsystems.walletkit.security.KeyStoreValidationError
 import io.horizontalsystems.dapp.core.HSDAppEvent
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 import java.util.UUID
 
@@ -45,7 +46,10 @@ class MainActivityViewModel(
         }
 
         viewModelScope.launch {
-            userManager.currentUserLevelFlow.collect {
+            // Only a change of user level sends the app back to the main screen. The StateFlow's
+            // current value replays on every activity start and would pop a page opened on
+            // launch (a widget deeplink, or a restored back stack).
+            userManager.currentUserLevelFlow.drop(1).collect {
                 navigateToMainLiveData.postValue(UUID.randomUUID().toString())
             }
         }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainModule.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainModule.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStoreOwner
 import io.horizontalsystems.walletkit.R
 import io.horizontalsystems.walletkit.core.App
 import io.horizontalsystems.walletkit.core.managers.ActionCompletedDelegate
@@ -14,6 +15,10 @@ import io.horizontalsystems.walletkit.modules.nav3.HSPage
 import io.horizontalsystems.walletkit.modules.walletconnect.WCManager
 
 object MainModule {
+
+    /** The activity-scoped [MainViewModel]; created on first use. */
+    fun viewModel(owner: ViewModelStoreOwner): MainViewModel =
+        ViewModelProvider(owner, Factory())[MainViewModel::class.java]
 
     class Factory : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainPage.kt
@@ -1,5 +1,7 @@
 package io.horizontalsystems.walletkit.modules.main
 
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.LocalActivity
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
@@ -82,7 +84,9 @@ private fun MainScreen(
     transactionsViewModel: TransactionsViewModel,
     navigation: HSNavigation,
     parentScreenContentKey: String,
-    viewModel: MainViewModel = viewModel(factory = MainModule.Factory())
+    // Activity-scoped so the navigation root (Nav3) can reach it for widget deeplinks
+    // before this screen is composed. EntryPage is never popped, so the lifetime is the same.
+    viewModel: MainViewModel = MainModule.viewModel(LocalActivity.current as ComponentActivity)
 ) {
     val activityIntent by mainActivityViewModel.intentLiveData.observeAsState()
     val isLocked by App.pinComponent.isLockedFlow.collectAsStateWithLifecycle()
@@ -90,21 +94,11 @@ private fun MainScreen(
     // while the app is locked would be acted on behind the lock screen — referral registration,
     // TonConnect links, prefilled send flows, the WalletConnect list. The intent is deliberately
     // left unconsumed (no intentHandled() call) so this effect re-runs when isLocked flips back.
-    // Market deeplinks (widget taps) only open pages that are browsable while locked, so they
-    // go through right away.
+    // Market deeplinks (widget taps) never get here: Nav3 opens them at the navigation root.
     LaunchedEffect(activityIntent, isLocked) {
-        val uri = activityIntent?.data
-        val publicWhileLocked = isLocked && uri != null && viewModel.isPublicDeepLink(uri)
-        if (isLocked && !publicWhileLocked) return@LaunchedEffect
+        if (isLocked) return@LaunchedEffect
 
-        uri?.let {
-            if (publicWhileLocked) {
-                // The app may be sitting on the keypad because of a pending unlock request
-                // (e.g. a wallet tab was tapped earlier). The user now asked for public
-                // content, so drop that request — otherwise the keypad would keep covering
-                // the page this deeplink opens.
-                viewModel.cancelPendingUnlockRequest()
-            }
+        activityIntent?.data?.let {
             delay(1000)
             viewModel.handleDeepLink(it)
             mainActivityViewModel.intentHandled()

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MainViewModel.kt
@@ -30,7 +30,6 @@ import io.horizontalsystems.walletkit.modules.balance.OpenSendTokenSelect
 import io.horizontalsystems.walletkit.modules.coin.CoinPage
 import io.horizontalsystems.walletkit.modules.main.MainModule.MainNavigation
 import io.horizontalsystems.walletkit.modules.market.platform.MarketPlatformPage
-import io.horizontalsystems.walletkit.modules.market.topplatforms.Platform
 import io.horizontalsystems.walletkit.modules.pin.core.LockGate
 import io.horizontalsystems.walletkit.modules.walletconnect.WCManager
 import io.horizontalsystems.walletkit.modules.walletconnect.WCSessionManager
@@ -388,28 +387,21 @@ class MainViewModel(
             }
 
             MarketDeepLinks.isMarketDeepLink(deeplinkString, deeplinkScheme) -> {
-                val uid = deepLink.getQueryParameter("uid")
-                when {
-                    deeplinkString.contains("coin-page") -> {
-                        uid?.let {
-                            deeplinkPage = DeeplinkPage(CoinPage(CoinPage.Input(it)))
+                // The page itself is opened at the navigation root (see Nav3) so it shows
+                // right away; only the tab behind it is switched here, so going back lands on
+                // Market and the page stays browsable while locked.
+                when (val page = MarketDeepLinks.page(deepLink, deeplinkScheme)) {
+                    is CoinPage -> stat(page = StatPage.Widget, event = StatEvent.OpenCoin(page.input.coinUid))
+                    is MarketPlatformPage -> stat(page = StatPage.Widget, event = StatEvent.Open(StatPage.TopPlatform))
+                    else -> {}
+                }
 
-                            stat(page = StatPage.Widget, event = StatEvent.OpenCoin(it))
-                        }
-                    }
-
-                    deeplinkString.contains("top-platforms") -> {
-                        val title = deepLink.getQueryParameter("title")
-                        if (title != null && uid != null) {
-                            val platform = Platform(uid, title)
-                            deeplinkPage = DeeplinkPage(MarketPlatformPage(platform))
-
-                            stat(
-                                page = StatPage.Widget,
-                                event = StatEvent.Open(StatPage.TopPlatform)
-                            )
-                        }
-                    }
+                if (lockGate.isLocked) {
+                    // The app may be sitting on the keypad because of a pending unlock request
+                    // (e.g. a wallet tab was tapped earlier). The user now asked for public
+                    // content, so drop that request — otherwise the keypad would keep covering
+                    // the page this deeplink opens.
+                    lockGate.cancelUnlockRequest()
                 }
 
                 tab = MainNavigation.Market
@@ -492,17 +484,6 @@ class MainViewModel(
     }
 
     /** Dismisses a keypad shown for a deferred action and drops that action. */
-    fun cancelPendingUnlockRequest() {
-        lockGate.cancelUnlockRequest()
-    }
-
-    /** Deeplink that resolves to Market content only (widget taps); safe to open while locked. */
-    fun isPublicDeepLink(uri: Uri): Boolean =
-        lockGate.isRestricted && MarketDeepLinks.isMarketDeepLink(
-            uri.toString(),
-            Translator.getString(R.string.DeeplinkScheme)
-        )
-
     fun deeplinkPageHandled() {
         deeplinkPage = null
         emitState()

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MarketDeepLinks.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/MarketDeepLinks.kt
@@ -1,12 +1,32 @@
 package io.horizontalsystems.walletkit.modules.main
 
+import android.net.Uri
+import io.horizontalsystems.walletkit.modules.coin.CoinPage
+import io.horizontalsystems.walletkit.modules.market.platform.MarketPlatformPage
+import io.horizontalsystems.walletkit.modules.market.topplatforms.Platform
+import io.horizontalsystems.walletkit.modules.nav3.HSPage
+
 /** Deeplinks produced by the market widget; they lead to read-only Market pages. */
 object MarketDeepLinks {
-    private val paths = listOf("coin-page", "top-platforms")
+    private const val COIN_PAGE = "coin-page"
+    private const val TOP_PLATFORMS = "top-platforms"
+    private val paths = listOf(COIN_PAGE, TOP_PLATFORMS)
 
-    fun isMarketDeepLink(deeplink: String, scheme: String): Boolean {
-        if (!deeplink.startsWith("$scheme:")) return false
-        val path = deeplink.removePrefix("$scheme:").trimStart('/').substringBefore('?')
-        return path in paths
+    fun isMarketDeepLink(deeplink: String, scheme: String): Boolean =
+        path(deeplink, scheme) in paths
+
+    /** Page a market deeplink opens, or null when it is not one or lacks its parameters. */
+    fun page(uri: Uri, scheme: String): HSPage? {
+        val uid = uri.getQueryParameter("uid") ?: return null
+        return when (path(uri.toString(), scheme)) {
+            COIN_PAGE -> CoinPage(CoinPage.Input(uid))
+            TOP_PLATFORMS -> uri.getQueryParameter("title")?.let { MarketPlatformPage(Platform(uid, it)) }
+            else -> null
+        }
+    }
+
+    private fun path(deeplink: String, scheme: String): String? {
+        if (!deeplink.startsWith("$scheme:")) return null
+        return deeplink.removePrefix("$scheme:").trimStart('/').substringBefore('?')
     }
 }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/platform/MarketPlatformPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/market/platform/MarketPlatformPage.kt
@@ -71,6 +71,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class MarketPlatformPage(val platform: Platform) : HSPage(accessibleWhileLocked = true) {
 
+    override fun contentKey() = "${super.contentKey()}-${platform.uid}"
+
     @Composable
     override fun GetContent(navigation: HSNavigation) {
         val factory = MarketPlatformModule.Factory(platform)

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/HSPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/HSPage.kt
@@ -31,7 +31,11 @@ abstract class HSPage(
     var navType: NavigationType = NavigationType.SlideFromRight,
 ) : NavKey {
 
-    fun contentKey() = this::class.simpleName ?: "HSScreen"
+    // Identifies the entry's content: NavDisplay, the saveable state holder and the per-entry
+    // ViewModel store are all keyed by it. Pages that can be replaced by another instance of
+    // the same class in one frame (e.g. a coin page by a widget tap) must include what makes
+    // the instance distinct, or the old content and its ViewModel stay on screen.
+    open fun contentKey(): String = this::class.simpleName ?: "HSScreen"
 
     @OptIn(ExperimentalMaterial3Api::class)
     fun getMetadata() = buildMap {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/Nav3.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/Nav3.kt
@@ -159,6 +159,15 @@ private fun IntentEffect(viewModel: MainActivityViewModel, navigation: HSNavigat
         val consumer = Consumer<Intent> {
             if (!handleWalletConnectDeepLink(it, navigation)) {
                 viewModel.setIntent(it)
+                // The intent is consumed by MainScreen's observer, which only runs while
+                // MainScreen (EntryPage) is composed. If an inner screen (e.g. a coin page
+                // opened from an earlier widget tap) is on top, the deeplink would sit
+                // unhandled until the user returns to the main screen. Pop to the root only
+                // for real deeplinks: a plain launcher tap also delivers a new intent (without
+                // data) and must keep the current screen.
+                if (it.data != null) {
+                    navigation.removeLastUntil(EntryPage::class, false)
+                }
             }
         }
         (activity as? ComponentActivity)?.addOnNewIntentListener(consumer)

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/Nav3.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/Nav3.kt
@@ -1,5 +1,6 @@
 package io.horizontalsystems.walletkit.modules.nav3
 
+import android.app.Activity
 import android.content.Intent
 import android.view.WindowManager
 import android.widget.Toast
@@ -17,8 +18,11 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.saveable.rememberSerializable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
@@ -33,11 +37,14 @@ import androidx.navigation3.runtime.serialization.NavKeySerializer
 import androidx.navigation3.ui.NavDisplay
 import io.horizontalsystems.walletkit.R
 import io.horizontalsystems.walletkit.core.App
+import io.horizontalsystems.walletkit.core.providers.Translator
 import io.horizontalsystems.walletkit.helpers.HudHelper
 import io.horizontalsystems.walletkit.hideKeyboard
 import io.horizontalsystems.walletkit.modules.keystore.KeyStoreActivity
 import io.horizontalsystems.walletkit.modules.main.MainActivityViewModel
 import io.horizontalsystems.walletkit.modules.main.MainActivityViewModel.Factory
+import io.horizontalsystems.walletkit.modules.main.MainModule
+import io.horizontalsystems.walletkit.modules.main.MarketDeepLinks
 import io.horizontalsystems.walletkit.modules.main.MainScreenValidationError
 import io.horizontalsystems.walletkit.modules.pin.ui.PinUnlock
 import io.horizontalsystems.walletkit.modules.walletconnect.WCAccountTypeNotSupportedSheet
@@ -56,10 +63,16 @@ fun Nav3(entryPage: HSPage) {
     // pages stay browsable while locked (see LockGate).
     val showUnlock by App.lockGate.showUnlockFlow.collectAsState()
 
+    val activity = LocalActivity.current
+
     val backStack = rememberSerializable(
         serializer = NavBackStackSerializer(elementSerializer = NavKeySerializer())
     ) {
-        NavBackStack<HSPage>(entryPage)
+        // A market widget tap starts right on its page. Pushing it after the first frame would
+        // show the main screen first and then slide the page in. IntentEffect switches the tab
+        // behind it.
+        val pages = listOfNotNull(entryPage, marketDeepLinkPage(activity?.intent))
+        NavBackStack<HSPage>(*pages.toTypedArray())
     }
 
     val hsNavigation = remember { HSNavigation(backStack) }
@@ -79,8 +92,6 @@ fun Nav3(entryPage: HSPage) {
             mainActivityViewModel.reEmitPendingWcEventIfNeeded()
         }
     }
-
-    val activity = LocalActivity.current
 
     Box {
         val eventBusNavEntryDecorator = rememberResultEventBusNavEntryDecorator<HSPage>()
@@ -148,25 +159,37 @@ private fun HandleNavigateToMain(
 @Composable
 private fun IntentEffect(viewModel: MainActivityViewModel, navigation: HSNavigation) {
     val activity = LocalActivity.current
+    // The launch intent is acted on once, on a fresh start. After process death the activity
+    // comes back with the same intent, and the restored back stack already reflects it.
+    var launchIntentHandled by rememberSaveable { mutableStateOf(false) }
     LaunchedEffect(Unit) {
+        if (launchIntentHandled) return@LaunchedEffect
+        launchIntentHandled = true
         activity?.intent?.let {
-            if (!handleWalletConnectDeepLink(it, navigation)) {
-                viewModel.setIntent(it)
+            when {
+                handleWalletConnectDeepLink(it, navigation) -> {}
+                // Its page is already the initial back stack entry (see Nav3).
+                handleMarketDeepLink(it, activity, navigation, openPage = false) -> {}
+                else -> viewModel.setIntent(it)
             }
         }
     }
     DisposableEffect(activity) {
         val consumer = Consumer<Intent> {
-            if (!handleWalletConnectDeepLink(it, navigation)) {
-                viewModel.setIntent(it)
-                // The intent is consumed by MainScreen's observer, which only runs while
-                // MainScreen (EntryPage) is composed. If an inner screen (e.g. a coin page
-                // opened from an earlier widget tap) is on top, the deeplink would sit
-                // unhandled until the user returns to the main screen. Pop to the root only
-                // for real deeplinks: a plain launcher tap also delivers a new intent (without
-                // data) and must keep the current screen.
-                if (it.data != null) {
-                    navigation.removeLastUntil(EntryPage::class, false)
+            when {
+                handleWalletConnectDeepLink(it, navigation) -> {}
+                handleMarketDeepLink(it, activity, navigation, openPage = true) -> {}
+                else -> {
+                    viewModel.setIntent(it)
+                    // The intent is consumed by MainScreen's observer, which only runs while
+                    // MainScreen (EntryPage) is composed. If an inner screen (e.g. Receive) is
+                    // on top, the deeplink would sit unhandled until the user returns to the
+                    // main screen. Pop to the root only for real deeplinks: a plain launcher
+                    // tap also delivers a new intent (without data) and must keep the current
+                    // screen.
+                    if (it.data != null) {
+                        navigation.removeLastUntil(EntryPage::class, false)
+                    }
                 }
             }
         }
@@ -175,6 +198,41 @@ private fun IntentEffect(viewModel: MainActivityViewModel, navigation: HSNavigat
             (activity as? ComponentActivity)?.removeOnNewIntentListener(consumer)
         }
     }
+}
+
+private fun deeplinkScheme(): String = Translator.getString(R.string.DeeplinkScheme)
+
+// Page a market widget deeplink opens, or null if the intent is not one. Before onboarding has
+// finished there is no main screen to put the page over, so the link is ignored.
+private fun marketDeepLinkPage(intent: Intent?): HSPage? {
+    val uri = intent?.data ?: return null
+    if (!App.localStorage.mainShowedOnceFlow.value) return null
+    return MarketDeepLinks.page(uri, deeplinkScheme())
+}
+
+// Market widget deeplinks are opened here, at the navigation root, rather than through
+// MainScreen's deeplink flow: that flow runs only while MainScreen is composed and shows the
+// Market tab before sliding the page in. Returns true if the intent was a market deeplink.
+//
+// The tab behind the page is switched to Market by MainViewModel (activity-scoped, so it can be
+// reached before MainScreen is composed) so that going back lands on Market and the page stays
+// browsable while locked — a wallet tab underneath would bring up the keypad.
+private fun handleMarketDeepLink(
+    intent: Intent,
+    activity: Activity?,
+    navigation: HSNavigation,
+    openPage: Boolean,
+): Boolean {
+    val uri = intent.data ?: return false
+    if (!MarketDeepLinks.isMarketDeepLink(uri.toString(), deeplinkScheme())) return false
+
+    val page = marketDeepLinkPage(intent) ?: return true
+    (activity as? ComponentActivity)?.let { MainModule.viewModel(it).handleDeepLink(uri) }
+    if (openPage) {
+        navigation.removeLastUntil(EntryPage::class, false)
+        navigation.slideFromRight(page)
+    }
+    return true
 }
 
 // WalletConnect deeplinks are handled here, at the navigation root, so they work no matter which


### PR DESCRIPTION
Two fixes for market widget taps.

**A second widget tap was ignored while a coin page was open.** Deep links are consumed by MainScreen, which is composed only while it is the top entry. Tapping Tron in the widget while the Sol page from an earlier tap was still on top left the new intent unhandled, so the app resumed on Sol. The new-intent listener now pops to the root for intents that carry data. A launcher-icon tap carries none, so it keeps the current screen (#9579 stays fixed).

**The Market tab showed for ~1.5s before the coin page.** The MainScreen flow waited a second, switched to the Market tab, waited again, then slid the page in. Market widget links are now handled at the navigation root: on a cold start the page is the initial back stack entry, on a warm start it is pushed immediately. `MainViewModel` is activity-scoped so the root can still switch the tab behind the page to Market, which keeps back landing on Market and keeps the page browsable while locked.

Supporting changes:
- `CoinPage` and `MarketPlatformPage` include their id in `contentKey()`. NavDisplay, the saveable state holder and the per-entry ViewModel store are keyed by it, so replacing the Sol page with the Tron page in one frame otherwise kept Sol's content and ViewModel on screen.
- The user-level observer in `MainActivityViewModel` reacts only to changes; its initial StateFlow value was popping the stack to the root on every start.
- The launch intent is handled once per fresh start instead of again after process death.
- A widget tap before onboarding is finished is ignored rather than queued.

Tested on an emulator by firing the intents the widget sends: cold start lands on the coin page with no Markets flash, a second tap replaces the first coin page, back lands on Market, the top-platforms link opens the platform page, and Settings or an inner Appearance page survive a launcher tap. walletkit unit tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved market deep-link handling for coin and platform pages.
  * Market links now open at the navigation root and support smoother routing from widgets and launch intents.
  * Navigation state is preserved more reliably across page entries.

* **Bug Fixes**
  * Prevented repeated processing of the initial user-level state during startup.
  * Deep links are now consistently deferred while the wallet is locked and can be processed after unlocking.
  * Improved separation of page state for different coins and market platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->