### PR TITLE
Add a config switch for auto-enabling received tokens

### DIFF
--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/core/managers/EvmAccountManager.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/core/managers/EvmAccountManager.kt
@@ -246,6 +246,7 @@ class EvmAccountManager(
     }
 
     private suspend fun handle(tokenInfos: List<TokenInfo>, account: Account, evmKit: EthereumKit) = withContext(Dispatchers.IO) {
+        if (!tokenAutoEnableManager.autoEnableTokensOnReceive) return@withContext
 //        Log.e("AAA", "handle tokens ${tokenInfos.size} \n ${tokenInfos.joinToString(separator = " ") { it.type.id }}")
 
         val existingWallets = walletManager.activeWallets

--- a/walletkit-chain-solana/src/main/java/io/horizontalsystems/walletkit/chain/solana/SolanaChainPlugin.kt
+++ b/walletkit-chain-solana/src/main/java/io/horizontalsystems/walletkit/chain/solana/SolanaChainPlugin.kt
@@ -55,7 +55,7 @@ class SolanaChainPlugin(
     val kitManager by lazy {
         SolanaKitManager(
             rpcSourceManager,
-            SolanaWalletManager(App.walletManager, App.accountManager, App.marketKit),
+            SolanaWalletManager(App.walletManager, App.accountManager, App.marketKit, App.tokenAutoEnableManager),
             App.backgroundManager,
         )
     }

--- a/walletkit-chain-solana/src/main/java/io/horizontalsystems/walletkit/core/managers/SolanaWalletManager.kt
+++ b/walletkit-chain-solana/src/main/java/io/horizontalsystems/walletkit/core/managers/SolanaWalletManager.kt
@@ -10,11 +10,13 @@ import io.horizontalsystems.solanakit.models.FullTokenAccount
 class SolanaWalletManager(
         private val walletManager: WalletManager,
         private val accountManager: IAccountManager,
-        private val marketKit: MarketKitWrapper
+        private val marketKit: MarketKitWrapper,
+        private val tokenAutoEnableManager: TokenAutoEnableManager,
 ) {
 
     @Synchronized
     fun add(tokenAccounts: List<FullTokenAccount>) {
+        if (!tokenAutoEnableManager.autoEnableTokensOnReceive) return
         val account = accountManager.activeAccount ?: return
         val queries = tokenAccounts
                 .filter { !it.mintAccount.isNft }

--- a/walletkit-chain-stellar/src/main/java/io/horizontalsystems/walletkit/core/managers/StellarAccountManager.kt
+++ b/walletkit-chain-stellar/src/main/java/io/horizontalsystems/walletkit/core/managers/StellarAccountManager.kt
@@ -100,6 +100,7 @@ class StellarAccountManager(
         val newAssets = assets.filter { !existingTokenTypeIds.contains(it.tokenType.id) }
 
         if (newAssets.isEmpty()) return
+        if (!tokenAutoEnableManager.autoEnableTokensOnReceive) return
 
         val enabledWallets = newAssets.map { asset ->
             val tokenQuery = TokenQuery(BlockchainType.Stellar, asset.tokenType)

--- a/walletkit-chain-thorchain/src/main/java/io/horizontalsystems/walletkit/core/managers/ThorchainAccountManager.kt
+++ b/walletkit-chain-thorchain/src/main/java/io/horizontalsystems/walletkit/core/managers/ThorchainAccountManager.kt
@@ -99,6 +99,7 @@ class ThorchainAccountManager(
         val existingTokenTypeIds = walletManager.activeWallets.map { it.token.type.id }
         val newQueries = queries.filter { !existingTokenTypeIds.contains(it.tokenType.id) }
         if (newQueries.isEmpty()) return
+        if (!tokenAutoEnableManager.autoEnableTokensOnReceive) return
 
         // Only tokens known to marketkit get enabled — resolves proper name/code/decimals/image.
         val tokens = marketKit.tokens(newQueries)

--- a/walletkit-chain-ton/src/main/java/io/horizontalsystems/walletkit/core/managers/TonAccountManager.kt
+++ b/walletkit-chain-ton/src/main/java/io/horizontalsystems/walletkit/core/managers/TonAccountManager.kt
@@ -121,6 +121,7 @@ class TonAccountManager(
             .filter { it.verification != JettonVerificationType.BLACKLIST }
 
         if (newJettons.isEmpty()) return
+        if (!tokenAutoEnableManager.autoEnableTokensOnReceive) return
 
         val enabledWallets = newJettons.map { jetton ->
             EnabledWallet(

--- a/walletkit-chain-tron/src/main/java/io/horizontalsystems/walletkit/core/managers/TronAccountManager.kt
+++ b/walletkit-chain-tron/src/main/java/io/horizontalsystems/walletkit/core/managers/TronAccountManager.kt
@@ -191,6 +191,7 @@ class TronAccountManager(
     }
 
     private suspend fun handle(tokenInfos: List<TokenInfo>, account: Account, tronKit: TronKit) = withContext(Dispatchers.IO) {
+        if (!tokenAutoEnableManager.autoEnableTokensOnReceive) return@withContext
         val existingWallets = walletManager.activeWallets
         val existingTokenTypeIds = existingWallets.map { it.token.type.id }
         val newTokenInfos = tokenInfos.filter { !existingTokenTypeIds.contains(it.type.id) }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/App.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/App.kt
@@ -329,7 +329,7 @@ abstract class App : CoreApp(), WorkConfiguration.Provider, ImageLoaderFactory {
 
         walletActivator = WalletActivator(walletManager, marketKit)
         passkeyManager = PasskeyManager()
-        tokenAutoEnableManager = TokenAutoEnableManager(appDatabase.tokenAutoEnabledBlockchainDao())
+        tokenAutoEnableManager = TokenAutoEnableManager(appDatabase.tokenAutoEnabledBlockchainDao(), appConfig.autoEnableTokensOnReceive)
 
         scannedTransactionStorage = ScannedTransactionStorage(appDatabase.scannedTransactionDao())
         contactsRepository = ContactsRepository(marketKit)

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/managers/TokenAutoEnableManager.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/managers/TokenAutoEnableManager.kt
@@ -6,7 +6,9 @@ import io.horizontalsystems.walletkit.entities.TokenAutoEnabledBlockchain
 import io.horizontalsystems.marketkit.models.BlockchainType
 
 class TokenAutoEnableManager(
-    private val tokenAutoEnabledBlockchainDao: TokenAutoEnabledBlockchainDao
+    private val tokenAutoEnabledBlockchainDao: TokenAutoEnabledBlockchainDao,
+    // Global switch over every chain's on-receive auto-enable path.
+    val autoEnableTokensOnReceive: Boolean = true,
 ) {
     fun markAutoEnable(account: Account, blockchainType: BlockchainType) {
         tokenAutoEnabledBlockchainDao.insert(TokenAutoEnabledBlockchain(account.id, blockchainType))

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/providers/IAppConfigProvider.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/providers/IAppConfigProvider.kt
@@ -66,4 +66,13 @@ interface IAppConfigProvider {
     val oneInchPartnerFeeAddress: String
     val swapFeeBps: Int
     val fdroidBuild: Boolean
+
+    /**
+     * Whether a token that shows up in the account's history (a received transfer, a swap
+     * output, a discovered token account) gets a wallet enabled for it automatically. An app
+     * that works with a fixed token set turns this off; its wallets then come only from the
+     * explicit enable paths.
+     */
+    val autoEnableTokensOnReceive: Boolean
+        get() = true
 }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/BalanceViewItemFactory.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/BalanceViewItemFactory.kt
@@ -3,6 +3,7 @@ package io.horizontalsystems.walletkit.modules.balance
 import androidx.compose.runtime.Immutable
 import io.horizontalsystems.walletkit.R
 import io.horizontalsystems.walletkit.core.AdapterState
+import io.horizontalsystems.walletkit.core.BalanceData
 import io.horizontalsystems.walletkit.core.App
 import io.horizontalsystems.walletkit.core.Caution
 import io.horizontalsystems.walletkit.core.diff
@@ -78,6 +79,9 @@ data class StellarAssetLockedValue(val title: String, val value: String)
 @Immutable
 data class BalanceViewItem2(
     val wallet: Wallet,
+    // The raw balance the formatted values were derived from, for callers that filter or
+    // compute rather than display.
+    val balanceData: BalanceData,
     val primaryValue: DeemedValue<String>?,
     val exchangeValue: DeemedValue<String>?,
     val diff: DeemedValue<BigDecimal>?,
@@ -438,6 +442,7 @@ class BalanceViewItemFactory {
 
         return BalanceViewItem2(
             wallet = item.wallet,
+            balanceData = item.balanceData,
             primaryValue = primaryValue,
             secondaryValue = secondaryValue,
             exchangeValue = latestRate?.let { BalanceViewHelper.rateValue(it, currency) },


### PR DESCRIPTION
Adds `IAppConfigProvider.autoEnableTokensOnReceive` (default true), checked in every chain's on-receive wallet enabling path, and exposes the raw `balanceData` on `BalanceViewItem2`. Part of #9409.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an app configuration option to control whether newly received or discovered tokens are automatically enabled.
  * Token auto-enabling now respects this setting across supported EVM, Solana, Stellar, THORChain, TON, and Tron accounts.
  * Balance view items now include the underlying balance data for more detailed balance handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->