### PR TITLE
Show sync error sheet once per token balance visit

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/token/TokenBalanceModule.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/token/TokenBalanceModule.kt
@@ -68,6 +68,7 @@ class TokenBalanceModule {
         val alertUnshieldedBalance: BigDecimal?,
         val attentionIcon: AttentionIcon?,
         val showTronNotActiveAlert: Boolean,
+        val showSyncErrorAlert: Boolean,
         val zcashMigrationRequiredAmount: String? = null,
     )
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/token/TokenBalanceScreen.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/token/TokenBalanceScreen.kt
@@ -112,9 +112,9 @@ fun TokenBalanceScreen(
 
     LaunchedEffect(uiState.showSyncErrorAlert) {
         if (uiState.showSyncErrorAlert) {
-            viewModel.hideSyncErrorAlert()
             delay(300)
             openSyncErrorDialog(uiState, navigation)
+            viewModel.hideSyncErrorAlert()
         }
     }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/token/TokenBalanceScreen.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/token/TokenBalanceScreen.kt
@@ -113,10 +113,8 @@ fun TokenBalanceScreen(
     LaunchedEffect(uiState.showSyncErrorAlert) {
         if (uiState.showSyncErrorAlert) {
             viewModel.hideSyncErrorAlert()
-            coroutineScope.launch {
-                delay(300)
-                openSyncErrorDialog(uiState, navigation)
-            }
+            delay(300)
+            openSyncErrorDialog(uiState, navigation)
         }
     }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/token/TokenBalanceScreen.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/token/TokenBalanceScreen.kt
@@ -112,10 +112,10 @@ fun TokenBalanceScreen(
 
     LaunchedEffect(uiState.showSyncErrorAlert) {
         if (uiState.showSyncErrorAlert) {
+            viewModel.hideSyncErrorAlert()
             coroutineScope.launch {
                 delay(300)
                 openSyncErrorDialog(uiState, navigation)
-                viewModel.hideSyncErrorAlert()
             }
         }
     }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/token/TokenBalanceScreen.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/token/TokenBalanceScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.material3.SheetState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -33,18 +32,16 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.LifecycleResumeEffect
 import io.horizontalsystems.walletkit.R
 import io.horizontalsystems.walletkit.core.Caution
+import io.horizontalsystems.walletkit.core.chain.ChainRegistry
 import io.horizontalsystems.walletkit.core.isCustom
 import io.horizontalsystems.walletkit.core.providers.Translator
 import io.horizontalsystems.walletkit.core.shorten
 import io.horizontalsystems.walletkit.core.stats.StatEvent
 import io.horizontalsystems.walletkit.core.stats.StatPage
 import io.horizontalsystems.walletkit.core.stats.stat
-import io.horizontalsystems.walletkit.core.App
 import io.horizontalsystems.walletkit.entities.Wallet
-import io.horizontalsystems.walletkit.core.chain.ChainRegistry
 import io.horizontalsystems.walletkit.helpers.HudHelper
 import io.horizontalsystems.walletkit.modules.balance.AttentionIconType
 import io.horizontalsystems.walletkit.modules.balance.BalanceViewItem
@@ -61,8 +58,8 @@ import io.horizontalsystems.walletkit.modules.receive.ReceivePage
 import io.horizontalsystems.walletkit.modules.send.address.EnterAddressPage
 import io.horizontalsystems.walletkit.modules.syncerror.SyncErrorSheet
 import io.horizontalsystems.walletkit.modules.transactionInfo.TransactionInfoPage
-import io.horizontalsystems.walletkit.modules.transactions.TransactionViewItem
 import io.horizontalsystems.walletkit.modules.transactionInfo.TransactionInfoPayload
+import io.horizontalsystems.walletkit.modules.transactions.TransactionViewItem
 import io.horizontalsystems.walletkit.modules.transactions.transactionList
 import io.horizontalsystems.walletkit.ui.compose.ComposeAppTheme
 import io.horizontalsystems.walletkit.ui.compose.TranslatableString
@@ -89,8 +86,6 @@ import io.horizontalsystems.walletkit.uiv3.components.cell.hs
 import io.horizontalsystems.walletkit.uiv3.components.controls.ButtonVariant
 import io.horizontalsystems.walletkit.uiv3.components.controls.HSButton
 import io.horizontalsystems.walletkit.uiv3.components.info.TextBlock
-import io.horizontalsystems.marketkit.models.BlockchainType
-import io.horizontalsystems.walletkit.ui.compose.components.InfoTextBody
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -115,15 +110,14 @@ fun TokenBalanceScreen(
 
     val loading = uiState.balanceViewItem?.syncingProgress?.progress != null
 
-    LifecycleResumeEffect(uiState.attentionIcon?.type) {
-        if (uiState.attentionIcon?.type == AttentionIconType.SyncError) {
+    LaunchedEffect(uiState.showSyncErrorAlert) {
+        if (uiState.showSyncErrorAlert) {
             coroutineScope.launch {
                 delay(300)
                 openSyncErrorDialog(uiState, navigation)
+                viewModel.hideSyncErrorAlert()
             }
         }
-
-        onPauseOrDispose { }
     }
 
     LaunchedEffect(uiState.showTronNotActiveAlert) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/token/TokenBalanceViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/token/TokenBalanceViewModel.kt
@@ -60,6 +60,7 @@ class TokenBalanceViewModel(
     private var alertUnshieldedBalance: BigDecimal? = null
     private var attentionIcon: AttentionIcon? = null
     private var showTronNotActiveAlert: Boolean? = null
+    private var showSyncErrorAlert: Boolean? = null
     private var zcashMigrationRequiredAmount: String? = null
 
     init {
@@ -119,6 +120,7 @@ class TokenBalanceViewModel(
         alertUnshieldedBalance = alertUnshieldedBalance,
         attentionIcon = attentionIcon,
         showTronNotActiveAlert = showTronNotActiveAlert ?: false,
+        showSyncErrorAlert = showSyncErrorAlert ?: false,
         zcashMigrationRequiredAmount = zcashMigrationRequiredAmount,
     )
 
@@ -170,6 +172,10 @@ class TokenBalanceViewModel(
 
         if (balanceViewItem.attentionIcon?.type == AttentionIconType.TronNotActive && showTronNotActiveAlert == null) {
             showTronNotActiveAlert = true
+        }
+
+        if (balanceViewItem.attentionIcon?.type == AttentionIconType.SyncError && showSyncErrorAlert == null) {
+            showSyncErrorAlert = true
         }
 
         updateErrorState()
@@ -259,6 +265,11 @@ class TokenBalanceViewModel(
 
     fun hideTronNotActiveAlert() {
         showTronNotActiveAlert = false
+        emitState()
+    }
+
+    fun hideSyncErrorAlert() {
+        showSyncErrorAlert = false
         emitState()
     }
 


### PR DESCRIPTION
#9615
## Summary
- On the token balance page, the sync error bottom sheet was reopened from a `LifecycleResumeEffect`, so dismissing it resumed the page and showed it again instantly.
- Replace it with a one-shot `showSyncErrorAlert` flag in `TokenBalanceViewModel`, consumed by a `LaunchedEffect` in the screen (same pattern as the Tron not-active alert).
- The ViewModel is scoped to the nav entry and cleared on pop, so the alert shows again only after the user goes back to the balance page and re-enters the token page.

## Test plan
- [ ] Open a token with a sync error: sheet appears once
- [ ] Dismiss the sheet: it does not reappear while staying on the page
- [ ] Background the app and return: it does not reappear
- [ ] Go back to balance and reopen the token: sheet appears again


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved token balance synchronization error alerts.
* Alerts now appear once when a synchronization error is detected and do not reappear unnecessarily when returning to the screen.
* Resolved repeated alert behavior by clearing the alert state after it is displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->