### PR TITLE
Update Gradle, AGP and KSP versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ minSdk = "28"
 
 # Kotlin & Compose
 kotlin = "2.3.21"
-ksp = "2.3.5"
+ksp = "2.3.6"
 compose = "1.11.2"
 composeMaterial3 = "1.4.0"
 
@@ -124,7 +124,7 @@ espresso = "3.7.0"
 testRunner = "1.7.0"
 
 # AGP
-agp = "9.2.1"
+agp = "9.4.0"
 
 # Nav 3
 nav3Core = "1.1.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 10 12:47:09 KGT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Gradle wrapper 9.4.1 -> 9.6.0
- Android Gradle Plugin 9.2.1 -> 9.4.0
- KSP 2.3.5 -> 2.3.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Android build tooling versions to newer releases.
  * Updated the Kotlin Symbol Processing tooling version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->