### PR TITLE
Add Chart button toggle to Appearance settings

### DIFF
--- a/translation_snapshot.json
+++ b/translation_snapshot.json
@@ -64,6 +64,8 @@
     "Appearance_BalanceTab": "BALANCE TAB",
     "Appearance_BalanceValue": "Coin Balances",
     "Appearance_BalanceValue_Tip": "Show balances highlighted in either crypto or fiat.",
+    "Appearance_ChartButton": "Chart Button",
+    "Appearance_ChartButton_Tip": "Show the Chart button on the token balance page.",
     "Appearance_HideBalanceTabButtons": "Hide Buttons",
     "Appearance_HideBalanceTabButtons_Tip": "Hide the Send, Receive, and Swap buttons from the Balance tab.",
     "Appearance_HideMarketsTab": "Hide Markets",

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/Interfaces.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/Interfaces.kt
@@ -123,6 +123,8 @@ interface ILocalStorage {
     val marketsTabEnabledFlow: StateFlow<Boolean>
     var balanceTabButtonsEnabled: Boolean
     val balanceTabButtonsEnabledFlow: StateFlow<Boolean>
+    var chartButtonEnabled: Boolean
+    val chartButtonEnabledFlow: StateFlow<Boolean>
     var amountRoundingEnabled: Boolean
     val amountRoundingEnabledFlow: StateFlow<Boolean>
     var personalSupportEnabled: Boolean

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/managers/LocalStorageManager.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/managers/LocalStorageManager.kt
@@ -619,6 +619,13 @@ class LocalStorageManager(
             balanceTabButtonsEnabledFlow.update { value }
         }
 
+    override var chartButtonEnabled: Boolean
+        get() = preferences.getBoolean("chartButtonEnabled", true)
+        set(value) {
+            preferences.edit { putBoolean("chartButtonEnabled", value) }
+            chartButtonEnabledFlow.update { value }
+        }
+
     override var amountRoundingEnabled: Boolean
         get() = preferences.getBoolean("amountRoundingEnabled", true)
         set(value) {
@@ -627,6 +634,7 @@ class LocalStorageManager(
         }
 
     override val balanceTabButtonsEnabledFlow = MutableStateFlow(balanceTabButtonsEnabled)
+    override val chartButtonEnabledFlow = MutableStateFlow(chartButtonEnabled)
     override val amountRoundingEnabledFlow = MutableStateFlow(amountRoundingEnabled)
 
     override var personalSupportEnabled: Boolean

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/token/TokenBalanceModule.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/token/TokenBalanceModule.kt
@@ -70,6 +70,7 @@ class TokenBalanceModule {
         val showTronNotActiveAlert: Boolean,
         val showSyncErrorAlert: Boolean,
         val zcashMigrationRequiredAmount: String? = null,
+        val chartButtonEnabled: Boolean,
     )
 
     data class TokenBalanceError(

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/token/TokenBalanceScreen.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/token/TokenBalanceScreen.kt
@@ -215,6 +215,7 @@ fun TokenBalanceScreen(
                         receiveAddress = uiState.receiveAddress,
                         warning = uiState.warningMessage,
                         onClickReceive = onClickReceive,
+                        chartButtonEnabled = uiState.chartButtonEnabled,
                         trailingContent = trailingContent,
                     )
 
@@ -455,6 +456,7 @@ private fun TokenBalanceHeader(
     receiveAddress: String?,
     warning: String?,
     onClickReceive: () -> Unit,
+    chartButtonEnabled: Boolean,
     trailingContent: (@Composable () -> Unit)? = null,
 ) {
     val context = LocalContext.current
@@ -532,6 +534,7 @@ private fun TokenBalanceHeader(
             ButtonsRow(
                 viewItem = balanceViewItem,
                 navigation = navigation,
+                chartButtonEnabled = chartButtonEnabled,
                 onClickReceive = onClickReceive
             )
         }
@@ -839,23 +842,26 @@ private fun LockedBalanceZcashCell(
 private fun ButtonsRow(
     viewItem: BalanceViewItem,
     navigation: HSNavigation,
+    chartButtonEnabled: Boolean,
     onClickReceive: () -> Unit
 ) {
     BalanceButtonsGroup {
-        BalanceActionButton(
-            variant = ButtonVariant.Primary,
-            icon = R.drawable.ic_balance_chart_24,
-            title = stringResource(R.string.Coin_Chart),
-            enabled = !viewItem.wallet.token.isCustom,
-            onClick = {
-                val coinUid = viewItem.wallet.coin.uid
-                val arguments = CoinPage.Input(coinUid)
+        if (chartButtonEnabled) {
+            BalanceActionButton(
+                variant = ButtonVariant.Primary,
+                icon = R.drawable.ic_balance_chart_24,
+                title = stringResource(R.string.Coin_Chart),
+                enabled = !viewItem.wallet.token.isCustom,
+                onClick = {
+                    val coinUid = viewItem.wallet.coin.uid
+                    val arguments = CoinPage.Input(coinUid)
 
-                navigation.slideFromRight(CoinPage(arguments))
+                    navigation.slideFromRight(CoinPage(arguments))
 
-                stat(page = StatPage.TokenPage, event = StatEvent.OpenCoin(coinUid))
-            },
-        )
+                    stat(page = StatPage.TokenPage, event = StatEvent.OpenCoin(coinUid))
+                },
+            )
+        }
         BalanceActionButton(
             variant = ButtonVariant.Secondary,
             icon = R.drawable.ic_arrow_down_24,

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/token/TokenBalanceViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/balance/token/TokenBalanceViewModel.kt
@@ -62,8 +62,16 @@ class TokenBalanceViewModel(
     private var showTronNotActiveAlert: Boolean? = null
     private var showSyncErrorAlert: Boolean? = null
     private var zcashMigrationRequiredAmount: String? = null
+    private var chartButtonEnabled = localStorage.chartButtonEnabledFlow.value
 
     init {
+        viewModelScope.launch {
+            localStorage.chartButtonEnabledFlow.collect {
+                chartButtonEnabled = it
+                emitState()
+            }
+        }
+
         viewModelScope.launch(Dispatchers.IO) {
             balanceService.balanceItemFlow.collect { balanceItem ->
                 balanceItem?.let {
@@ -122,6 +130,7 @@ class TokenBalanceViewModel(
         showTronNotActiveAlert = showTronNotActiveAlert ?: false,
         showSyncErrorAlert = showSyncErrorAlert ?: false,
         zcashMigrationRequiredAmount = zcashMigrationRequiredAmount,
+        chartButtonEnabled = chartButtonEnabled,
     )
 
     private fun setReceiveAddressForWatchAccount() {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/settings/appearance/AppearancePage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/settings/appearance/AppearancePage.kt
@@ -238,6 +238,19 @@ fun AppearanceScreen(navigation: HSNavigation) {
                     },
                     {
                         SettingUniversalCell(
+                            title = R.string.Appearance_ChartButton,
+                            subtitle = R.string.Appearance_ChartButton_Tip,
+                        ) {
+                            HsSwitch(
+                                checked = uiState.chartButtonEnabled,
+                                onCheckedChange = {
+                                    viewModel.onChartButtonToggle(it)
+                                }
+                            )
+                        }
+                    },
+                    {
+                        SettingUniversalCell(
                             title = R.string.Appearance_AmountRounding,
                             subtitle = R.string.Appearance_AmountRounding_Tip,
                         ) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/settings/appearance/AppearanceViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/settings/appearance/AppearanceViewModel.kt
@@ -31,6 +31,7 @@ class AppearanceViewModel(
     private var themeOptions = themeService.optionsFlow.value
     private var marketsTabHidden = !localStorage.marketsTabEnabled
     private var balanceTabButtonsHidden = !localStorage.balanceTabButtonsEnabled
+    private var chartButtonEnabled = localStorage.chartButtonEnabled
     private var amountRoundingEnabled = localStorage.amountRoundingEnabled
     private var recentlySentEnabled = localStorage.recentlySentEnabled
     private var balanceViewTypeOptions = buildBalanceViewTypeSelect(balanceViewTypeManager.balanceViewTypeFlow.value)
@@ -83,6 +84,7 @@ class AppearanceViewModel(
         balanceViewTypeOptions = balanceViewTypeOptions,
         marketsTabHidden = marketsTabHidden,
         balanceTabButtonsHidden = balanceTabButtonsHidden,
+        chartButtonEnabled = chartButtonEnabled,
         selectedTheme = themeService.selectedTheme,
         selectedLaunchScreen = launchScreenService.selectedLaunchScreen,
         selectedBalanceViewType = balanceViewTypeManager.balanceViewType,
@@ -168,6 +170,12 @@ class AppearanceViewModel(
         stat(page = StatPage.Appearance, event = StatEvent.HideBalanceButtons(shown = !hidden))
     }
 
+    fun onChartButtonToggle(enabled: Boolean) {
+        localStorage.chartButtonEnabled = enabled
+        chartButtonEnabled = enabled
+        emitState()
+    }
+
     fun onAmountRoundingToggle(enabled: Boolean) {
         localStorage.amountRoundingEnabled = enabled
         amountRoundingEnabled = enabled
@@ -204,6 +212,7 @@ data class AppearanceUIState(
     val balanceViewTypeOptions: Select<BalanceViewType>,
     val marketsTabHidden: Boolean,
     val balanceTabButtonsHidden: Boolean,
+    val chartButtonEnabled: Boolean,
     val selectedTheme: ThemeType,
     val selectedLaunchScreen: LaunchPage,
     val selectedBalanceViewType: BalanceViewType,

--- a/walletkit/src/main/res/values-de/strings.xml
+++ b/walletkit/src/main/res/values-de/strings.xml
@@ -1874,4 +1874,6 @@
     <string name="NetworkSettings_Latency">%d ms</string>
     <string name="ZcashEndpointSettings_AutoSelectDescription">Verwenden Sie automatisch den schnellsten Server</string>
     <string name="Send_Hodler_PrivateSendUnavailable">Nicht verfügbar, wenn Private Send aktiviert ist.</string>
+    <string name="Appearance_ChartButton">Diagramm-Schaltfläche</string>
+    <string name="Appearance_ChartButton_Tip">Zeige die Diagramm-Schaltfläche auf der Token-Bilanzseite an.</string>
 </resources>

--- a/walletkit/src/main/res/values-es/strings.xml
+++ b/walletkit/src/main/res/values-es/strings.xml
@@ -1865,4 +1865,6 @@
     <string name="NetworkSettings_Latency">%d ms</string>
     <string name="ZcashEndpointSettings_AutoSelectDescription">Usar automáticamente el servidor más rápido</string>
     <string name="Send_Hodler_PrivateSendUnavailable">No disponible cuando Private Send está activado.</string>
+    <string name="Appearance_ChartButton">Botón de Gráfico</string>
+    <string name="Appearance_ChartButton_Tip">Mostrar el botón de gráfico en la página de saldo de tokens.</string>
 </resources>

--- a/walletkit/src/main/res/values-fa/strings.xml
+++ b/walletkit/src/main/res/values-fa/strings.xml
@@ -799,4 +799,6 @@
     <string name="ZcashEndpointSettings_AutoSelectDescription">استفاده خودکار از سریع‌ترین سرور</string>
     <string name="Send_Hodler_Description">TimeLock فقط برای ارسال به آدرس‌های BIP44 (شروع‌شده با 1) کار می‌کند.</string>
     <string name="Send_Hodler_PrivateSendUnavailable">در دسترس نیست هنگامی که Private Send فعال است.</string>
+    <string name="Appearance_ChartButton">دکمه نمودار</string>
+    <string name="Appearance_ChartButton_Tip">نمایش دکمه نمودار در صفحه موجودی توکن.</string>
 </resources>

--- a/walletkit/src/main/res/values-fr/strings.xml
+++ b/walletkit/src/main/res/values-fr/strings.xml
@@ -1867,4 +1867,6 @@
     <string name="NetworkSettings_Latency">%d ms</string>
     <string name="ZcashEndpointSettings_AutoSelectDescription">Utiliser automatiquement le serveur le plus rapide</string>
     <string name="Send_Hodler_PrivateSendUnavailable">Non disponible lorsque Private Send est activé.</string>
+    <string name="Appearance_ChartButton">Bouton Graphique</string>
+    <string name="Appearance_ChartButton_Tip">Afficher le bouton Graphique sur la page de solde des tokens.</string>
 </resources>

--- a/walletkit/src/main/res/values-ko/strings.xml
+++ b/walletkit/src/main/res/values-ko/strings.xml
@@ -1866,4 +1866,6 @@
     <string name="NetworkSettings_Latency">%d ms</string>
     <string name="ZcashEndpointSettings_AutoSelectDescription">가장 빠른 서버를 자동으로 사용</string>
     <string name="Send_Hodler_PrivateSendUnavailable">Private Send가 켜져 있을 때는 사용할 수 없습니다.</string>
+    <string name="Appearance_ChartButton">차트 버튼</string>
+    <string name="Appearance_ChartButton_Tip">토큰 잔액 페이지에 차트 버튼을 표시합니다.</string>
 </resources>

--- a/walletkit/src/main/res/values-pt-rBR/strings.xml
+++ b/walletkit/src/main/res/values-pt-rBR/strings.xml
@@ -1870,4 +1870,6 @@
     <string name="NetworkSettings_Latency">%d ms</string>
     <string name="ZcashEndpointSettings_AutoSelectDescription">Usar automaticamente o servidor mais rápido</string>
     <string name="Send_Hodler_PrivateSendUnavailable">Não disponível quando Private Send está ativado.</string>
+    <string name="Appearance_ChartButton">Botão de Gráfico</string>
+    <string name="Appearance_ChartButton_Tip">Mostrar o botão de gráfico na página de saldo de tokens.</string>
 </resources>

--- a/walletkit/src/main/res/values-ru/strings.xml
+++ b/walletkit/src/main/res/values-ru/strings.xml
@@ -1872,4 +1872,6 @@
     <string name="NetworkSettings_Latency">%d ms</string>
     <string name="ZcashEndpointSettings_AutoSelectDescription">Автоматически использовать самый быстрый сервер</string>
     <string name="Send_Hodler_PrivateSendUnavailable">Недоступно, когда включена функция Private Send.</string>
+    <string name="Appearance_ChartButton">Кнопка Графика</string>
+    <string name="Appearance_ChartButton_Tip">Показать кнопку графика на странице баланса токена.</string>
 </resources>

--- a/walletkit/src/main/res/values-tr/strings.xml
+++ b/walletkit/src/main/res/values-tr/strings.xml
@@ -1866,4 +1866,6 @@
     <string name="NetworkSettings_Latency">%d ms</string>
     <string name="ZcashEndpointSettings_AutoSelectDescription">En hızlı sunucuyu otomatik olarak kullan</string>
     <string name="Send_Hodler_PrivateSendUnavailable">Private Send açık olduğunda kullanılamaz.</string>
+    <string name="Appearance_ChartButton">Grafik Düğmesi</string>
+    <string name="Appearance_ChartButton_Tip">Token bakiyesi sayfasında Grafik düğmesini gösterin.</string>
 </resources>

--- a/walletkit/src/main/res/values-zh/strings.xml
+++ b/walletkit/src/main/res/values-zh/strings.xml
@@ -1865,4 +1865,6 @@
     <string name="NetworkSettings_Latency">%d ms</string>
     <string name="ZcashEndpointSettings_AutoSelectDescription">自动使用最快的服务器</string>
     <string name="Send_Hodler_PrivateSendUnavailable">启用Private Send时不可用。</string>
+    <string name="Appearance_ChartButton">图表按钮</string>
+    <string name="Appearance_ChartButton_Tip">在代币余额页面上显示图表按钮。</string>
 </resources>

--- a/walletkit/src/main/res/values/strings.xml
+++ b/walletkit/src/main/res/values/strings.xml
@@ -1266,6 +1266,8 @@
     <string name="Appearance_HideMarketsTab_Tip">Hide the Markets tab completely.</string>
     <string name="Appearance_HideBalanceTabButtons">Hide Buttons</string>
     <string name="Appearance_HideBalanceTabButtons_Tip">Hide the Send, Receive, and Swap buttons from the Balance tab.</string>
+    <string name="Appearance_ChartButton">Chart Button</string>
+    <string name="Appearance_ChartButton_Tip">Show the Chart button on the token balance page.</string>
     <string name="Appearance_AmountRounding">Amount Rounding</string>
     <string name="Appearance_AmountRounding_Tip">Display rounded balances and transaction amounts.</string>
     <string name="Appearance_BalanceAutoHide">Balance Auto Hide</string>


### PR DESCRIPTION
#8359
## Summary
- Add a "Chart Button" switch to the Balance Tab section of Appearance settings, enabled by default, with the description "Show the Chart button on the token balance page."
- Store the setting in `ILocalStorage` / `LocalStorageManager` with a `StateFlow` so open screens react immediately
- Token balance page renders the Chart action button only when the setting is enabled

## Notes
- When the Chart button is hidden, Receive/Send/Swap keep their secondary styling
- The setting is not added to the full backup settings

## Test plan
- Settings → Appearance → Balance Tab shows "Chart Button" switch, on by default
- Turn it off → open a token balance page → Chart button is gone, Receive/Send/Swap remain
- Turn it on again → Chart button returns (also while the token page is already open)
- Setting persists across app restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Appearance setting to show or hide the Chart button.
  * The Chart button can now be displayed on token balance pages when enabled.
  * Added explanatory text for the new setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->