### PR TITLE
Hide Private send toggle on send screens

### DIFF
--- a/walletkit-chain-bitcoin/src/main/java/io/horizontalsystems/walletkit/modules/send/bitcoin/SendBitcoinScreen.kt
+++ b/walletkit-chain-bitcoin/src/main/java/io/horizontalsystems/walletkit/modules/send/bitcoin/SendBitcoinScreen.kt
@@ -204,9 +204,9 @@ fun SendBitcoinScreen(
                 rate = rate
             )
 
-            Column(modifier = Modifier.padding(horizontal = 16.dp)) {
-                PrivateSendToggleSection(privateSendViewModel, navigation)
-            }
+            //Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+            //    PrivateSendToggleSection(privateSendViewModel, navigation)
+            //}
 
             VSpacer(16.dp)
             // Stays editable under Private send but warns that the memo cannot travel:

--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/send/evm/SendEvmScreen.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/send/evm/SendEvmScreen.kt
@@ -118,9 +118,9 @@ fun SendEvmScreen(
             rate = viewModel.coinRate
         )
 
-        Column(modifier = Modifier.padding(horizontal = 16.dp)) {
-            PrivateSendToggleSection(privateSendViewModel, navigation)
-        }
+        //Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+        //    PrivateSendToggleSection(privateSendViewModel, navigation)
+        //}
 
         val forResult = navigation.slideFromBottomForResult<AddressRiskySheet.Result>(
             {

--- a/walletkit-chain-solana/src/main/java/io/horizontalsystems/walletkit/modules/send/solana/SendSolanaScreen.kt
+++ b/walletkit-chain-solana/src/main/java/io/horizontalsystems/walletkit/modules/send/solana/SendSolanaScreen.kt
@@ -113,9 +113,9 @@ fun SendSolanaScreen(
             rate = viewModel.coinRate
         )
 
-        Column(modifier = Modifier.padding(horizontal = 16.dp)) {
-            PrivateSendToggleSection(privateSendViewModel, navigation)
-        }
+        //Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+        //    PrivateSendToggleSection(privateSendViewModel, navigation)
+        //}
 
         val forResult = navigation.slideFromBottomForResult<AddressRiskySheet.Result>(
             {

--- a/walletkit-chain-stellar/src/main/java/io/horizontalsystems/walletkit/modules/send/stellar/SendStellarScreen.kt
+++ b/walletkit-chain-stellar/src/main/java/io/horizontalsystems/walletkit/modules/send/stellar/SendStellarScreen.kt
@@ -114,9 +114,9 @@ fun SendStellarScreen(
             rate = viewModel.coinRate
         )
 
-        Column(modifier = Modifier.padding(horizontal = 16.dp)) {
-            PrivateSendToggleSection(privateSendViewModel, navigation)
-        }
+        //Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+        //    PrivateSendToggleSection(privateSendViewModel, navigation)
+        //}
 
         VSpacer(16.dp)
         // Stays editable under Private send but warns that the memo cannot travel:

--- a/walletkit-chain-thorchain/src/main/java/io/horizontalsystems/walletkit/modules/send/thorchain/SendThorchainScreen.kt
+++ b/walletkit-chain-thorchain/src/main/java/io/horizontalsystems/walletkit/modules/send/thorchain/SendThorchainScreen.kt
@@ -115,9 +115,9 @@ fun SendThorchainScreen(
             rate = viewModel.coinRate
         )
 
-        Column(modifier = Modifier.padding(horizontal = 16.dp)) {
-            PrivateSendToggleSection(privateSendViewModel, navigation)
-        }
+        //Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+        //    PrivateSendToggleSection(privateSendViewModel, navigation)
+        //}
 
         VSpacer(16.dp)
         // Stays editable under Private send but warns that the memo cannot travel:

--- a/walletkit-chain-ton/src/main/java/io/horizontalsystems/walletkit/modules/send/ton/SendTonScreen.kt
+++ b/walletkit-chain-ton/src/main/java/io/horizontalsystems/walletkit/modules/send/ton/SendTonScreen.kt
@@ -115,9 +115,9 @@ fun SendTonScreen(
             rate = viewModel.coinRate
         )
 
-        Column(modifier = Modifier.padding(horizontal = 16.dp)) {
-            PrivateSendToggleSection(privateSendViewModel, navigation)
-        }
+        //Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+        //    PrivateSendToggleSection(privateSendViewModel, navigation)
+        //}
 
         VSpacer(16.dp)
         // Stays editable under Private send but warns that the memo cannot travel:

--- a/walletkit-chain-tron/src/main/java/io/horizontalsystems/walletkit/modules/send/tron/SendTronScreen.kt
+++ b/walletkit-chain-tron/src/main/java/io/horizontalsystems/walletkit/modules/send/tron/SendTronScreen.kt
@@ -115,9 +115,9 @@ fun SendTronScreen(
             rate = viewModel.coinRate
         )
 
-        Column(modifier = Modifier.padding(horizontal = 16.dp)) {
-            PrivateSendToggleSection(privateSendViewModel, navigation)
-        }
+        //Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+        //    PrivateSendToggleSection(privateSendViewModel, navigation)
+        //}
 
         val forResult = navigation.slideFromBottomForResult<AddressRiskySheet.Result>(
             {


### PR DESCRIPTION
Temporarily hides the Private send toggle on all send screens while the feature is held back. The logic stays in place. Refs #9545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Changes**
  - Removed the Private Send toggle from send screens for Bitcoin, EVM, Solana, Stellar, THORChain, TON, and Tron.
  - Existing Private Send state and confirmation handling remain active in the send flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->