### PR TITLE
Use derived identifiers for commit requests in USwapProvider

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
@@ -407,8 +407,21 @@ class USwapProvider(
         buyAsset: String?,
     ): UnstoppableAPI.Response.Route {
         val usingDerivedIdentifiers = assetsMap.isEmpty()
-        val assetIn = sellAsset ?: assetsMap[tokenIn] ?: deriveIdentifier(tokenIn) ?: throw IllegalStateException("No identifier for tokenIn")
-        val assetOut = buyAsset ?: assetsMap[tokenOut] ?: deriveIdentifier(tokenOut) ?: throw IllegalStateException("No identifier for tokenOut")
+        // Providers on derived identifiers (LI.FI, Barter, Jupiter) must commit with the SAME
+        // asset spelling the rate request used. The route echoes a server-normalized form
+        // (`ROBINHOOD.ETH` for `ROBINHOOD.0xeee…`) that the server's own resolver does not
+        // accept back on every chain. The route passthrough stays for token-list providers:
+        // Exolix's shielded Zcash variant is chosen at rate time and must be committed as such.
+        val assetIn = if (usingDerivedIdentifiers) {
+            deriveIdentifier(tokenIn)
+        } else {
+            sellAsset ?: assetsMap[tokenIn]
+        } ?: throw IllegalStateException("No identifier for tokenIn")
+        val assetOut = if (usingDerivedIdentifiers) {
+            deriveIdentifier(tokenOut)
+        } else {
+            buyAsset ?: assetsMap[tokenOut]
+        } ?: throw IllegalStateException("No identifier for tokenOut")
         val chainId = if (usingDerivedIdentifiers) chainIdByBlockchainType[tokenIn.blockchainType] else null
 
         val request = UnstoppableAPI.Request.Swap(


### PR DESCRIPTION
## Problem

Swapping from Robinhood Chain via LI.FI failed in release builds at the Confirm Swap step with `HTTP 502 Bad Gateway`, while debug builds worked and iOS worked on the same production server.

The rate request sends LI.FI the derived native id (`ROBINHOOD.0xeee…`), and the server echoes the route back with a normalized `sellAsset` of `ROBINHOOD.ETH`. `commitSwap` preferred the route's echoed `sellAsset`/`buyAsset` over the derived id, so the `/swap` call went out with `ROBINHOOD.ETH`. The production resolver rejects that spelling on Robinhood (`ETH is not a valid EVM address`); the dev server accepts both, which is why debug builds never showed it.

iOS never reuses the route's asset strings on commit: `DefaultUSwapSubProvider.commit` rebuilds both sides from `asset(token:)`, and LI.FI/Barter/Jupiter derive it from the token.

## Change

For providers on derived identifiers (LI.FI, Barter, Jupiter, Bitania) always commit with the same id the rate request used. Token-list providers keep the route passthrough, which Exolix's shielded Zcash variant relies on.

## Verification

- Replayed the exact `/swap` request against production: `ROBINHOOD.ETH` → 502, `ROBINHOOD.0xeee…` → 200 with a signed_transaction route.
- Confirmed the derived form also commits on production for Ethereum → Ethereum and Base → Arbitrum pairs.
- Release build on emulator now reaches Confirm Swap for Robinhood ETH → USDT (ERC20) with fee and guaranteed amount.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved swap execution for providers that use derived token identifiers, reducing failures caused by normalized asset names.
  - Preserved route-provided asset identifiers for token-list providers, including support for shielded Zcash swaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->