### PR TITLE
Revert "Use derived identifiers for commit requests in USwapProvider"

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/providers/USwapProvider.kt
@@ -407,21 +407,8 @@ class USwapProvider(
         buyAsset: String?,
     ): UnstoppableAPI.Response.Route {
         val usingDerivedIdentifiers = assetsMap.isEmpty()
-        // Providers on derived identifiers (LI.FI, Barter, Jupiter) must commit with the SAME
-        // asset spelling the rate request used. The route echoes a server-normalized form
-        // (`ROBINHOOD.ETH` for `ROBINHOOD.0xeee…`) that the server's own resolver does not
-        // accept back on every chain. The route passthrough stays for token-list providers:
-        // Exolix's shielded Zcash variant is chosen at rate time and must be committed as such.
-        val assetIn = if (usingDerivedIdentifiers) {
-            deriveIdentifier(tokenIn)
-        } else {
-            sellAsset ?: assetsMap[tokenIn]
-        } ?: throw IllegalStateException("No identifier for tokenIn")
-        val assetOut = if (usingDerivedIdentifiers) {
-            deriveIdentifier(tokenOut)
-        } else {
-            buyAsset ?: assetsMap[tokenOut]
-        } ?: throw IllegalStateException("No identifier for tokenOut")
+        val assetIn = sellAsset ?: assetsMap[tokenIn] ?: deriveIdentifier(tokenIn) ?: throw IllegalStateException("No identifier for tokenIn")
+        val assetOut = buyAsset ?: assetsMap[tokenOut] ?: deriveIdentifier(tokenOut) ?: throw IllegalStateException("No identifier for tokenOut")
         val chainId = if (usingDerivedIdentifiers) chainIdByBlockchainType[tokenIn.blockchainType] else null
 
         val request = UnstoppableAPI.Request.Swap(


### PR DESCRIPTION
This reverts commit 0f60a83bf114ec6922054c4f6957c27c649b9e29.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multi-provider swap handling by correctly recognizing assets returned from swap routes.
  - Increased reliability when identifying input and output assets across supported providers, including LI.FI, Barter, and Jupiter.
  - Preserved existing fallback behavior when route-provided asset details are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->