### PR TITLE
Fix nav3 bottom sheet close animation

### DIFF
--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/WcRequestEvmScreen.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/WcRequestEvmScreen.kt
@@ -35,6 +35,7 @@ import com.google.gson.Gson
 import io.horizontalsystems.walletkit.R
 import io.horizontalsystems.walletkit.core.AppLogger
 import io.horizontalsystems.walletkit.helpers.HudHelper
+import io.horizontalsystems.walletkit.modules.nav3.BottomSheetDismissHandler
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.walletconnect.WCDelegate
 import io.horizontalsystems.walletkit.modules.walletconnect.request.sendtransaction.WCEthereumTransaction
@@ -54,6 +55,7 @@ import io.horizontalsystems.walletkit.uiv3.components.AlertCard
 import io.horizontalsystems.walletkit.uiv3.components.AlertFormat
 import io.horizontalsystems.walletkit.uiv3.components.AlertType
 import io.horizontalsystems.walletkit.uiv3.components.bottombars.ButtonsGroupHorizontal
+import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetBody
 import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetContent
 import io.horizontalsystems.walletkit.uiv3.components.cell.CellMiddleInfo
 import io.horizontalsystems.walletkit.uiv3.components.cell.CellPrimary
@@ -145,37 +147,22 @@ fun WCNewSignRequestScreen(
     onAllow: suspend () -> Unit,
     onDecline: () -> Unit
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val scope = rememberCoroutineScope()
     val view = LocalView.current
     val messageBottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var messageBottomSheet by remember { mutableStateOf<String?>(null) }
     val confirmAction = rememberAsyncAction()
 
-    // Animate the bottom sheet out before popping. Removing the entry directly disposes the
-    // ModalBottomSheet's window abruptly, which intermittently leaves the sheet content on screen
-    // (the dim is removed but the sheet card stays).
-    val hideAndPop = {
-        scope.launch {
-            sheetState.hide()
+    BottomSheetDismissHandler {
+        // Discard synchronously (avoids the reEmit race) before popping. A confirmed sign is
+        // already responding (NonCancellable); discarding now would race the pending response,
+        // so ignore dismissal until it completes.
+        if (!confirmAction.inProgress) {
+            WCDelegate.discardActiveSessionRequest()
             navigation.removeLastOrNull()
         }
-        Unit
     }
-
-    BottomSheetContent(
-        onDismissRequest = {
-            // Discard synchronously (avoids the reEmit race), then animate out before popping —
-            // same reason as hideAndPop above; popping outright can leave the sheet card on screen.
-            // A confirmed sign is already responding (NonCancellable); discarding now would race
-            // the pending response, so ignore dismissal until it completes.
-            if (!confirmAction.inProgress) {
-                WCDelegate.discardActiveSessionRequest()
-                hideAndPop()
-            }
-        },
-        sheetState = sheetState
-    ) { snackbarActions ->
+    BottomSheetBody { snackbarActions ->
         Column(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
@@ -342,7 +329,7 @@ fun WCNewSignRequestScreen(
                     onClick = {
                         logger.info("decline request")
                         onDecline()
-                        hideAndPop()
+                        navigation.removeLastOrNull()
                     }
                 )
                 HSButton(
@@ -355,12 +342,11 @@ fun WCNewSignRequestScreen(
                         confirmAction.run {
                             try {
                                 // Offload the signing (CPU-bound crypto) off the Main thread, but
-                                // keep hide()/removeLastOrNull() on Main — they mutate UI state.
+                                // keep removeLastOrNull() on Main — it mutates UI state.
                                 // NonCancellable: this scope dies with the composition (locking the
                                 // app tears the sheet down), and a confirmed sign-and-respond must
                                 // not be dropped halfway.
                                 withContext(Dispatchers.Default + NonCancellable) { onAllow() }
-                                sheetState.hide()
                                 navigation.removeLastOrNull()
                             } catch (e: Throwable) {
                                 showError(view, e)

--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/sendtransaction/WCSendEthScreen.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/sendtransaction/WCSendEthScreen.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,6 +28,7 @@ import io.horizontalsystems.walletkit.core.AppLogger
 import io.horizontalsystems.walletkit.core.ethereum.CautionViewItem
 import io.horizontalsystems.walletkit.core.shorten
 import io.horizontalsystems.walletkit.modules.evmfee.FeeSettingsInfoSheet
+import io.horizontalsystems.walletkit.modules.nav3.BottomSheetDismissHandler
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.sendevmtransaction.SectionViewItem
 import io.horizontalsystems.walletkit.modules.sendevmtransaction.ViewItem
@@ -47,7 +46,7 @@ import io.horizontalsystems.walletkit.uiv3.components.AlertCard
 import io.horizontalsystems.walletkit.uiv3.components.AlertFormat
 import io.horizontalsystems.walletkit.uiv3.components.AlertType
 import io.horizontalsystems.walletkit.uiv3.components.bottombars.ButtonsGroupHorizontal
-import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetContent
+import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetBody
 import io.horizontalsystems.walletkit.uiv3.components.cell.CellMiddleInfo
 import io.horizontalsystems.walletkit.uiv3.components.cell.CellMiddleInfoTextIcon
 import io.horizontalsystems.walletkit.uiv3.components.cell.CellRightControlsButtonText
@@ -60,7 +59,6 @@ import io.horizontalsystems.walletkit.uiv3.components.controls.HSButton
 import io.horizontalsystems.marketkit.models.BlockchainType
 import kotlinx.coroutines.delay
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WCSendEthRequestScreen(
     navigation: HSNavigation,
@@ -69,7 +67,6 @@ fun WCSendEthRequestScreen(
     transaction: WalletConnectTransaction,
     sessionRequestUI: SessionRequestUI.Content,
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val viewModel = viewModel<WCSendEthereumTransactionRequestViewModel>(
         factory = WCSendEthereumTransactionRequestViewModel.Factory(
             blockchainType = blockchainType,
@@ -87,17 +84,15 @@ fun WCSendEthRequestScreen(
     val feeText = stringResource(id = R.string.Send_Fee)
     val feeInfoText = stringResource(id = R.string.FeeSettings_NetworkFee_Info)
 
-    BottomSheetContent(
-        onDismissRequest = {
-            // A confirmed send is already broadcasting (NonCancellable); discarding or rejecting
-            // now would race the pending response, so ignore dismissal until it completes.
-            if (!confirmAction.inProgress) {
-                WCDelegate.discardActiveSessionRequest(sessionRequestUI.requestId)
-                navigation.removeLastOrNull()
-            }
-        },
-        sheetState = sheetState,
-    ) { snackbarActions ->
+    BottomSheetDismissHandler {
+        // A confirmed send is already broadcasting (NonCancellable); discarding or rejecting
+        // now would race the pending response, so ignore dismissal until it completes.
+        if (!confirmAction.inProgress) {
+            WCDelegate.discardActiveSessionRequest(sessionRequestUI.requestId)
+            navigation.removeLastOrNull()
+        }
+    }
+    BottomSheetBody { snackbarActions ->
         Column(
             modifier = Modifier.fillMaxWidth(),
             horizontalAlignment = Alignment.CenterHorizontally

--- a/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/signtransaction/WCSignEthereumTransactionRequestScreen.kt
+++ b/walletkit-chain-evm/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/signtransaction/WCSignEthereumTransactionRequestScreen.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -31,6 +29,7 @@ import io.horizontalsystems.walletkit.core.stats.StatPage
 import io.horizontalsystems.walletkit.helpers.HudHelper
 import io.horizontalsystems.walletkit.modules.confirm.ConfirmTransactionScreen
 import io.horizontalsystems.walletkit.modules.evmfee.FeeSettingsInfoSheet
+import io.horizontalsystems.walletkit.modules.nav3.BottomSheetDismissHandler
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.sendevmtransaction.SendEvmTransactionView
 import io.horizontalsystems.walletkit.modules.walletconnect.WCDelegate
@@ -49,7 +48,7 @@ import io.horizontalsystems.walletkit.ui.compose.components.subhead_grey
 import io.horizontalsystems.walletkit.modules.walletconnect.VerificationAlert
 import io.horizontalsystems.walletkit.ui.helpers.TextHelper
 import io.horizontalsystems.walletkit.uiv3.components.bottombars.ButtonsGroupHorizontal
-import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetContent
+import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetBody
 import io.horizontalsystems.walletkit.uiv3.components.controls.ButtonSize
 import io.horizontalsystems.walletkit.uiv3.components.controls.ButtonVariant
 import io.horizontalsystems.walletkit.uiv3.components.controls.HSButton
@@ -57,7 +56,6 @@ import io.horizontalsystems.walletkit.uiv3.components.info.TextBlock
 import io.horizontalsystems.marketkit.models.BlockchainType
 import kotlinx.coroutines.delay
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WCSignEthereumTransactionRequestScreen(
     navigation: HSNavigation,
@@ -77,7 +75,6 @@ fun WCSignEthereumTransactionRequestScreen(
     )
     val uiState = viewModel.uiState
     val view = LocalView.current
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     // Shared by the sheet's Approve and the confirmation screen's Sign button: both respond to
     // the same request, so a click on either must lock out both.
     val signAction = rememberAsyncAction()
@@ -86,17 +83,15 @@ fun WCSignEthereumTransactionRequestScreen(
     val feeInfoText = stringResource(id = R.string.FeeSettings_NetworkFee_Info)
     val doneMessage = stringResource(R.string.Hud_Text_Done)
 
-    BottomSheetContent(
-        onDismissRequest = {
-            // A confirmed sign is already responding (NonCancellable); discarding or rejecting
-            // now would race the pending response, so ignore dismissal until it completes.
-            if (!signAction.inProgress) {
-                WCDelegate.discardActiveSessionRequest(sessionRequestUI.requestId)
-                navigation.removeLastOrNull()
-            }
-        },
-        sheetState = sheetState,
-    ) { snackbarActions ->
+    BottomSheetDismissHandler {
+        // A confirmed sign is already responding (NonCancellable); discarding or rejecting
+        // now would race the pending response, so ignore dismissal until it completes.
+        if (!signAction.inProgress) {
+            WCDelegate.discardActiveSessionRequest(sessionRequestUI.requestId)
+            navigation.removeLastOrNull()
+        }
+    }
+    BottomSheetBody { snackbarActions ->
         Column(
             modifier = Modifier.fillMaxWidth(),
             horizontalAlignment = Alignment.CenterHorizontally

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/confirm/ErrorSheet.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/confirm/ErrorSheet.kt
@@ -1,8 +1,6 @@
 package io.horizontalsystems.walletkit.modules.confirm
 
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -13,7 +11,7 @@ import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.ui.compose.ComposeAppTheme
 import io.horizontalsystems.walletkit.ui.extensions.HSBottomSheet
 import io.horizontalsystems.walletkit.ui.helpers.TextHelper
-import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetContent
+import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetBody
 import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetHeaderV3
 import io.horizontalsystems.walletkit.uiv3.components.controls.ButtonVariant
 import io.horizontalsystems.walletkit.uiv3.components.controls.HSButton
@@ -21,7 +19,7 @@ import io.horizontalsystems.walletkit.uiv3.components.info.TextBlock
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class ErrorSheet(val input: Input) : HSBottomSheet() {
+data class ErrorSheet(val input: Input) : HSBottomSheet(expanded = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {
@@ -32,15 +30,12 @@ data class ErrorSheet(val input: Input) : HSBottomSheet() {
     data class Input(val error: String)
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ErrorBottomSheetScreen(
     navigation: HSNavigation,
     error: String
 ) {
-    BottomSheetContent(
-        onDismissRequest = navigation::removeLastOrNull,
-        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    BottomSheetBody(
         buttons = {
             HSButton(
                 title = stringResource(R.string.Button_CopyError),
@@ -59,7 +54,7 @@ fun ErrorBottomSheetScreen(
                 title = stringResource(R.string.Send_UnexpectedError)
             )
             TextBlock(text = stringResource(R.string.Send_UnexpectedError_Description), textAlign = TextAlign.Center)
-        }
+        },
     )
 }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/createaccount/CreatePasskeyNotSupportedSheet.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/createaccount/CreatePasskeyNotSupportedSheet.kt
@@ -1,8 +1,6 @@
 package io.horizontalsystems.walletkit.modules.createaccount
 
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -13,7 +11,7 @@ import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.ui.compose.ComposeAppTheme
 import io.horizontalsystems.walletkit.ui.compose.components.InfoTextBody
 import io.horizontalsystems.walletkit.ui.extensions.HSBottomSheet
-import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetContent
+import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetBody
 import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetHeaderV3
 import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.ButtonsStack
 import io.horizontalsystems.walletkit.uiv3.components.controls.ButtonVariant
@@ -21,7 +19,7 @@ import io.horizontalsystems.walletkit.uiv3.components.controls.HSButton
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object CreatePasskeyNotSupportedSheet : HSBottomSheet() {
+data object CreatePasskeyNotSupportedSheet : HSBottomSheet(expanded = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {
@@ -29,13 +27,9 @@ data object CreatePasskeyNotSupportedSheet : HSBottomSheet() {
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CreatePasskeyNotSupportedScreen(navigation: HSNavigation) {
-    BottomSheetContent(
-        onDismissRequest = navigation::removeLastOrNull,
-        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    ) {
+    BottomSheetBody {
         BottomSheetHeaderV3(
             image72 = painterResource(R.drawable.warning_filled_24),
             imageTint = ComposeAppTheme.colors.jacob,

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/createaccount/PasskeyProviderAttentionSheet.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/createaccount/PasskeyProviderAttentionSheet.kt
@@ -1,8 +1,6 @@
 package io.horizontalsystems.walletkit.modules.createaccount
 
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -13,7 +11,7 @@ import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.ui.compose.ComposeAppTheme
 import io.horizontalsystems.walletkit.ui.compose.components.InfoTextBody
 import io.horizontalsystems.walletkit.ui.extensions.HSBottomSheet
-import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetContent
+import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetBody
 import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetHeaderV3
 import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.ButtonsStack
 import io.horizontalsystems.walletkit.uiv3.components.controls.ButtonVariant
@@ -29,7 +27,7 @@ import kotlinx.serialization.Serializable
  * lock — gets its own concrete steps.
  */
 @Serializable
-data class PasskeyProviderAttentionSheet(val gpmPassphrase: Boolean) : HSBottomSheet() {
+data class PasskeyProviderAttentionSheet(val gpmPassphrase: Boolean) : HSBottomSheet(expanded = true) {
 
     companion object {
         // Play services' passphrase/key-retrieval error family: 11000
@@ -52,13 +50,9 @@ data class PasskeyProviderAttentionSheet(val gpmPassphrase: Boolean) : HSBottomS
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PasskeyProviderAttentionScreen(navigation: HSNavigation, gpmPassphrase: Boolean) {
-    BottomSheetContent(
-        onDismissRequest = navigation::removeLastOrNull,
-        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    ) {
+    BottomSheetBody {
         BottomSheetHeaderV3(
             image72 = painterResource(R.drawable.warning_filled_24),
             imageTint = ComposeAppTheme.colors.jacob,

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/createaccount/RestorePasskeyNotSupportedSheet.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/createaccount/RestorePasskeyNotSupportedSheet.kt
@@ -1,8 +1,6 @@
 package io.horizontalsystems.walletkit.modules.createaccount
 
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -13,7 +11,7 @@ import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.ui.compose.ComposeAppTheme
 import io.horizontalsystems.walletkit.ui.compose.components.InfoTextBody
 import io.horizontalsystems.walletkit.ui.extensions.HSBottomSheet
-import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetContent
+import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetBody
 import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetHeaderV3
 import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.ButtonsStack
 import io.horizontalsystems.walletkit.uiv3.components.controls.ButtonVariant
@@ -21,7 +19,7 @@ import io.horizontalsystems.walletkit.uiv3.components.controls.HSButton
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object RestorePasskeyNotSupportedSheet : HSBottomSheet() {
+data object RestorePasskeyNotSupportedSheet : HSBottomSheet(expanded = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {
@@ -29,13 +27,9 @@ data object RestorePasskeyNotSupportedSheet : HSBottomSheet() {
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RestorePasskeyNotSupportedScreen(navigation: HSNavigation) {
-    BottomSheetContent(
-        onDismissRequest = navigation::removeLastOrNull,
-        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    ) {
+    BottomSheetBody {
         BottomSheetHeaderV3(
             image72 = painterResource(R.drawable.warning_filled_24),
             imageTint = ComposeAppTheme.colors.jacob,

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/WalletSwitchSheet.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/main/WalletSwitchSheet.kt
@@ -1,7 +1,5 @@
 package io.horizontalsystems.walletkit.modules.main
 
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.horizontalsystems.walletkit.core.stats.StatEntity
@@ -11,29 +9,23 @@ import io.horizontalsystems.walletkit.core.stats.stat
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.ui.extensions.HSBottomSheet
 import io.horizontalsystems.walletkit.ui.extensions.WalletSwitchBottomSheet
-import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetContent
+import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetBody
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object WalletSwitchSheet : HSBottomSheet() {
+data object WalletSwitchSheet : HSBottomSheet(expanded = true) {
     @Composable
     override fun GetContent(navigation: HSNavigation) {
         WalletSwitchScreen(navigation)
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun WalletSwitchScreen(navigation: HSNavigation) {
     val viewModel = viewModel<WalletSwitchViewModel>(factory = WalletSwitchViewModel.Factory())
     val uiState = viewModel.uiState
 
-    BottomSheetContent(
-        onDismissRequest = {
-            navigation.removeLastOrNull()
-        },
-        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    ) {
+    BottomSheetBody {
         WalletSwitchBottomSheet(
             wallets = uiState.wallets,
             watchingAddresses = uiState.watchWallets,

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/manageaccount/dialogs/BackupRequiredSheet.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/manageaccount/dialogs/BackupRequiredSheet.kt
@@ -4,8 +4,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -23,7 +21,7 @@ import io.horizontalsystems.walletkit.ui.compose.ComposeAppTheme
 import io.horizontalsystems.walletkit.ui.compose.components.HsDivider
 import io.horizontalsystems.walletkit.ui.compose.components.VSpacer
 import io.horizontalsystems.walletkit.ui.extensions.HSBottomSheet
-import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetContent
+import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetBody
 import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetHeaderV3
 import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetTextBlock
 import io.horizontalsystems.walletkit.uiv3.components.cell.CellGroup
@@ -36,7 +34,7 @@ import io.horizontalsystems.walletkit.uiv3.components.controls.HSButton
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class BackupRequiredSheet(val input: Input) : HSBottomSheet() {
+data class BackupRequiredSheet(val input: Input) : HSBottomSheet(expanded = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {
@@ -47,12 +45,9 @@ data class BackupRequiredSheet(val input: Input) : HSBottomSheet() {
     data class Input(val account: Account)
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BackupRequiredScreen(navigation: HSNavigation, account: Account) {
-    BottomSheetContent(
-        onDismissRequest = navigation::removeLastOrNull,
-        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    BottomSheetBody(
         buttons = {
             HSButton(
                 title = stringResource(R.string.BackupRequired_RemindLater),
@@ -125,6 +120,6 @@ fun BackupRequiredScreen(navigation: HSNavigation, account: Account) {
                 )
             }
             VSpacer(16.dp)
-        }
+        },
     )
 }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/RiskLevelInfoSheet.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/RiskLevelInfoSheet.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,7 +28,7 @@ import io.horizontalsystems.walletkit.ui.compose.components.HSpacer
 import io.horizontalsystems.walletkit.ui.compose.components.HsDivider
 import io.horizontalsystems.walletkit.ui.compose.components.VSpacer
 import io.horizontalsystems.walletkit.ui.extensions.HSBottomSheet
-import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetContent
+import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetBody
 import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetHeaderV3
 import io.horizontalsystems.walletkit.uiv3.components.cell.CellMiddleInfo
 import io.horizontalsystems.walletkit.uiv3.components.cell.CellPrimary
@@ -41,7 +39,7 @@ import io.horizontalsystems.walletkit.uiv3.components.info.TextBlock
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object RiskLevelInfoSheet : HSBottomSheet() {
+data object RiskLevelInfoSheet : HSBottomSheet(expanded = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {
@@ -49,12 +47,9 @@ data object RiskLevelInfoSheet : HSBottomSheet() {
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RiskLevelInfoScreen(navigation: HSNavigation) {
-    BottomSheetContent(
-        onDismissRequest = navigation::removeLastOrNull,
-        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    BottomSheetBody(
         buttons = {
             HSButton(
                 title = stringResource(R.string.Button_Close),
@@ -84,7 +79,7 @@ fun RiskLevelInfoScreen(navigation: HSNavigation) {
             ) {
                 RiskLevelList()
             }
-        }
+        },
     )
 }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapInfoSheet.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/SwapInfoSheet.kt
@@ -1,8 +1,6 @@
 package io.horizontalsystems.walletkit.modules.multiswap
 
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -11,7 +9,7 @@ import androidx.compose.ui.text.style.TextAlign
 import io.horizontalsystems.walletkit.R
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.ui.extensions.HSBottomSheet
-import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetContent
+import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetBody
 import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetHeaderV3
 import io.horizontalsystems.walletkit.uiv3.components.controls.ButtonVariant
 import io.horizontalsystems.walletkit.uiv3.components.controls.HSButton
@@ -19,7 +17,7 @@ import io.horizontalsystems.walletkit.uiv3.components.info.TextBlock
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class SwapInfoSheet(val input: Input) : HSBottomSheet() {
+data class SwapInfoSheet(val input: Input) : HSBottomSheet(expanded = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {
@@ -30,12 +28,9 @@ data class SwapInfoSheet(val input: Input) : HSBottomSheet() {
     data class Input(val title: String, val text: String, val icon: Int? = null)
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SwapInfoView(title: String, text: String, icon: Int? = null, onCloseClick: () -> Unit) {
-    BottomSheetContent(
-        onDismissRequest = onCloseClick,
-        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    BottomSheetBody(
         buttons = {
             HSButton(
                 title = stringResource(R.string.Button_Understand),
@@ -43,7 +38,7 @@ fun SwapInfoView(title: String, text: String, icon: Int? = null, onCloseClick: (
                 modifier = Modifier.fillMaxWidth(),
                 onClick = onCloseClick
             )
-        }
+        },
     ) {
         BottomSheetHeaderV3(
             image72 = painterResource(icon ?: R.drawable.book_24),

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/history/RequestRefundSheet.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/history/RequestRefundSheet.kt
@@ -7,8 +7,6 @@ import android.net.Uri
 import android.view.View
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -28,7 +26,7 @@ import io.horizontalsystems.walletkit.ui.compose.components.VSpacer
 import io.horizontalsystems.walletkit.ui.extensions.HSBottomSheet
 import io.horizontalsystems.walletkit.ui.helpers.LinkHelper
 import io.horizontalsystems.walletkit.ui.helpers.TextHelper
-import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetContent
+import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetBody
 import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetHeaderV3
 import io.horizontalsystems.walletkit.uiv3.components.cell.CellGroup
 import io.horizontalsystems.walletkit.uiv3.components.cell.CellLeftImage
@@ -45,7 +43,7 @@ import io.horizontalsystems.walletkit.uiv3.components.info.TextBlock
 import kotlinx.serialization.Serializable
 
 @Serializable
-class RequestRefundSheet(val input: Input) : HSBottomSheet() {
+class RequestRefundSheet(val input: Input) : HSBottomSheet(expanded = true) {
     @Composable
     override fun GetContent(navigation: HSNavigation) {
         RequestRefundScreen(navigation, input.data)
@@ -55,17 +53,12 @@ class RequestRefundSheet(val input: Input) : HSBottomSheet() {
     data class Input(val data: RequestRefundData)
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun RequestRefundScreen(navigation: HSNavigation, data: RequestRefundData) {
     val context = LocalContext.current
     val view = LocalView.current
 
-    BottomSheetContent(
-        onDismissRequest = {
-            navigation.removeLastOrNull()
-        },
-        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    BottomSheetBody(
         buttons = {
             HSButton(
                 modifier = Modifier.fillMaxWidth(),

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/BottomSheetDismissHandler.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/BottomSheetDismissHandler.kt
@@ -1,0 +1,34 @@
+package io.horizontalsystems.walletkit.modules.nav3
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/** Where a sheet's content registers its [BottomSheetDismissHandler]; owned by the sheet scene. */
+internal class BottomSheetDismissRegistry {
+    var handler: (() -> Unit)? = null
+}
+
+internal val LocalBottomSheetDismissRegistry =
+    staticCompositionLocalOf<BottomSheetDismissRegistry?> { null }
+
+/**
+ * Replaces the default pop when the user dismisses the enclosing nav3 bottom sheet by swiping it
+ * down, tapping the scrim or pressing back. [onDismiss] decides what happens next, typically some
+ * cleanup followed by popping the entry itself. Closing through the sheet's own buttons is not
+ * affected. Does nothing outside a bottom-sheet scene.
+ */
+@Composable
+fun BottomSheetDismissHandler(onDismiss: () -> Unit) {
+    val registry = LocalBottomSheetDismissRegistry.current ?: return
+    val currentOnDismiss by rememberUpdatedState(onDismiss)
+    DisposableEffect(registry) {
+        val handler = { currentOnDismiss() }
+        registry.handler = handler
+        onDispose {
+            if (registry.handler === handler) registry.handler = null
+        }
+    }
+}

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/BottomSheetSceneStrategy.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/BottomSheetSceneStrategy.kt
@@ -3,8 +3,10 @@ package io.horizontalsystems.walletkit.modules.nav3
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.ModalBottomSheetProperties
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.NavEntry
@@ -14,6 +16,9 @@ import androidx.navigation3.scene.SceneStrategy
 import androidx.navigation3.scene.SceneStrategyScope
 import io.horizontalsystems.walletkit.core.App
 import io.horizontalsystems.walletkit.modules.nav3.BottomSheetSceneStrategy.Companion.bottomSheet
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.isActive
 
 /** An [OverlayScene] that renders an [entry] within a [ModalBottomSheet]. */
 @OptIn(ExperimentalMaterial3Api::class)
@@ -29,6 +34,10 @@ internal class BottomSheetScene<T : Any>(
 
     override val entries: List<NavEntry<T>> = listOf(entry)
 
+    // The state of the sheet currently on screen, so onRemove can animate it out. Null while the
+    // sheet is not composed (see the lock gate below).
+    private var sheetState: SheetState? = null
+
     override val content: @Composable (() -> Unit) = {
         // ModalBottomSheet opens its own window, composited above the activity window — and so
         // above the PinUnlock overlay, which would leave the sheet interactable over the keypad.
@@ -40,15 +49,62 @@ internal class BottomSheetScene<T : Any>(
         // usable while browsing the Market tab locked.
         val showUnlock by App.lockGate.showUnlockFlow.collectAsStateWithLifecycle()
         if (!showUnlock) {
+            val state = rememberModalBottomSheetState(skipPartiallyExpanded = skipPartiallyExpanded)
+            DisposableEffect(state) {
+                sheetState = state
+                onDispose {
+                    if (sheetState === state) sheetState = null
+                }
+            }
             ModalBottomSheet(
                 onDismissRequest = onBack,
-                sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = skipPartiallyExpanded),
+                sheetState = state,
                 properties = modalBottomSheetProperties,
                 dragHandle = null
             ) {
                 entry.Content()
             }
         }
+    }
+
+    // NavDisplay keeps a popped overlay scene composed until this returns, so the sheet and its
+    // scrim animate out on every pop, not only on the swipe/scrim-tap paths the sheet drives
+    // itself. A pop that follows one of those finds the sheet already hidden and returns at once.
+    override suspend fun onRemove() {
+        val state = sheetState ?: return
+        try {
+            state.hide()
+        } catch (e: CancellationException) {
+            // A drag or another sheet animation interrupted the hide; the scene still has to go.
+            if (!currentCoroutineContext().isActive) throw e
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as BottomSheetScene<*>
+
+        return key == other.key &&
+            previousEntries == other.previousEntries &&
+            overlaidEntries == other.overlaidEntries &&
+            entry == other.entry &&
+            modalBottomSheetProperties == other.modalBottomSheetProperties &&
+            skipPartiallyExpanded == other.skipPartiallyExpanded
+    }
+
+    override fun hashCode(): Int {
+        return key.hashCode() * 31 +
+            previousEntries.hashCode() * 31 +
+            overlaidEntries.hashCode() * 31 +
+            entry.hashCode() * 31 +
+            modalBottomSheetProperties.hashCode() * 31 +
+            skipPartiallyExpanded.hashCode()
+    }
+
+    override fun toString(): String {
+        return "BottomSheetScene(key=$key, entry=$entry, previousEntries=$previousEntries, overlaidEntries=$overlaidEntries)"
     }
 }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/BottomSheetSceneStrategy.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/BottomSheetSceneStrategy.kt
@@ -6,8 +6,10 @@ import androidx.compose.material3.ModalBottomSheetProperties
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.scene.OverlayScene
@@ -16,6 +18,7 @@ import androidx.navigation3.scene.SceneStrategy
 import androidx.navigation3.scene.SceneStrategyScope
 import io.horizontalsystems.walletkit.core.App
 import io.horizontalsystems.walletkit.modules.nav3.BottomSheetSceneStrategy.Companion.bottomSheet
+import io.horizontalsystems.walletkit.ui.compose.ComposeAppTheme
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.isActive
@@ -56,13 +59,20 @@ internal class BottomSheetScene<T : Any>(
                     if (sheetState === state) sheetState = null
                 }
             }
+            val dismissRegistry = remember { BottomSheetDismissRegistry() }
             ModalBottomSheet(
-                onDismissRequest = onBack,
+                onDismissRequest = {
+                    val handler = dismissRegistry.handler
+                    if (handler != null) handler() else onBack()
+                },
                 sheetState = state,
+                containerColor = ComposeAppTheme.colors.lawrence,
                 properties = modalBottomSheetProperties,
                 dragHandle = null
             ) {
-                entry.Content()
+                CompositionLocalProvider(LocalBottomSheetDismissRegistry provides dismissRegistry) {
+                    entry.Content()
+                }
             }
         }
     }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/HSPage.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/nav3/HSPage.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheetProperties
 import androidx.compose.runtime.Composable
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.ui.NavDisplay
@@ -40,7 +41,12 @@ abstract class HSPage(
     @OptIn(ExperimentalMaterial3Api::class)
     fun getMetadata() = buildMap {
         if (bottomSheet) {
-            putAll(BottomSheetSceneStrategy.bottomSheet(skipPartiallyExpanded = expandedBottomSheet))
+            putAll(
+                BottomSheetSceneStrategy.bottomSheet(
+                    modalBottomSheetProperties = bottomSheetProperties,
+                    skipPartiallyExpanded = expandedBottomSheet,
+                )
+            )
         }
 
         putAll(getAnimationMetadata())
@@ -88,4 +94,13 @@ abstract class HSPage(
 
     @Composable
     abstract fun GetContent(navigation: HSNavigation)
+
+    companion object {
+        // Light system bar icons over the sheet's scrim in both themes.
+        @OptIn(ExperimentalMaterial3Api::class)
+        private val bottomSheetProperties = ModalBottomSheetProperties(
+            isAppearanceLightStatusBars = false,
+            isAppearanceLightNavigationBars = false,
+        )
+    }
 }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/settings/security/securesend/SecureSendConfigSheet.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/settings/security/securesend/SecureSendConfigSheet.kt
@@ -2,8 +2,6 @@ package io.horizontalsystems.walletkit.modules.settings.security.securesend
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -14,7 +12,7 @@ import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.ui.compose.components.HsDivider
 import io.horizontalsystems.walletkit.ui.compose.components.VSpacer
 import io.horizontalsystems.walletkit.ui.extensions.HSBottomSheet
-import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetContent
+import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetBody
 import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetHeaderV3
 import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetTextBlock
 import io.horizontalsystems.walletkit.uiv3.components.cell.CellGroup
@@ -27,24 +25,19 @@ import io.horizontalsystems.walletkit.uiv3.components.controls.HSButton
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object SecureSendConfigSheet : HSBottomSheet() {
+data object SecureSendConfigSheet : HSBottomSheet(expanded = true) {
     @Composable
     override fun GetContent(navigation: HSNavigation) {
         SecureSendConfigScreen(navigation)
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SecureSendConfigScreen(navigation: HSNavigation) {
     val viewModel = viewModel<SecureSendConfigViewModel>(factory = SecureSendConfigModule.Factory())
     val uiState = viewModel.uiState
 
-    BottomSheetContent(
-        onDismissRequest = {
-            navigation.removeLastOrNull()
-        },
-        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    BottomSheetBody(
         buttons = {
             HSButton(
                 title = stringResource(R.string.Button_Done),
@@ -110,6 +103,6 @@ private fun SecureSendConfigScreen(navigation: HSNavigation) {
                 )
             }
             VSpacer(24.dp)
-        }
+        },
     )
 }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/syncerror/SyncErrorSheet.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/syncerror/SyncErrorSheet.kt
@@ -1,8 +1,6 @@
 package io.horizontalsystems.walletkit.modules.syncerror
 
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -16,7 +14,7 @@ import io.horizontalsystems.walletkit.modules.evmnetwork.EvmNetworkPage
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.ui.compose.ComposeAppTheme
 import io.horizontalsystems.walletkit.ui.extensions.HSBottomSheet
-import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetContent
+import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetBody
 import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetHeaderV3
 import io.horizontalsystems.walletkit.uiv3.components.controls.ButtonSize
 import io.horizontalsystems.walletkit.uiv3.components.controls.ButtonVariant
@@ -25,7 +23,7 @@ import io.horizontalsystems.walletkit.uiv3.components.info.TextBlock
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class SyncErrorSheet(val input: Input) : HSBottomSheet() {
+data class SyncErrorSheet(val input: Input) : HSBottomSheet(expanded = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {
@@ -36,7 +34,6 @@ data class SyncErrorSheet(val input: Input) : HSBottomSheet() {
     data class Input(val wallet: Wallet, val errorMessage: String?)
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SyncErrorScreen(navigation: HSNavigation, wallet: Wallet) {
     val viewModel = viewModel<SyncErrorViewModel>(factory = SyncErrorModule.Factory(wallet))
@@ -46,11 +43,7 @@ private fun SyncErrorScreen(navigation: HSNavigation, wallet: Wallet) {
         stringResource(R.string.BalanceSyncError_ErrorText)
     }
 
-    BottomSheetContent(
-        onDismissRequest = {
-            navigation.removeLastOrNull()
-        },
-        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    BottomSheetBody(
         buttons = {
             HSButton(
                 title = stringResource(R.string.BalanceSyncError_ButtonRetry),
@@ -104,7 +97,7 @@ private fun SyncErrorScreen(navigation: HSNavigation, wallet: Wallet) {
                 text = text,
                 textAlign = TextAlign.Center
             )
-        }
+        },
     )
 }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/unlinkaccount/UnlinkAccountSheet.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/unlinkaccount/UnlinkAccountSheet.kt
@@ -5,8 +5,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -27,7 +25,7 @@ import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.ui.compose.ComposeAppTheme
 import io.horizontalsystems.walletkit.ui.compose.components.HsDivider
 import io.horizontalsystems.walletkit.ui.extensions.HSBottomSheet
-import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetContent
+import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetBody
 import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetHeaderV3
 import io.horizontalsystems.walletkit.uiv3.components.cell.CellMiddleInfo
 import io.horizontalsystems.walletkit.uiv3.components.cell.CellSecondary
@@ -39,14 +37,13 @@ import io.horizontalsystems.walletkit.uiv3.components.info.TextBlock
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class UnlinkAccountSheet(val account: Account) : HSBottomSheet() {
+data class UnlinkAccountSheet(val account: Account) : HSBottomSheet(expanded = true) {
     @Composable
     override fun GetContent(navigation: HSNavigation) {
         UnlinkAccountScreen(navigation, account)
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun UnlinkAccountScreen(navigation: HSNavigation, account: Account) {
     val viewModel =
@@ -59,11 +56,7 @@ private fun UnlinkAccountScreen(navigation: HSNavigation, account: Account) {
     val view = LocalView.current
     val doneConfirmationMessage = stringResource(R.string.Hud_Text_Done)
 
-    BottomSheetContent(
-        onDismissRequest = {
-            navigation.removeLastOrNull()
-        },
-        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    BottomSheetBody(
         buttons = {
             HSButton(
                 title = stringResource(viewModel.deleteButtonText),
@@ -122,6 +115,6 @@ private fun UnlinkAccountScreen(navigation: HSNavigation, account: Account) {
                     }
                 }
             }
-        }
+        },
     )
 }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/usersubscription/SelectPlanSheet.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/usersubscription/SelectPlanSheet.kt
@@ -40,8 +40,10 @@ import io.horizontalsystems.walletkit.ui.compose.components.VSpacer
 import io.horizontalsystems.walletkit.ui.compose.components.subhead2_remus
 import io.horizontalsystems.walletkit.ui.extensions.HSBottomSheet
 import io.horizontalsystems.walletkit.uiv3.components.bottombars.ButtonsGroupHorizontal
+import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetBody
 import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetContent
 import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetHeaderV3
+import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.SnackbarActions
 import io.horizontalsystems.walletkit.uiv3.components.cell.CellPrimary
 import io.horizontalsystems.walletkit.uiv3.components.cell.HSString
 import io.horizontalsystems.walletkit.uiv3.components.cell.hs
@@ -53,27 +55,44 @@ import io.horizontalsystems.subscriptions.core.numberOfDays
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object SelectPlanSheet : HSBottomSheet() {
+data object SelectPlanSheet : HSBottomSheet(expanded = true) {
     @Composable
     override fun GetContent(navigation: HSNavigation) {
-        SelectPlanBottomSheet(
-            onDismiss = { navigation.removeLastOrNull() },
-            onPurchase = {
-                navigation.removeLastOrNull()
-                navigation.slideFromBottom(PremiumSubscribedSheet)
-            },
-        )
+        BottomSheetBody { snackbarActions ->
+            SelectPlanContent(
+                onDismiss = { navigation.removeLastOrNull() },
+                onPurchase = {
+                    navigation.removeLastOrNull()
+                    navigation.slideFromBottom(PremiumSubscribedSheet)
+                },
+                snackbarActions = snackbarActions,
+            )
+        }
     }
 }
 
+/** [SelectPlanContent] as a modal sheet over a page. */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SelectPlanBottomSheet(
     onDismiss: () -> Unit,
     onPurchase: () -> Unit,
+) {
+    BottomSheetContent(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    ) { snackbarActions ->
+        SelectPlanContent(onDismiss, onPurchase, snackbarActions)
+    }
+}
+
+@Composable
+private fun SelectPlanContent(
+    onDismiss: () -> Unit,
+    onPurchase: () -> Unit,
+    snackbarActions: SnackbarActions,
     viewModel: BuySubscriptionChoosePlanViewModel = viewModel(),
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val uiState = viewModel.uiState
     val activity = LocalActivity.current
 
@@ -91,113 +110,108 @@ fun SelectPlanBottomSheet(
     val freeTrialPeriodDays = uiState.freeTrialPeriod?.let {
         stringResource(R.string.Period_Days, it.numberOfDays())
     }
-    BottomSheetContent(
-        onDismissRequest = onDismiss,
-        sheetState = sheetState
-    ) { snackbarActions ->
-        uiState.error?.let {
-            snackbarActions.showErrorMessage(it.message ?: "Error")
-            viewModel.onErrorHandled()
-        }
+    uiState.error?.let {
+        snackbarActions.showErrorMessage(it.message ?: "Error")
+        viewModel.onErrorHandled()
+    }
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+
+        BottomSheetHeaderV3(
+            title = stringResource(R.string.Premium_SelectSubscription),
+            onCloseClick = onDismiss
+        )
+
+        VSpacer(12.dp)
+
         Column(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .border(0.5.dp, ComposeAppTheme.colors.blade, shape = RoundedCornerShape(16.dp))
+                .clip(RoundedCornerShape(16.dp))
         ) {
-
-            BottomSheetHeaderV3(
-                title = stringResource(R.string.Premium_SelectSubscription),
-                onCloseClick = onDismiss
-            )
-
-            VSpacer(12.dp)
-
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier
-                    .padding(horizontal = 16.dp)
-                    .border(0.5.dp, ComposeAppTheme.colors.blade, shape = RoundedCornerShape(16.dp))
-                    .clip(RoundedCornerShape(16.dp))
-            ) {
-                uiState.basePlans.forEachIndexed { index, basePlan ->
-                    if (index > 0) {
-                        HsDivider()
-                    }
-                    SubscriptionOption(
-                        title = basePlan.title(),
-                        price = basePlan.stringRepresentation(),
-                        isSelected = selectedItemIndex == index,
-                        badgeText = basePlan.badge(),
-                        gradientBadge = basePlan.gradientBadge,
-                        noteAmount = basePlan.noteAmount,
-                        noteText = basePlan.noteText,
-                        onClick = {
-                            viewModel.select(index)
-                        }
-                    )
+            uiState.basePlans.forEachIndexed { index, basePlan ->
+                if (index > 0) {
+                    HsDivider()
                 }
-            }
-
-            val bottomText = if (freeTrialPeriodDays != null) {
-                buildAnnotatedString {
-                    withStyle(SpanStyle(color = ComposeAppTheme.colors.remus)) {
-                        append(
-                            text = stringResource(
-                                R.string.Premium_EnjoyFreePeriod,
-                                freeTrialPeriodDays
-                            )
-                        )
-                    }
-                    append(" ")
-                    withStyle(SpanStyle(color = ComposeAppTheme.colors.leah)) {
-                        append(text = stringResource(R.string.Premium_CancelSubscriptionInfo))
-                    }
-                }
-            } else {
-                buildAnnotatedString {
-                    withStyle(SpanStyle(color = ComposeAppTheme.colors.leah)) {
-                        append(text = stringResource(R.string.Premium_CancelSubscriptionInfo))
-                    }
-                }
-            }
-
-
-            VSpacer(12.dp)
-            Text(
-                text = bottomText,
-                color = ComposeAppTheme.colors.grey,
-                style = ComposeAppTheme.typography.subheadR,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.padding(horizontal = 32.dp, vertical = 12.dp)
-            )
-            VSpacer(12.dp)
-
-            val buttonTitle = if (freeTrialPeriodDays != null) {
-                stringResource(R.string.Premium_GetFreePeriod, freeTrialPeriodDays)
-            } else {
-                stringResource(R.string.Premium_Subscribe)
-            }
-
-            ButtonsGroupHorizontal {
-                HSButton(
-                    title = buttonTitle,
-                    size = ButtonSize.Medium,
-                    modifier = Modifier
-                        .fillMaxWidth(),
+                SubscriptionOption(
+                    title = basePlan.title(),
+                    price = basePlan.stringRepresentation(),
+                    isSelected = selectedItemIndex == index,
+                    badgeText = basePlan.badge(),
+                    gradientBadge = basePlan.gradientBadge,
+                    noteAmount = basePlan.noteAmount,
+                    noteText = basePlan.noteText,
                     onClick = {
-                        activity?.let { activity ->
-                            uiState.subscriptionId?.let { subscriptionId ->
-                                viewModel.launchPurchaseFlow(
-                                    subscriptionId = subscriptionId,
-                                    offerToken = uiState.basePlans[selectedItemIndex].offerToken,
-                                    activity = activity
-                                )
-                            }
-                        }
+                        viewModel.select(index)
                     }
                 )
             }
-            VSpacer(8.dp)
         }
+
+        val bottomText = if (freeTrialPeriodDays != null) {
+            buildAnnotatedString {
+                withStyle(SpanStyle(color = ComposeAppTheme.colors.remus)) {
+                    append(
+                        text = stringResource(
+                            R.string.Premium_EnjoyFreePeriod,
+                            freeTrialPeriodDays
+                        )
+                    )
+                }
+                append(" ")
+                withStyle(SpanStyle(color = ComposeAppTheme.colors.leah)) {
+                    append(text = stringResource(R.string.Premium_CancelSubscriptionInfo))
+                }
+            }
+        } else {
+            buildAnnotatedString {
+                withStyle(SpanStyle(color = ComposeAppTheme.colors.leah)) {
+                    append(text = stringResource(R.string.Premium_CancelSubscriptionInfo))
+                }
+            }
+        }
+
+
+        VSpacer(12.dp)
+        Text(
+            text = bottomText,
+            color = ComposeAppTheme.colors.grey,
+            style = ComposeAppTheme.typography.subheadR,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(horizontal = 32.dp, vertical = 12.dp)
+        )
+        VSpacer(12.dp)
+
+        val buttonTitle = if (freeTrialPeriodDays != null) {
+            stringResource(R.string.Premium_GetFreePeriod, freeTrialPeriodDays)
+        } else {
+            stringResource(R.string.Premium_Subscribe)
+        }
+
+        ButtonsGroupHorizontal {
+            HSButton(
+                title = buttonTitle,
+                size = ButtonSize.Medium,
+                modifier = Modifier
+                    .fillMaxWidth(),
+                onClick = {
+                    activity?.let { activity ->
+                        uiState.subscriptionId?.let { subscriptionId ->
+                            viewModel.launchPurchaseFlow(
+                                subscriptionId = subscriptionId,
+                                offerToken = uiState.basePlans[selectedItemIndex].offerToken,
+                                activity = activity
+                            )
+                        }
+                    }
+                }
+            )
+        }
+        VSpacer(8.dp)
     }
 }
 

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/WCRequestSheet.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/WCRequestSheet.kt
@@ -13,13 +13,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.SheetState
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -36,6 +33,7 @@ import io.horizontalsystems.walletkit.R
 import io.horizontalsystems.walletkit.core.AppLogger
 import io.horizontalsystems.walletkit.core.chain.ChainRegistry
 import io.horizontalsystems.walletkit.helpers.HudHelper
+import io.horizontalsystems.walletkit.modules.nav3.BottomSheetDismissHandler
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.walletconnect.WCDelegate
 import io.horizontalsystems.walletkit.ui.compose.ComposeAppTheme
@@ -48,7 +46,7 @@ import io.horizontalsystems.walletkit.uiv3.components.AlertCard
 import io.horizontalsystems.walletkit.uiv3.components.AlertFormat
 import io.horizontalsystems.walletkit.uiv3.components.AlertType
 import io.horizontalsystems.walletkit.uiv3.components.bottombars.ButtonsGroupHorizontal
-import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetContent
+import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetBody
 import io.horizontalsystems.walletkit.uiv3.components.cell.CellMiddleInfo
 import io.horizontalsystems.walletkit.uiv3.components.cell.CellPrimary
 import io.horizontalsystems.walletkit.uiv3.components.cell.CellRightControlsButtonText
@@ -60,14 +58,13 @@ import io.horizontalsystems.walletkit.uiv3.components.controls.HSButton
 import io.horizontalsystems.walletkit.uiv3.components.info.TextBlock
 import io.horizontalsystems.marketkit.models.BlockchainType
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 
 private val logger = AppLogger("wallet-connect request")
 
 @Serializable
-data object WCRequestSheet : HSBottomSheet() {
+data object WCRequestSheet : HSBottomSheet(expanded = true) {
     @Composable
     override fun GetContent(navigation: HSNavigation) {
         val wcRequestRouterViewModel =
@@ -96,20 +93,12 @@ data object WCRequestSheet : HSBottomSheet() {
 fun WcRequestError(
     onDismiss: () -> Unit
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    val scope = rememberCoroutineScope()
     val dismiss = {
-        // Discard synchronously, then animate the sheet out before popping (see WCNewSignRequestScreen).
         WCDelegate.discardActiveSessionRequest()
-        scope.launch {
-            sheetState.hide()
-            onDismiss()
-        }
-        Unit
+        onDismiss()
     }
-    BottomSheetContent(
-        onDismissRequest = dismiss,
-        sheetState = sheetState,
+    BottomSheetDismissHandler(dismiss)
+    BottomSheetBody(
         buttons = {
             HSButton(
                 title = stringResource(R.string.Button_Close),

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/WcRequestScreen.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/request/WcRequestScreen.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
@@ -28,6 +26,7 @@ import coil.compose.rememberAsyncImagePainter
 import io.horizontalsystems.walletkit.R
 import io.horizontalsystems.walletkit.helpers.HudHelper
 import io.horizontalsystems.walletkit.modules.evmfee.FeeSettingsInfoSheet
+import io.horizontalsystems.walletkit.modules.nav3.BottomSheetDismissHandler
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.walletconnect.WCDelegate
 import io.horizontalsystems.walletkit.modules.walletconnect.request.sendtransaction.DataBlock
@@ -38,13 +37,12 @@ import io.horizontalsystems.walletkit.ui.compose.components.subhead_grey
 import io.horizontalsystems.walletkit.modules.walletconnect.VerificationAlert
 import io.horizontalsystems.walletkit.ui.helpers.TextHelper
 import io.horizontalsystems.walletkit.uiv3.components.bottombars.ButtonsGroupHorizontal
-import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetContent
+import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetBody
 import io.horizontalsystems.walletkit.uiv3.components.controls.ButtonSize
 import io.horizontalsystems.walletkit.uiv3.components.controls.ButtonVariant
 import io.horizontalsystems.walletkit.uiv3.components.controls.HSButton
 import io.horizontalsystems.dapp.core.HSDAppRequest
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WcRequestScreen(
     navigation: HSNavigation,
@@ -72,17 +70,14 @@ fun WcRequestScreen(
         }
     }
 
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val feeText = stringResource(id = R.string.Send_Fee)
     val feeInfoText = stringResource(id = R.string.FeeSettings_NetworkFee_Info)
 
-    BottomSheetContent(
-        onDismissRequest = {
-            WCDelegate.discardActiveSessionRequest(sessionRequest.requestId)
-            navigation.removeLastOrNull()
-        },
-        sheetState = sheetState
-    ) { snackbarActions ->
+    BottomSheetDismissHandler {
+        WCDelegate.discardActiveSessionRequest(sessionRequest.requestId)
+        navigation.removeLastOrNull()
+    }
+    BottomSheetBody { snackbarActions ->
         Column(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/session/WCSessionSheet.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/walletconnect/session/WCSessionSheet.kt
@@ -18,13 +18,11 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -39,6 +37,7 @@ import coil.compose.rememberAsyncImagePainter
 import io.horizontalsystems.walletkit.R
 import io.horizontalsystems.walletkit.modules.walletconnect.VerificationAlert
 import io.horizontalsystems.walletkit.core.imageUrl
+import io.horizontalsystems.walletkit.modules.nav3.BottomSheetDismissHandler
 import io.horizontalsystems.walletkit.modules.nav3.HSNavigation
 import io.horizontalsystems.walletkit.modules.usersubscription.BuySubscriptionHavHostPage
 import io.horizontalsystems.walletkit.ui.compose.ComposeAppTheme
@@ -54,7 +53,7 @@ import io.horizontalsystems.walletkit.uiv3.components.AlertCard
 import io.horizontalsystems.walletkit.uiv3.components.AlertFormat
 import io.horizontalsystems.walletkit.uiv3.components.AlertType
 import io.horizontalsystems.walletkit.uiv3.components.bottombars.ButtonsGroupHorizontal
-import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetContent
+import io.horizontalsystems.walletkit.uiv3.components.bottomsheet.BottomSheetBody
 import io.horizontalsystems.walletkit.uiv3.components.cell.CellMiddleInfo
 import io.horizontalsystems.walletkit.uiv3.components.cell.CellRightInfo
 import io.horizontalsystems.walletkit.uiv3.components.cell.CellSecondary
@@ -65,11 +64,10 @@ import io.horizontalsystems.walletkit.uiv3.components.controls.HSButton
 import io.horizontalsystems.walletkit.uiv3.components.info.TextBlock
 import io.horizontalsystems.walletkit.uiv3.components.section.SectionHeader
 import io.horizontalsystems.marketkit.models.BlockchainType
-import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class WCSessionSheet(val input: WCSessionModule.Input?) : HSBottomSheet() {
+data class WCSessionSheet(val input: WCSessionModule.Input?) : HSBottomSheet(expanded = true) {
 
     @Composable
     override fun GetContent(navigation: HSNavigation) {
@@ -86,19 +84,8 @@ fun WCSessionScreen(
     navigation: HSNavigation,
     viewModel: WCSessionViewModel,
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    val scope = rememberCoroutineScope()
     val uiState = viewModel.uiState
     val buttonsStates = uiState.buttonStates
-
-    // Animate the sheet out before popping; removing the entry outright can leave the card on screen.
-    val hideAndPop = {
-        scope.launch {
-            sheetState.hide()
-            navigation.removeLastOrNull()
-        }
-        Unit
-    }
 
     val connectionTitleRes =
         if (uiState.connected) R.string.WalletConnect_ConnectedTo else R.string.WalletConnect_ConnectTo
@@ -114,14 +101,12 @@ fun WCSessionScreen(
     // closes, so the only path that must re-enable it is a failure surfacing through showError.
     var connectButtonEnabled by remember { mutableStateOf(true) }
 
-    BottomSheetContent(
-        onDismissRequest = {
-            // Reject the proposal on dismiss so the dApp isn't left waiting, then animate out.
-            viewModel.rejectProposal()
-            hideAndPop()
-        },
-        sheetState = sheetState,
-    ) { snackbarActions ->
+    // Reject the proposal on dismiss so the dApp isn't left waiting.
+    BottomSheetDismissHandler {
+        viewModel.rejectProposal()
+        navigation.removeLastOrNull()
+    }
+    BottomSheetBody { snackbarActions ->
         uiState.showError?.let {
             snackbarActions.showErrorMessage(it)
             connectButtonEnabled = true

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/uiv3/components/bottomsheet/BottomSheet.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/uiv3/components/bottomsheet/BottomSheet.kt
@@ -162,13 +162,6 @@ fun BottomSheetContent(
     buttons: (@Composable ColumnScope.() -> Unit)? = null,
     content: @Composable (snackbarActions: SnackbarActions) -> Unit,
 ) {
-    val snackbarHostState = remember { SnackbarHostState() }
-    val scope = rememberCoroutineScope()
-
-    val snackbarActions = remember(snackbarHostState, scope) {
-        SnackbarActionsImpl(snackbarHostState, scope)
-    }
-
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
         sheetState = sheetState,
@@ -179,40 +172,63 @@ fun BottomSheetContent(
         ),
         dragHandle = { }
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .navigationBarsPadding()
-        ) {
-            Column(
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                content(snackbarActions)
+        BottomSheetBody(buttons = buttons, content = content)
+    }
+}
 
-                buttons?.let {
-                    ButtonsStack {
-                        buttons()
-                    }
+/**
+ * The inside of a sheet: the content column, an optional [buttons] stack and a snackbar host.
+ *
+ * For sheets on the nav3 back stack ([io.horizontalsystems.walletkit.ui.extensions.HSBottomSheet]),
+ * whose [ModalBottomSheet] is provided by the bottom-sheet scene. A second [ModalBottomSheet]
+ * inside it would open another window with its own scrim, doubling the dimming and leaving the
+ * two layers to animate out separately. Sheets shown from a page use [BottomSheetContent].
+ */
+@Composable
+fun BottomSheetBody(
+    buttons: (@Composable ColumnScope.() -> Unit)? = null,
+    content: @Composable (snackbarActions: SnackbarActions) -> Unit,
+) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+
+    val snackbarActions = remember(snackbarHostState, scope) {
+        SnackbarActionsImpl(snackbarHostState, scope)
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .navigationBarsPadding()
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            content(snackbarActions)
+
+            buttons?.let {
+                ButtonsStack {
+                    buttons()
                 }
             }
-
-            SnackbarHost(
-                hostState = snackbarHostState,
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .padding(bottom = 16.dp, start = 16.dp, end = 16.dp),
-                snackbar = { snackbarData: SnackbarData ->
-                    val actionLabel = snackbarData.visuals.actionLabel
-                    Snackbar(
-                        modifier = Modifier,
-                        containerColor = if (actionLabel == SnackbarActionsImpl.ACTION_ERROR) ComposeAppTheme.colors.redD else ComposeAppTheme.colors.greenD,
-                        contentColor = ComposeAppTheme.colors.white,
-                    ) {
-                        Text(snackbarData.visuals.message)
-                    }
-                }
-            )
         }
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 16.dp, start = 16.dp, end = 16.dp),
+            snackbar = { snackbarData: SnackbarData ->
+                val actionLabel = snackbarData.visuals.actionLabel
+                Snackbar(
+                    modifier = Modifier,
+                    containerColor = if (actionLabel == SnackbarActionsImpl.ACTION_ERROR) ComposeAppTheme.colors.redD else ComposeAppTheme.colors.greenD,
+                    contentColor = ComposeAppTheme.colors.white,
+                ) {
+                    Text(snackbarData.visuals.message)
+                }
+            }
+        )
     }
 }
 


### PR DESCRIPTION
Hides the sheet in `OverlayScene.onRemove` so a popped nav entry animates out like a swipe, and renders nav3 sheets in the scene's modal only instead of a nested `ModalBottomSheet`.

Closes #9631