### PR TITLE
Record which operation produced a swap

### DIFF
--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/storage/AppDatabase.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/storage/AppDatabase.kt
@@ -58,6 +58,7 @@ import io.horizontalsystems.walletkit.core.storage.migrations.Migration_80_81
 import io.horizontalsystems.walletkit.core.storage.migrations.Migration_81_82
 import io.horizontalsystems.walletkit.core.storage.migrations.Migration_82_83
 import io.horizontalsystems.walletkit.core.storage.migrations.Migration_83_84
+import io.horizontalsystems.walletkit.core.storage.migrations.Migration_84_85
 import io.horizontalsystems.walletkit.entities.ActiveAccount
 import io.horizontalsystems.walletkit.entities.BlockchainSettingRecord
 import io.horizontalsystems.walletkit.entities.EnabledWallet
@@ -91,7 +92,7 @@ import io.horizontalsystems.walletkit.modules.pin.core.PinDao
 import io.horizontalsystems.walletkit.modules.walletconnect.storage.WCSessionDao
 import io.horizontalsystems.walletkit.modules.walletconnect.storage.WalletConnectV2Session
 
-@Database(version = 84, exportSchema = false, entities = [
+@Database(version = 85, exportSchema = false, entities = [
     EnabledWallet::class,
     EnabledWalletCache::class,
     AccountRecord::class,
@@ -224,6 +225,7 @@ abstract class AppDatabase : RoomDatabase() {
                     Migration_81_82,
                     Migration_82_83,
                     Migration_83_84,
+                    Migration_84_85,
                 )
                 .build()
         }

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/core/storage/migrations/Migration_84_85.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/core/storage/migrations/Migration_84_85.kt
@@ -1,0 +1,14 @@
+package io.horizontalsystems.walletkit.core.storage.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+object Migration_84_85 : Migration(84, 85) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE `SwapRecord` ADD COLUMN `operation` TEXT NOT NULL DEFAULT 'Swap'")
+        // Every confidential-rail record written so far is a private send — the rail was
+        // used for nothing else before this column existed. CrossPay records only start
+        // appearing after this migration, so no other backfill is possible or needed.
+        db.execSQL("UPDATE `SwapRecord` SET `operation` = 'PrivateSend' WHERE `providerId` = 'u_NEAR_CONFIDENTIAL'")
+    }
+}

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/entities/SwapRecord.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/entities/SwapRecord.kt
@@ -2,6 +2,7 @@ package io.horizontalsystems.walletkit.entities
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import io.horizontalsystems.walletkit.modules.multiswap.history.SwapOperation
 
 @Entity
 data class SwapRecord(
@@ -39,6 +40,9 @@ data class SwapRecord(
     val toAsset: String?,
     val depositAddress: String?,
     val status: String,
+    // SwapOperation.name — which user-facing operation produced this record (plain swap,
+    // private send, CrossPay). Same rail can serve several; history renders each differently.
+    val operation: String = SwapOperation.Swap.name,
     val pauseReason: String? = null,
     // opaque handle linking the record to an external settlement mechanism
     // (e.g. a smart-account userOp hash) until the real transactionHash is known

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/history/SwapOperation.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/multiswap/history/SwapOperation.kt
@@ -1,0 +1,19 @@
+package io.horizontalsystems.walletkit.modules.multiswap.history
+
+/**
+ * Which user-facing operation produced a swap record. The rail can be identical — the
+ * NEAR_CONFIDENTIAL provider serves both private sends and confidential payments — so the
+ * record must carry the operation itself; history renders each kind differently.
+ */
+enum class SwapOperation {
+    Swap,
+    PrivateSend,
+    CrossPay;
+
+    companion object {
+        // Unknown values (a record written by a NEWER app version) read as a plain swap
+        // rather than crashing history.
+        fun fromString(value: String?): SwapOperation =
+            entries.firstOrNull { it.name == value } ?: Swap
+    }
+}

--- a/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/privatesend/PrivateSendConfirmViewModel.kt
+++ b/walletkit/src/main/java/io/horizontalsystems/walletkit/modules/privatesend/PrivateSendConfirmViewModel.kt
@@ -11,6 +11,7 @@ import io.horizontalsystems.walletkit.entities.Currency
 import io.horizontalsystems.walletkit.entities.SwapRecord
 import io.horizontalsystems.walletkit.modules.multiswap.TimerService
 import io.horizontalsystems.walletkit.modules.xrate.XRateService
+import io.horizontalsystems.walletkit.modules.multiswap.history.SwapOperation
 import io.horizontalsystems.walletkit.modules.multiswap.history.SwapRecordManager
 import io.horizontalsystems.walletkit.modules.multiswap.history.SwapStatus
 import io.horizontalsystems.walletkit.modules.multiswap.sendtransaction.AbstractSendTransactionService
@@ -298,6 +299,7 @@ class PrivateSendConfirmViewModel(
         toAsset = null,
         depositAddress = order.depositAddress,
         status = SwapStatus.Depositing.name,
+        operation = SwapOperation.PrivateSend.name,
         estimatedTime = order.estimatedTime,
     )
 


### PR DESCRIPTION
## What

Adds an `operation` field to `SwapRecord` (`Swap` / `PrivateSend` / `CrossPay`, stored as a string like `status`) with a Room migration (84 → 85).

## Why

The NEAR_CONFIDENTIAL rail is about to serve two different user-facing products — private sends and confidential CrossPay payments — so `providerId` can no longer tell what the user actually did. Swap history needs to render each operation differently; this PR adds only the field and the migration, the rendering comes separately.

## Details

- `SwapRecord.operation` defaults to `Swap` in the constructor, so every existing ordinary-swap write site stays untouched and correct.
- The private-send confirmation now stamps `PrivateSend` on its records.
- Migration backfills existing `u_NEAR_CONFIDENTIAL` records as `PrivateSend` — the only thing that rail has served before this column existed. CrossPay records cannot predate the migration, so no other backfill is needed.
- `SwapOperation.fromString` reads unknown values (a record written by a newer app) as `Swap` instead of crashing history.